### PR TITLE
Add __getattr__ to LazyDataFrame

### DIFF
--- a/coffea/processor/dataframe.py
+++ b/coffea/processor/dataframe.py
@@ -121,6 +121,12 @@ class PreloadedDataFrame(MutableMapping):
         self._accessed.add(key)
         return self._dict[key]
 
+    def __getattr__(self, key):
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            raise AttributeError(key)
+
     def __iter__(self):
         for key in self._dict:
             self._accessed.add(key)

--- a/coffea/processor/dataframe.py
+++ b/coffea/processor/dataframe.py
@@ -52,7 +52,10 @@ class LazyDataFrame(MutableMapping):
             raise KeyError(key)
 
     def __getattr__(self, key):
-        return self.__getitem__(key)
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            raise AttributeError(key)
 
     def __iter__(self):
         for item in self._dict:

--- a/coffea/processor/dataframe.py
+++ b/coffea/processor/dataframe.py
@@ -51,6 +51,9 @@ class LazyDataFrame(MutableMapping):
         else:
             raise KeyError(key)
 
+    def __getattr__(self, key):
+        return self.__getitem__(key)
+
     def __iter__(self):
         for item in self._dict:
             yield item

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -191,6 +191,7 @@ def test_lazy_dataframe():
     assert(len(df) == 1)
     
     pt = df['Muon_pt']
+    assert(len(df) == 2)
     df['Muon_pt_up'] = pt * 1.05
     assert(len(df) == 3)
     assert('Muon_pt' in df.materialized)
@@ -199,10 +200,8 @@ def test_lazy_dataframe():
     
     assert(df.size == tree.numentries)
 
-    try:
+    with pytest.raises(KeyError):
         x = df['notthere']
-    except KeyError:
-        pass
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason='problems with paths on windows')


### PR DESCRIPTION
Using `__getattr__`, one can access columns from lazy dataframe like `df.electron_pt` in addition to `df["electron_pt"]`. This just forwards to `__getitem__` which is obviously already implemented.

Pandas does something like this (they're a bit more clever I believe), so I thought it makes sense to have it here as well. (Also I prefer it 😄 )