### PR TITLE
adds six as a install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ INSTALL_REQUIRES = ['awkward>=0.8.4',
                     'futures; python_version == "2.7"',
                     'tqdm',
                     'lz4',
+                    'six',
                     'cloudpickle',
                     ]
 EXTRAS_REQUIRE = {}


### PR DESCRIPTION
`coffea` seems to import the python 2/3 compatibility library `six` in a few places, but it's not listed as a requirement in `setup.py`. This PR adds this.