### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if six.PY3:
     blobbing = ['cloudpickle', 'lz4']
     pandas = ['pandas']
     templates = ['jinja2']
-    EXTRAS_REQUIRE['spark'] = ['pyspark>=2.4.1', 'pyarrow'] + blobbing + templates + pandas
+    EXTRAS_REQUIRE['spark'] = ['pyspark>=2.4.1', 'pyarrow>=0.10.0'] + blobbing + templates + pandas
     EXTRAS_REQUIRE['parsl'] = ['parsl>=0.7.2'] + blobbing
 if six.PY2:
     EXTRAS_REQUIRE['striped'] = []


### PR DESCRIPTION
To fix
```python
TypeError: Unsupported type in conversion to Arrow: BinaryType
Please install pyarrow >= 0.10.0 for BinaryType support.
```