### PR TITLE
Allow flattening in parsl

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -173,6 +173,7 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
     executor_args.setdefault('config', _default_cfg)
     executor_args.setdefault('timeout', 180)
     executor_args.setdefault('chunking_timeout', 10)
+    executor_args.setdefault('flatten', True)
 
     # initialize spark if we need to
     # if we initialize, then we deconstruct

--- a/coffea/processor/test_items/NanoTestProcessor.py
+++ b/coffea/processor/test_items/NanoTestProcessor.py
@@ -31,7 +31,7 @@ class NanoTestProcessor(processor.ProcessorABC):
         dataset = df['dataset']
 
         muon = None
-        if isinstance(df['Muon_pt'],akd.JaggedArray):
+        if isinstance(df['Muon_pt'], akd.JaggedArray):
             muon = CandArray.candidatesfromcounts(counts=df['Muon_pt'].counts,
                                                   pt=df['Muon_pt'].content,
                                                   eta=df['Muon_eta'].content,

--- a/coffea/processor/test_items/NanoTestProcessor.py
+++ b/coffea/processor/test_items/NanoTestProcessor.py
@@ -1,6 +1,7 @@
 from coffea import hist, processor
 from coffea.analysis_objects import JaggedCandidateArray as CandArray
-import numpy as np
+from coffea.util import awkward as akd
+from coffea.util import numpy as np
 
 
 class NanoTestProcessor(processor.ProcessorABC):
@@ -29,11 +30,19 @@ class NanoTestProcessor(processor.ProcessorABC):
 
         dataset = df['dataset']
 
-        muon = CandArray.candidatesfromcounts(counts=df['nMuon'],
-                                              pt=df['Muon_pt'],
-                                              eta=df['Muon_eta'],
-                                              phi=df['Muon_phi'],
-                                              mass=df['Muon_mass'])
+        muon = None
+        if isinstance(df['Muon_pt'],akd.JaggedArray):
+            muon = CandArray.candidatesfromcounts(counts=df['Muon_pt'].counts,
+                                                  pt=df['Muon_pt'].content,
+                                                  eta=df['Muon_eta'].content,
+                                                  phi=df['Muon_phi'].content,
+                                                  mass=df['Muon_mass'].content)
+        else:
+            muon = CandArray.candidatesfromcounts(counts=df['nMuon'],
+                                                  pt=df['Muon_pt'],
+                                                  eta=df['Muon_eta'],
+                                                  phi=df['Muon_phi'],
+                                                  mass=df['Muon_mass'])
 
         dimuon = muon.distincts()
 

--- a/tests/test_local_executors.py
+++ b/tests/test_local_executors.py
@@ -10,7 +10,7 @@ if sys.platform.startswith("win"):
     pytest.skip("skipping tests that only function in linux", allow_module_level=True)
 
 
-def template_analysis(executor):
+def template_analysis(executor, flatten):
     from coffea.processor import run_uproot_job
     
     filelist = {
@@ -23,7 +23,7 @@ def template_analysis(executor):
 
     exe_args = {'workers': 1,
                 'pre_workers': 1,
-                'function_args': {'flatten': True}}
+                'function_args': {'flatten': flatten}}
 
     hists = run_uproot_job(filelist, treename, NanoTestProcessor(), executor,
                            executor_args = exe_args)
@@ -36,10 +36,12 @@ def template_analysis(executor):
 
 def test_iterative_executor():
     from coffea.processor import iterative_executor
-    template_analysis(iterative_executor)
+    template_analysis(iterative_executor, True)
+    template_analysis(iterative_executor, False)
 
 
 def test_futures_executor():
     from coffea.processor import futures_executor
-    template_analysis(futures_executor)
+    template_analysis(futures_executor, True)
+    template_analysis(futures_executor, False)
 

--- a/tests/test_parsl.py
+++ b/tests/test_parsl.py
@@ -71,9 +71,16 @@ def test_parsl_executor():
 
     hists = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, data_flow=dfk)
 
+    hists2 = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, data_flow=dfk, executor_args={'flatten': False})
+
     _parsl_stop(dfk)
 
     assert( hists['cutflow']['ZJets_pt'] == 4 )
     assert( hists['cutflow']['ZJets_mass'] == 1 )
     assert( hists['cutflow']['Data_pt'] == 15 )
     assert( hists['cutflow']['Data_mass'] == 5 )
+
+    assert( hists2['cutflow']['ZJets_pt'] == 4 )
+    assert( hists2['cutflow']['ZJets_mass'] == 1 )
+    assert( hists2['cutflow']['Data_pt'] == 15 )
+    assert( hists2['cutflow']['Data_mass'] == 5 )


### PR DESCRIPTION
Allow parsl to use flat jagged arrays within processors, this is off by default.

You'll need to pass `executor_args={'flatten': False}` to `run_parsl_job` in addition to the usual to use this feature.