### PR TITLE
Remove timeout decorator for Parsl apps

### DIFF
--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -14,8 +14,6 @@ from parsl.executors import HighThroughputExecutor
 
 from ..executor import futures_handler
 
-from .timeout import timeout
-
 try:
     from collections.abc import Sequence
 except ImportError:

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -48,7 +48,6 @@ def _parsl_stop(dfk):
 
 
 @python_app
-@timeout
 def derive_chunks(filename, treename, chunksize, ds, timeout=None):
     import uproot
     from collections.abc import Sequence
@@ -61,7 +60,7 @@ def derive_chunks(filename, treename, chunksize, ds, timeout=None):
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(uproot.open, filename)
             try:
-                afile = future.result(timeout=5)
+                afile = future.result(timeout=timeout)
             except TimeoutError:
                 afile = None
             else:

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -48,7 +48,7 @@ def _parsl_stop(dfk):
 
 
 @python_app
-def derive_chunks(filename, treename, chunksize, ds, timeout=None):
+def derive_chunks(filename, treename, chunksize, ds, timeout=10):
     import uproot
     from collections.abc import Sequence
     from concurrent.futures import ThreadPoolExecutor, TimeoutError
@@ -87,7 +87,7 @@ def derive_chunks(filename, treename, chunksize, ds, timeout=None):
     return ds, treename, [(filename, chunksize, index) for index in range(nentries // chunksize + 1)]
 
 
-def _parsl_get_chunking(filelist, treename, chunksize, status=True, timeout=None):
+def _parsl_get_chunking(filelist, treename, chunksize, status=True, timeout=10):
     futures = set(derive_chunks(fn, treename, chunksize, ds, timeout=timeout) for ds, fn in filelist)
 
     items = []

--- a/coffea/processor/parsl/parsl_executor.py
+++ b/coffea/processor/parsl/parsl_executor.py
@@ -18,7 +18,6 @@ lz4_clevel = 1
 
 
 @python_app
-@timeout
 def coffea_pyapp(dataset, fn, treename, chunksize, index, procstr, timeout=None, flatten=True):
     import uproot
     import cloudpickle as cpkl
@@ -49,7 +48,7 @@ def coffea_pyapp(dataset, fn, treename, chunksize, index, procstr, timeout=None,
         with ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(uproot.open, fn)
             try:
-                afile = future.result(timeout=5)
+                afile = future.result(timeout=timeout)
             except TimeoutError:
                 afile = None
             else:


### PR DESCRIPTION
Fixes #131 

The current Parsl backend uses apps decorated with a `timeout` decorator which sends SIGALRM if the runtime of a decorated function exceeds the allotted time; this kills the worker.

This PR removes the timeout decorator for Parsl apps.

