### PR TITLE
Allow spark jobs to deal with multiple tree names

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -338,8 +338,10 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
 
     executor_args.setdefault('config', None)
     executor_args.setdefault('file_type', 'parquet')
-    executor_args.setdefault('laurelin_version', '0.1.0')
+    executor_args.setdefault('laurelin_version', '0.3.0')
+    executor_args.setdefault('treeName', 'Events')
     file_type = executor_args['file_type']
+    treeName = executor_args['treeName']
 
     if executor_args['config'] is None:
         executor_args.pop('config')
@@ -356,7 +358,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
             raise ValueError("Expected 'spark' to be a pyspark.sql.session.SparkSession")
 
     dfslist = _spark_make_dfs(spark, fileset, partitionsize, processor_instance.columns,
-                              thread_workers, file_type)
+                              thread_workers, file_type, treeName)
 
     output = processor_instance.accumulator.identity()
     executor(spark, dfslist, processor_instance, output, thread_workers)

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -40,8 +40,8 @@ def test_spark_executor():
 
     spark = _spark_initialize(config=spark_config,log_level='ERROR',spark_progress=False)
 
-    filelist = {'ZJets': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dy.root')],
-                'Data'  : ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')]
+    filelist = {'ZJets': {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dy.root')], 'treename': 'Events' },
+                'Data'  : {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')], 'treename': 'Events'}
                 }
 
     from coffea.processor.test_items import NanoTestProcessor


### PR DESCRIPTION
Allow spark to take either a specified tree name from the executor args, or one specified in the input file list.