### PR TITLE
Custom treename per filelist entry redux

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -119,7 +119,7 @@ def _get_chunking_lazy(filelist, treename, chunksize):
             yield (fn, chunksize, index)
 
 
-def run_uproot_job(fileset, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
+def run_uproot_job(fileset, treename, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
     '''
     A convenience wrapper to submit jobs for a file set, which is a
     dictionary of dataset: [file list] entries.  Supports only uproot
@@ -132,7 +132,9 @@ def run_uproot_job(fileset, processor_instance, executor, executor_args={}, chun
         fileset:
             dictionary {dataset: [file, file], }
         treename:
-            name of tree inside each root file
+            name of tree inside each root file, can be ``None``
+
+            .. note:: treename can also be defined in fileset, which will override the passed treename
         processor_instance:
             an instance of a class deriving from ProcessorABC
         executor:
@@ -162,18 +164,22 @@ def run_uproot_job(fileset, processor_instance, executor, executor_args={}, chun
     executor_args.setdefault('pre_workers', 4 * executor_args['workers'])
     executor_args.setdefault('savemetrics', False)
 
+    tn = treename
     items = []
     for dataset, filelist in tqdm(fileset.items(), desc='Preprocessing'):
-        treename = filelist['treename']
-        filelist = filelist['files']
+        if isinstance(filelist, dict):
+            tn = filelist['treename'] if 'treename' in filelist else tn
+            filelist = filelist['files']
+        if not isinstance(filelist, list):
+            raise ValueError('list of filenames in fileset must be a list or a dict')
         if maxchunks is not None:
-            chunks = _get_chunking_lazy(tuple(filelist), treename, chunksize)
+            chunks = _get_chunking_lazy(tuple(filelist), tn, chunksize)
         else:
-            chunks = _get_chunking(tuple(filelist), treename, chunksize, executor_args['pre_workers'])
+            chunks = _get_chunking(tuple(filelist), tn, chunksize, executor_args['pre_workers'])
         for ichunk, chunk in enumerate(chunks):
             if (maxchunks is not None) and (ichunk > maxchunks):
                 break
-            items.append((dataset, chunk[0], treename, chunk[1], chunk[2], processor_instance))
+            items.append((dataset, chunk[0], tn, chunk[1], chunk[2], processor_instance))
 
     out = processor_instance.accumulator.identity()
     wrapped_out = dict_accumulator({'out': out, 'metrics': dict_accumulator()})
@@ -248,14 +254,19 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
             raise ValueError("Expected 'data_flow' to be a parsl.dataflow.dflow.DataFlowKernel")
 
     tn = treename
-    if not isinstance(tn, str):
-        tn = tuple(treename)
     to_chunk = []
     for dataset, filelist in fileset.items():
+        if isinstance(filelist, dict):
+            tn = filelist['treename'] if 'treename' in filelist else tn
+            filelist = filelist['files']
+        if not isinstance(filelist, list):
+            raise ValueError('list of filenames in fileset must be a list or a dict')
+        if not isinstance(tn, str):
+            tn = tuple(treename)
         for afile in filelist:
-            to_chunk.append((dataset, afile))
+            to_chunk.append((dataset, afile, tn))
 
-    items = _parsl_get_chunking(to_chunk, tn, chunksize, timeout=executor_args['chunking_timeout'])
+    items = _parsl_get_chunking(to_chunk, chunksize, timeout=executor_args['chunking_timeout'])
 
     # loose items we don't need any more
     executor_args.pop('chunking_timeout')

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -119,7 +119,7 @@ def _get_chunking_lazy(filelist, treename, chunksize):
             yield (fn, chunksize, index)
 
 
-def run_uproot_job(fileset, treename, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
+def run_uproot_job(fileset, processor_instance, executor, executor_args={}, chunksize=500000, maxchunks=None):
     '''
     A convenience wrapper to submit jobs for a file set, which is a
     dictionary of dataset: [file list] entries.  Supports only uproot
@@ -164,6 +164,8 @@ def run_uproot_job(fileset, treename, processor_instance, executor, executor_arg
 
     items = []
     for dataset, filelist in tqdm(fileset.items(), desc='Preprocessing'):
+        treename = filelist['treename']
+        filelist = filelist['files']
         if maxchunks is not None:
             chunks = _get_chunking_lazy(tuple(filelist), treename, chunksize)
         else:

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -85,8 +85,8 @@ def derive_chunks(filename, treename, chunksize, ds, timeout=10):
     return ds, treename, [(filename, chunksize, index) for index in range(nentries // chunksize + 1)]
 
 
-def _parsl_get_chunking(filelist, treename, chunksize, status=True, timeout=10):
-    futures = set(derive_chunks(fn, treename, chunksize, ds, timeout=timeout) for ds, fn in filelist)
+def _parsl_get_chunking(filelist, chunksize, status=True, timeout=10):
+    futures = set(derive_chunks(fn, tn, chunksize, ds, timeout=timeout) for ds, fn, tn in filelist)
 
     items = []
 

--- a/tests/test_local_executors.py
+++ b/tests/test_local_executors.py
@@ -10,13 +10,9 @@ if sys.platform.startswith("win"):
     pytest.skip("skipping tests that only function in linux", allow_module_level=True)
 
 
-def template_analysis(executor, flatten):
+def template_analysis(filelist, executor, flatten):
     from coffea.processor import run_uproot_job
     
-    filelist = {
-        'ZJets': [osp.abspath('tests/samples/nano_dy.root')],
-        'Data': [osp.abspath('tests/samples/nano_dimuon.root')]
-    }
     treename='Events'
 
     from coffea.processor.test_items import NanoTestProcessor
@@ -36,12 +32,39 @@ def template_analysis(executor, flatten):
 
 def test_iterative_executor():
     from coffea.processor import iterative_executor
-    template_analysis(iterative_executor, True)
-    template_analysis(iterative_executor, False)
+    
+    filelist = {
+        'ZJets': [osp.abspath('tests/samples/nano_dy.root')],
+        'Data': [osp.abspath('tests/samples/nano_dimuon.root')]
+    }
+    
+    template_analysis(filelist, iterative_executor, True)
+    template_analysis(filelist, iterative_executor, False)
+
+    filelist = {
+        'ZJets': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dy.root')]},
+        'Data': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dimuon.root')]}
+        }
+
+    template_analysis(filelist, iterative_executor, True)
+    template_analysis(filelist, iterative_executor, False)
 
 
 def test_futures_executor():
     from coffea.processor import futures_executor
-    template_analysis(futures_executor, True)
-    template_analysis(futures_executor, False)
+    
+    filelist = {
+        'ZJets': [osp.abspath('tests/samples/nano_dy.root')],
+        'Data': [osp.abspath('tests/samples/nano_dimuon.root')]
+    }
 
+    template_analysis(filelist, futures_executor, True)
+    template_analysis(filelist, futures_executor, False)
+
+    filelist = {
+        'ZJets': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dy.root')]},
+        'Data': {'treename':'Events', 'files': [osp.abspath('tests/samples/nano_dimuon.root')]}
+    }
+    
+    template_analysis(filelist, futures_executor, True)
+    template_analysis(filelist, futures_executor, False)


### PR DESCRIPTION
Fixes #119 

#120 but retain the original method of passing a common tree name for compatibility and simplicity.

@lukasheinrich 

