### PR TITLE
processor.Weights: Add option to store individual weights

### DIFF
--- a/coffea/processor/helpers.py
+++ b/coffea/processor/helpers.py
@@ -6,11 +6,22 @@ class Weights(object):
     Keep track of event weight corrections, as well as any accompanying systematic
     shifts via multiplicative modifiers.
     """
-    def __init__(self, size):
+    def __init__(self, size, storeIndividual=False):
+        """
+        Initialization.
+
+        Parameters
+        ----------
+            size:
+                Size of the weight arrays to be handled (i.e. the number of events / instances).
+            storeIndividual:
+                Store not only the total weight + variations, but also each individual weight.
+        """
         self._weight = np.ones(size)
+        self._weights = {}
         self._modifiers = {}
         self._weightStats = {}
-
+        self._storeIndividual = storeIndividual
     def add(self, name, weight, weightUp=None, weightDown=None, shift=False):
         """
         Add a correction to the overall event weight, and keep track of systematic uncertainties
@@ -24,6 +35,8 @@ class Weights(object):
         if 'Up' in name or 'Down' in name:
             raise ValueError("Avoid using 'Up' and 'Down' in weight names, instead pass appropriate shifts to add() call")
         self._weight *= weight
+        if self._storeIndividual:
+            self._weights[name] = weight
         if weightUp is not None:
             if shift:
                 weightUp += weight
@@ -51,6 +64,39 @@ class Weights(object):
         elif 'Down' in modifier and modifier not in self._modifiers:
             return self._weight / self._modifiers[modifier.replace('Down', 'Up')]
         return self._weight * self._modifiers[modifier]
+
+    def partial_weight(self, include=[], exclude=[]):
+        """
+        Return a partial weight by multiplying a subset of all weights.
+
+        Can be operated either by specifying weights to include or
+        weights to exclude, but not both at the same time. The method
+        can only be used if the individual weights are stored (see
+        storeIndividual argument in the initializer).
+
+        Parameters
+        ----------
+            include:
+                Weight names to include, defaults to []
+            exclude:
+                Weight names to exclude, defaults to []
+        """
+        if not self._storeIndividual:
+            raise ValueError("To be able to request weight exclusion, use storeIndividual=True when creating Weights object.")
+        if (include and exclude) or not (include or exclude):
+            raise ValueError("Need to specify exactly one of the 'exclude' or 'include' arguments.")
+
+        names = set(self._weights.keys())
+        if include:
+            names = names & set(include)
+        if exclude:
+            names = names - set(exclude)
+
+        w = np.ones(self._weight.size)
+        for name in names:
+            w = w * self._weights[name]
+
+        return w
 
     @property
     def variations(self):

--- a/coffea/processor/helpers.py
+++ b/coffea/processor/helpers.py
@@ -22,6 +22,7 @@ class Weights(object):
         self._modifiers = {}
         self._weightStats = {}
         self._storeIndividual = storeIndividual
+
     def add(self, name, weight, weightUp=None, weightDown=None, shift=False):
         """
         Add a correction to the overall event weight, and keep track of systematic uncertainties

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -50,6 +50,63 @@ def test_weights():
 
     assert(np.all(np.abs(test_shift_down - (exp_down)) < 1e-6))
 
+
+def test_weights_partial():
+    from coffea.processor import Weights
+    counts, _, _ = dummy_jagged_eta_pt()
+    w1 = np.random.normal(loc=1.0, scale=0.01, size=counts.size)
+    w2 = np.random.normal(loc=1.3, scale=0.05, size=counts.size)
+
+    weights = Weights(counts.size, storeIndividual=True)
+    weights.add('w1', w1)
+    weights.add('w2', w2)
+
+    test_exclude_none = weights.weight()
+    assert(np.all(np.abs(test_exclude_none - w1 * w2)<1e-6))
+
+    test_exclude1 = weights.partial_weight(exclude=['w1'])
+    assert(np.all(np.abs(test_exclude1 - w2)<1e-6))
+
+    test_include1 = weights.partial_weight(include=['w1'])
+    assert(np.all(np.abs(test_include1 - w1)<1e-6))
+
+    test_exclude2 = weights.partial_weight(exclude=['w2'])
+    assert(np.all(np.abs(test_exclude2 - w1)<1e-6))
+
+    test_include2 = weights.partial_weight(include=['w2'])
+    assert(np.all(np.abs(test_include2 - w2)<1e-6))
+
+    test_include_both = weights.partial_weight(include=['w1','w2'])
+    assert(np.all(np.abs(test_include_both - w1 * w2)<1e-6))
+
+    # Check that exception is thrown if arguments are incompatible
+    error_raised = False
+    try:
+        weights.partial_weight(exclude=['w1'], include=['w2'])
+    except ValueError:
+        error_raised = True
+    assert(error_raised)
+
+    error_raised = False
+    try:
+        weights.partial_weight()
+    except ValueError:
+        error_raised = True
+    assert(error_raised)
+
+    # Check that exception is thrown if individual weights
+    # are not saved from the start
+    weights = Weights(counts.size, storeIndividual=False)
+    weights.add('w1', w1)
+    weights.add('w2', w2)
+
+    error_raised = False
+    try:
+        weights.partial_weight(exclude=['test'], include=['test'])
+    except ValueError:
+        error_raised = True
+    assert(error_raised)
+
 def test_packed_selection():
     from coffea.processor import PackedSelection
 


### PR DESCRIPTION
I would like to be able to flexibly combine individual weights or make control plots by excluding a subset of individual weights from the total weight product, e.g.:

```
# Only pick a given subset of weights
weights.partial_weight(include=['weight_i_want_1', 'weight_i_want_2'])

# Use all weights except a given subset
weights.partial_weight(exclude=['weight_i_dont_want_1', 'weight_i_dont_want_2'])
```

This PR includes an implementation that would work for my purposes, but I'm open to suggestions for better implementations.