### PR TITLE
First iteration of ux improvements as discussed with Allie and Matteo

### DIFF
--- a/fnal_column_analysis_tools/analysis_objects/JaggedCandidateArray.py
+++ b/fnal_column_analysis_tools/analysis_objects/JaggedCandidateArray.py
@@ -57,13 +57,6 @@ class JaggedCandidateMethods(awkward.Methods):
             del items['eta']
             del items['phi']
             del items['energy']
-        elif 'pt' in argkeys and 'phi' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
-            p4 = uproot_methods.TLorentzVectorArray.from_cylindrical(items['pt'],items['phi'],
-                                                                     items['pz'],items['energy'])
-            del items['pt']
-            del items['phi']
-            del items['pz']
-            del items['energy']
         elif 'px' in argkeys and 'py' in argkeys and 'pz' in argkeys and 'mass' in argkeys:
             p4 = uproot_methods.TLorentzVectorArray.from_xyzm(items['px'],items['py'],
                                                               items['pz'],items['mass'])
@@ -71,6 +64,20 @@ class JaggedCandidateMethods(awkward.Methods):
             del items['py']
             del items['pz']
             del items['mass']
+        elif 'pt' in argkeys and 'phi' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_cylindrical(items['pt'],items['phi'],
+                                                                     items['pz'],items['energy'])
+            del items['pt']
+            del items['phi']
+            del items['pz']
+            del items['energy']
+        elif 'px' in argkeys and 'py' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_cartesian(items['px'],items['py'],
+                                                                   items['pz'],items['energy'])
+            del items['px']
+            del items['py']
+            del items['pz']
+            del items['energy']
         elif 'p' in argkeys and 'theta' in argkeys and 'phi' in argkeys and 'energy' in argkeys:
             p4 = uproot_methods.TLorentzVectorArray.from_spherical(items['p'],items['theta'],
                                                                    items['phi'],items['energy'])

--- a/fnal_column_analysis_tools/analysis_objects/JaggedCandidateArray.py
+++ b/fnal_column_analysis_tools/analysis_objects/JaggedCandidateArray.py
@@ -29,24 +29,67 @@ def fast_mass(p4):
 class JaggedCandidateMethods(awkward.Methods):
     
     @classmethod
-    def candidatesfromcounts(cls,counts,p4,**kwargs):
+    def candidatesfromcounts(cls,counts,**kwargs):
         offsets = awkward.array.jagged.counts2offsets(counts)
-        return cls.candidatesfromoffsets(offsets,p4,**kwargs)
+        return cls.candidatesfromoffsets(offsets,**kwargs)
     
     @classmethod
-    def candidatesfromoffsets(cls,offsets,p4,**kwargs):
-        items = {}
-        if isinstance(p4,uproot_methods.TLorentzVectorArray):
-            items['p4'] = p4
+    def candidatesfromoffsets(cls,offsets,**kwargs):
+        items = kwargs
+        argkeys = items.keys()
+        p4 = None
+        if 'p4' in argkeys:
+            p4 = items['p4']
+            if not isinstance(p4,uproot_methods.TLorentzVectorArray):
+                p4 = uproot_methods.TLorentzVectorArray.from_cartesian(p4[:,0],p4[:,1],
+                                                                       p4[:,2],p4[:,3])
+        elif 'pt' in argkeys and 'eta' in argkeys and 'phi' in argkeys and 'mass' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_ptetaphim(items['pt'],items['eta'],
+                                                                   items['phi'],items['mass'])
+            del items['pt']
+            del items['eta']
+            del items['phi']
+            del items['mass']
+        elif 'pt' in argkeys and 'eta' in argkeys and 'phi' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_ptetaphi(items['pt'],items['eta'],
+                                                                  items['phi'],items['energy'])
+            del items['pt']
+            del items['eta']
+            del items['phi']
+            del items['energy']
+        elif 'pt' in argkeys and 'phi' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_cylindrical(items['pt'],items['phi'],
+                                                                     items['pz'],items['energy'])
+            del items['pt']
+            del items['phi']
+            del items['pz']
+            del items['energy']
+        elif 'px' in argkeys and 'py' in argkeys and 'pz' in argkeys and 'mass' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_xyzm(items['px'],items['py'],
+                                                              items['pz'],items['mass'])
+            del items['px']
+            del items['py']
+            del items['pz']
+            del items['mass']
+        elif 'p' in argkeys and 'theta' in argkeys and 'phi' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_spherical(items['p'],items['theta'],
+                                                                   items['phi'],items['energy'])
+            del items['p']
+            del items['theta']
+            del items['phi']
+            del items['energy']
+        elif 'p3' in argkeys and 'energy' in argkeys:
+            p4 = uproot_methods.TLorentzVectorArray.from_p3(items['p3'],items['energy'])
+            del items['p3']
+            del items['energy']
         else:
