### PR TITLE
Fix unexpected keyword

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -247,7 +247,7 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
     # when we're done
     killParsl = False
     if data_flow is None:
-        data_flow = _parsl_initialize(executor_args['config'])
+        data_flow = _parsl_initialize(executor_args.get('config'))
         killParsl = True
     else:
         if not isinstance(data_flow, parsl.dataflow.dflow.DataFlowKernel):

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -247,7 +247,7 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
     # when we're done
     killParsl = False
     if data_flow is None:
-        data_flow = _parsl_initialize(**executor_args)
+        data_flow = _parsl_initialize(executor_args['config'])
         killParsl = True
     else:
         if not isinstance(data_flow, parsl.dataflow.dflow.DataFlowKernel):


### PR DESCRIPTION
The `_parsl_initialize` function is only expecting one argument. Fixes #162.