### PR TITLE
Fix hangs in Parsl executor

### DIFF
--- a/coffea/processor/parsl/timeout.py
+++ b/coffea/processor/parsl/timeout.py
@@ -7,24 +7,18 @@ def timeout(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-
         import signal
-        import datetime
 
         def _timeout_handler(signum, frame):
             raise Exception("Timeout hit")
 
         signal.signal(signal.SIGALRM, _timeout_handler)
-        if kwargs.get('timeout', None):
-            signal.alarm(kwargs.get('timeout'))
-            print("[Timeout wrapper:{}] Timeout {}".format(datetime.datetime.now(),
-                                                           kwargs.get('timeout')))
+        if kwargs.get('timeout'):
+            signal.alarm(max(1, int(kwargs['timeout'])))
         try:
-            retval = func(*args, **kwargs)
-            return retval
-        except Exception as e:
-            print("[Timeout wrapper:{}] Caught an exception {}".format(datetime.datetime.now(),
-                                                                       e))
-            raise
+            result = func(*args, **kwargs)
+        finally:
+            signal.alarm(0)
+        return result
 
     return wrapper


### PR DESCRIPTION
Major changes:
1) The timeout decorator is now applied to all Parsl apps
   (previously it was not being used). This switches the timeout mechanism
   from a threading-exception-based timeout to a more heavy-handed
   signal-based timeout which interrupts the process.
2) A few bugs in the timeout decorator are fixed: always pass it a
   an int, and disable the alarm after the task has finished.
3) The number of allowed retries is now controlled by the `retries` keyword arg
   to the Parsl app, rather than hard-coded in the app definition.

Fixes #164.