### PR TITLE
Optimizations in spark workflow for caching.

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -340,8 +340,10 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
     executor_args.setdefault('file_type', 'parquet')
     executor_args.setdefault('laurelin_version', '0.3.0')
     executor_args.setdefault('treeName', 'Events')
+    executor_args.setdefault('cache', True)
     file_type = executor_args['file_type']
     treeName = executor_args['treeName']
+    use_cache = executor_args['cache']
 
     if executor_args['config'] is None:
         executor_args.pop('config')
@@ -361,7 +363,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
                               thread_workers, file_type, treeName)
 
     output = processor_instance.accumulator.identity()
-    executor(spark, dfslist, processor_instance, output, thread_workers)
+    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache)
     processor_instance.postprocess(output)
 
     if killSpark:

--- a/coffea/processor/spark/detail.py
+++ b/coffea/processor/spark/detail.py
@@ -73,7 +73,9 @@ def _read_df(spark, dataset, files_or_dirs, ana_cols, partitionsize, file_type, 
         df = df.withColumn(missing, fn.lit(0.0))
     df = df.withColumn('dataset', fn.lit(dataset))
     npartitions = (count // partitionsize) + 1
-    if df.rdd.getNumPartitions() > npartitions:
+    actual_partitions = df.rdd.getNumPartitions()
+    avg_counts = count / actual_partitions
+    if actual_partitions > 1.50 * npartitions or avg_counts > partitionsize:
         df = df.repartition(npartitions)
 
     return df, dataset, count


### PR DESCRIPTION
- make caching an option (on by default)
- parallelize caching in case it's more "verby" for that workflow / cluster
- select() is always lazy so just fill cached_dfs with the select statement when not caching