### PR TITLE
custom treename per filelist entry

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -109,7 +109,7 @@ def _get_chunking_lazy(filelist, treename, chunksize):
             yield (fn, chunksize, index)
 
 
-def run_uproot_job(fileset, treename, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
+def run_uproot_job(fileset, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
     '''
     A convenience wrapper to submit jobs for a file set, which is a
     dictionary of dataset: [file list] entries.  Supports only uproot
@@ -154,6 +154,8 @@ def run_uproot_job(fileset, treename, processor_instance, executor, executor_arg
 
     items = []
     for dataset, filelist in tqdm(fileset.items(), desc='Preprocessing'):
+        treename = filelist['treename']
+        filelist = filelist['files']
         if maxchunks is not None:
             chunks = _get_chunking_lazy(tuple(filelist), treename, chunksize)
         else:


### PR DESCRIPTION
this allows a specification of a filelist like this

```
fileset = {
    'ttbar': {
        'treename': 'ttbar_mc16a_Nom',
        'files': glob.glob('../exported/ttbar_mc16a/*.root')
    },
    'CC1N1_higgsino_300_mc16a': {
        'treename': 'C1N1_higgsino_300_mc16a_Nom',
        'files': glob.glob('../exported/C1N1_higgsino_300_mc16a/*.root')
    },
}

output = processor.run_uproot_job(
    fileset,
    processor_instance=MyProcessor(),
    executor=processor.futures_executor,
    executor_args={'workers': 10, 'function_args': {'flatten': True}},
)
```