### PR TITLE
Add ability to reduce collected weights down in python

### DIFF
--- a/fnal_column_analysis_tools/lookup_tools/extractor.py
+++ b/fnal_column_analysis_tools/lookup_tools/extractor.py
@@ -123,5 +123,19 @@ class extractor(object):
         del self.__filecache
         self.__finalized = True
     
-    def make_evaluator(self):
-        return evaluator(self.__names,self.__weights)
+    def make_evaluator(self,reduce_list=None):
+        names = None
+        weights = None
+        if reduce_list is not None:
+            names = {}
+            weights = []
+            for i,name in enumerate(reduce_list):
+                if name not in self.__names:
+                    raise Exception('Weights named "{}" not in extractor!'.format(name))
+                names[name] = i
+                weights.append(self.__weights[self.__names[name]])
+        else:
+            names = self.__names
+            weights = self.__weights
+        
+        return evaluator(names,weights)

--- a/fnal_column_analysis_tools/version.py
+++ b/fnal_column_analysis_tools/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.0.1.dev4"
+__version__ = "0.0.1.dev5"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 


### PR DESCRIPTION
Add in capability to weights extractor to reduce the list of weights that you push into the evaluator.

This makes things more compact when you send it to a job (less overhead).