### PR TITLE
Fork pyxrootd

### DIFF
--- a/fnal_column_analysis_tools/processor/dataframe.py
+++ b/fnal_column_analysis_tools/processor/dataframe.py
@@ -1,4 +1,3 @@
-import warnings
 from ..util import awkward
 
 try:
@@ -39,9 +38,7 @@ class LazyDataFrame(MutableMapping):
             raise KeyError(key)
 
     def __iter__(self):
-        warnings.warning("An iterator has requested to read all branches from the tree", RuntimeWarning)
         for item in self._dict:
-            self._materialized.add(item[0])
             yield item
 
     def __len__(self):


### PR DESCRIPTION
This resolves a bug in the `processor.run_uproot_job` tool which causes things to completely hang if using `futures_executor` with xrootd files.