### PR TITLE
Simplify parsl dfk

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -242,7 +242,7 @@ def run_parsl_job(fileset, treename, processor_instance, executor, executor_args
     executor_args.setdefault('chunking_timeout', 10)
     executor_args.setdefault('flatten', True)
 
-    # initialize spark if we need to
+    # initialize parsl if we need to
     # if we initialize, then we deconstruct
     # when we're done
     killParsl = False

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -190,7 +190,7 @@ def run_uproot_job(fileset, treename, processor_instance, executor, executor_arg
     return out
 
 
-def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=None, executor_args={}, chunksize=500000):
+def run_parsl_job(fileset, treename, processor_instance, executor, executor_args={}, chunksize=500000):
     '''
     A convenience wrapper to submit jobs for a file, which is a
     dictionary of dataset: [file list] entries. In this case using parsl.
@@ -246,12 +246,12 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
     # if we initialize, then we deconstruct
     # when we're done
     killParsl = False
-    if data_flow is None:
-        data_flow = _parsl_initialize(executor_args.get('config'))
+    if parsl.dfk() is None:
+        _parsl_initialize(executor_args.get('config'))
         killParsl = True
     else:
-        if not isinstance(data_flow, parsl.dataflow.dflow.DataFlowKernel):
-            raise ValueError("Expected 'data_flow' to be a parsl.dataflow.dflow.DataFlowKernel")
+        if not isinstance(parsl.dfk(), parsl.dataflow.dflow.DataFlowKernel):
+            raise ValueError("Expected parsl.dfk() to be a parsl.dataflow.dflow.DataFlowKernel")
 
     tn = treename
     to_chunk = []
@@ -273,11 +273,11 @@ def run_parsl_job(fileset, treename, processor_instance, executor, data_flow=Non
     executor_args.pop('config')
 
     output = processor_instance.accumulator.identity()
-    executor(data_flow, items, processor_instance, output, **executor_args)
+    executor(items, processor_instance, output, **executor_args)
     processor_instance.postprocess(output)
 
     if killParsl:
-        _parsl_stop(data_flow)
+        _parsl_stop()
 
     return output
 

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -41,8 +41,8 @@ def _parsl_initialize(config=None):
     return dfk
 
 
-def _parsl_stop(dfk):
-    dfk.cleanup()
+def _parsl_stop():
+    parsl.dfk().cleanup()
     parsl.clear()
 
 

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -37,8 +37,8 @@ _default_cfg = Config(
 
 
 def _parsl_initialize(config=None):
-    dfk = parsl.load(config)
-    return dfk
+    parsl.clear()
+    parsl.load(config)
 
 
 def _parsl_stop():

--- a/coffea/processor/parsl/parsl_executor.py
+++ b/coffea/processor/parsl/parsl_executor.py
@@ -78,7 +78,7 @@ class ParslExecutor(object):
     def counts(self):
         return self._counts
 
-    def __call__(self, dfk, items, processor_instance, output, status=True, unit='items', desc='Processing', timeout=None, flatten=True):
+    def __call__(self, items, processor_instance, output, status=True, unit='items', desc='Processing', timeout=None, flatten=True):
         procstr = lz4f.compress(cpkl.dumps(processor_instance))
 
         futures = set()

--- a/tests/test_parsl.py
+++ b/tests/test_parsl.py
@@ -18,9 +18,9 @@ def test_parsl_start_stop():
                                                _parsl_stop,
                                                _default_cfg)
 
-    dfk = _parsl_initialize(config=_default_cfg)
+    _parsl_initialize(config=_default_cfg)
     
-    _parsl_stop(dfk)
+    _parsl_stop()
 
 
 def do_parsl_job(parsl_config, filelist):
@@ -36,15 +36,15 @@ def do_parsl_job(parsl_config, filelist):
     from coffea.processor.test_items import NanoTestProcessor
     from coffea.processor.parsl.parsl_executor import parsl_executor
     
-    dfk = _parsl_initialize(parsl_config)
+    _parsl_initialize(parsl_config)
     
     proc = NanoTestProcessor()
     
-    hists = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, data_flow=dfk)
+    hists = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor)
     
-    hists2 = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, data_flow=dfk, executor_args={'flatten': False})
+    hists2 = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, executor_args={'flatten': False})
     
-    _parsl_stop(dfk)
+    _parsl_stop()
     
     assert( hists['cutflow']['ZJets_pt'] == 4 )
     assert( hists['cutflow']['ZJets_mass'] == 1 )


### PR DESCRIPTION
This PR removes explicitly passing around the Parsl DFK. It's not a critical change, I just think it simplifies things a bit.