-            items['p4'] = uproot_methods.TLorentzVectorArray(p4[:,0],p4[:,1],
-                                                             p4[:,2],p4[:,3])
-        thep4 = items['p4']
-        items['__fast_pt'] = fast_pt(thep4)
-        items['__fast_eta'] = fast_eta(thep4)
-        items['__fast_phi'] = fast_phi(thep4)
-        items['__fast_mass'] = fast_mass(thep4)
-        items.update(kwargs)
+            raise Exception('No valid definition of four-momentum found to build JaggedCandidateArray')
+        
+        items['p4'] = p4
+        items['__fast_pt'] = fast_pt(p4)
+        items['__fast_eta'] = fast_eta(p4)
+        items['__fast_phi'] = fast_phi(p4)
+        items['__fast_mass'] = fast_mass(p4)
         return cls.fromoffsets(offsets,awkward.Table(items))
     
     @property
@@ -118,6 +161,13 @@ class JaggedCandidateMethods(awkward.Methods):
     def i9(self):
         if 'p4' in self['9'].columns: return self.fromjagged(self['9'])
         return self['9']
+
+    def add_attributes(self,**kwargs):
+        for key,item in kwargs.items():
+            if isinstance(item,awkward.JaggedArray):
+                self[key] = awkward.JaggedArray.fromoffsets(self.offsets,item.flatten())
+            elif isinstance(item,np.ndarray):
+                self[key] = awkward.JaggedArray.fromoffsets(self.offsets,item)
 
     def distincts(self, nested=False):
         outs = super(JaggedCandidateMethods, self).distincts(nested)

--- a/fnal_column_analysis_tools/striped/ColumnGroup2JaggedTable.py
+++ b/fnal_column_analysis_tools/striped/ColumnGroup2JaggedTable.py
@@ -4,9 +4,11 @@ import awkward
 
 def jaggedFromColumnGroup(cgroup):
     if isinstance(cgroup,PhysicalColumnGroup):
-        return JaggedCandidateArray.candidatesfromcounts(counts = cgroup.counts(),
-                                                         p4 = cgroup.p4Column(),
-                                                         **cgroup.otherColumns())
+        theargs = {}
+        theargs.update(cgroup.p4Columns())
+        theargs.update(cgroup.otherColumns())
+        return JaggedCandidateArray.candidatesfromcounts(counts=cgroup.counts(),
+                                                         **theargs)
     else:
         return awkward.JaggedArray.fromcounts(cgroup.counts(),
                                               awkward.Table(cgroup.columns()))

--- a/fnal_column_analysis_tools/striped/StripedColumnTransformer.py
+++ b/fnal_column_analysis_tools/striped/StripedColumnTransformer.py
@@ -36,26 +36,46 @@ class ColumnGroup(object):
         return self._counts
     
 class PhysicalColumnGroup(ColumnGroup):
-    def __init__(self,events,objName,p4Name,*args):
-        self._p4  = p4Name
-        allargs = [p4Name]
-        allargs.extend(args)        
+    def __init__(self,events,objName,*args,**kwargs):
+        self._hasp4 = False
+        argkeys = kwargs.keys()
+        self._p4 = None
+        if 'p4' in argkeys:
+            self._hasp4 = True
+            self._p4 = {'p4':kwargs['p4']}
+        elif 'pt' in argkeys and 'eta' in argkeys and 'phi' in argkeys and 'mass' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['pt','eta','phi','mass']}
+        elif 'pt' in argkeys and 'eta' in argkeys and 'phi' in argkeys and 'energy' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['pt','eta','phi','energy']}
+        elif 'px' in argkeys and 'py' in argkeys and 'pz' in argkeys and 'mass' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['px','py','pz','mass']}
+        elif 'pt' in argkeys and 'phi' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['pt','phi','pz','energy']}
+        elif 'px' in argkeys and 'py' in argkeys and 'pz' in argkeys and 'energy' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['px','py','pz','energy']}
+        elif 'p' in argkeys and 'theta' in argkeys and 'phi' in argkeys and 'energy' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['p','theta','phi','energy']}
+        elif 'p3' in argkeys and 'energy' in argkeys:
+            self._hasp4 = True
+            self._p4 = {key:kwargs[key] for key in ['p3','energy']}
+        else:
+            raise Exception('No valid definition of four-momentum found to build JaggedCandidateArray')
+        allargs = list(args) + [val for val in kwargs.values()]
         super(PhysicalColumnGroup,self).__init__(events,objName,*allargs)
