### PR TITLE
Add OSError catching to executor to allow skipping corrupted files over xrootd

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -95,7 +95,7 @@ def _work_function(item, flatten=False, savemetrics=False, mmap=False, skipbadfi
         if not skipbadfiles:
             raise e
         else:
-            print("File",fn,"corrupted, skipping!")
+            print("Skipping corrupted file:", fn)
 
     metrics = dict_accumulator()
     if savemetrics:


### PR DESCRIPTION
Fixes #135 

@andrzejnovak can you try this PR to see if it fixes your problem?

You need to pass the executor_arg `skipbadfiles=True` and it should propagate down to the thread running the analysis.