-        if p4Name is not None:
-            self.setP4Name(p4Name)
-    
-    def setP4Name(self,name):
-        if name not in self.columns().keys():
-            raise Exception('{} not an available name in this PhysicalColumnGroup'.format(name))
-        self._p4 = name
-    
+        
     def p4Name(self):
         if self._p4 is None:
             raise Exception('p4 is not set for this PhysicalColumnGroup')
-        return self._p4
+        return self._p4.values()
     
-    def p4Column(self):        
-        return self[self.p4Name()]
+    def p4Columns(self):
+        return {key:self.columns()[value] for key,value in self._p4.items()}
     
     def otherColumns(self):
         return self.columnsWithout(self.p4Name())

--- a/tests/dummy_distributions.py
+++ b/tests/dummy_distributions.py
@@ -27,6 +27,14 @@ def dummy_events():
     class obj(object):
         def __init__(self):
             self.p4 = thep4
+            self.px = px
+            self.py = py
+            self.pz = pz
+            self.en = energy
+            self.pt = np.hypot(px,py)
+            self.phi = np.arctan2(py,px)
+            self.eta = np.arctanh(pz/np.sqrt(px*px + py*py + pz*pz))
+            self.mass = np.sqrt(np.abs(energy*energy - (px*px + py*py + pz*pz)))
             self.blah = energy*px
             self.count = counts
     

--- a/tests/test_analysis_objects.py
+++ b/tests/test_analysis_objects.py
@@ -44,6 +44,8 @@ def test_analysis_objects():
     addon2 = jca2.ones_like()
     jca1['addon'] = addon1
     jca2['addon'] = addon2
+
+    jca1.add_attributes(addonFlat=addon1.flatten(),addonJagged=addon1)
     
     diffm = np.abs(jca1.p4.mass - jca2.p4.mass)
     assert( (jca1.offsets == jca2.offsets).all() )

--- a/tests/test_striped.py
+++ b/tests/test_striped.py
@@ -11,10 +11,18 @@ from dummy_distributions import dummy_events
 def test_striped():
     events = dummy_events()
     colgroup = ColumnGroup(events,"thing","p4","blah")
-    physcolgroup = PhysicalColumnGroup(events,"thing","p4","blah")
-
+    physcolgroup = PhysicalColumnGroup(events,"thing","blah",p4="p4")
+    physcolgroup2 = PhysicalColumnGroup(events,"thing","blah",
+                                        pt="pt",eta="eta",phi="phi",mass="mass")
+    physcolgroup3 = PhysicalColumnGroup(events,"thing","blah",
+                                        px="px",py="py",pz="pz",energy="en")
+    
     jagged = jaggedFromColumnGroup(colgroup)
     candjagged = jaggedFromColumnGroup(physcolgroup)
+    candjagged2 = jaggedFromColumnGroup(physcolgroup2)
+    candjagged3 = jaggedFromColumnGroup(physcolgroup3)
     
     assert not hasattr(jagged,'p4')
     assert hasattr(candjagged,'p4')
+    assert hasattr(candjagged2,'p4')
+    assert hasattr(candjagged3,'p4')


### PR DESCRIPTION
This PR implements four-vector construction from a variety of input types, example:
```python
#from p4
muons = JaggedCandidateArray.candidatefromcounts(
    events.Muon.count,
    p4=events.Muon.p4
)
#or from pt/eta/phi/m
muons = JaggedCandidateArray.candidatefromcounts(
    event.Muon.count,
    pt=events.Muon.pt,
    eta=events.Muon.eta,
    phi=events.Muon.phi,
    m=events.Muon.mass
)
```
... and a number of others. Note that the special keywords will be removed from the final object and replaced by a constructed lorentz vector!
If you don't pass a valid p4 definition it will throw an exception.

This PR also implements a concise wrapper for adding extra stuff to the analysis object, example:
```python
muons.add_attribute(pfRelIso04_all=events.Muon.pfRelIso04_all)
```

does the same thing as
```python
muons['pfRelIso04_all'] = awkward.JaggedArray.fromoffsets(muons.offsets,events.Muon.pfRelIso04_all)
```
You can also pass in jagged arrays to this function and it will try to insert the passed array into the candidate

@mcremone @areinsvo 