### PR TITLE
Implement a dask executor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - PY_MAJ=`python -c 'import sys; print(sys.version_info[0])'`
 - PY_MIN=`python -c 'import sys; print(sys.version_info[1])'`
 - pip -q install numpy scipy numba tqdm matplotlib pytest pytest-runner flake8 --upgrade
-- pip -q install pandas pyarrow\<0.15.0 cloudpickle lz4 jinja2 pyspark --upgrade
+- pip -q install pandas pyarrow\<0.15.0 cloudpickle lz4 jinja2 pyspark dask distributed --upgrade
 - if [ $PY_MAJ -eq 3 ]; then pip -q install https://github.com/Parsl/parsl/zipball/master; fi
 - pip -q install ${AWKWARD}
 - pip -q install uproot 

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -19,6 +19,7 @@ from .executor import (
 from .accumulator import (
     AccumulatorABC,
     value_accumulator,
+    list_accumulator,
     set_accumulator,
     dict_accumulator,
     defaultdict_accumulator,
@@ -39,6 +40,7 @@ __all__ = [
     'run_spark_job',
     'AccumulatorABC',
     'value_accumulator',
+    'list_accumulator',
     'set_accumulator',
     'dict_accumulator',
     'defaultdict_accumulator',

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -12,6 +12,7 @@ from .executor import (
     iterative_executor,
     futures_executor,
     dask_executor,
+    parsl_executor,
     run_uproot_job,
     run_parsl_job,
     run_spark_job
@@ -35,6 +36,7 @@ __all__ = [
     'iterative_executor',
     'futures_executor',
     'dask_executor',
+    'parsl_executor',
     'run_uproot_job',
     'run_parsl_job',
     'run_spark_job',

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -11,6 +11,7 @@ from .helpers import Weights, PackedSelection
 from .executor import (
     iterative_executor,
     futures_executor,
+    dask_executor,
     run_uproot_job,
     run_parsl_job,
     run_spark_job

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     'PackedSelection',
     'iterative_executor',
     'futures_executor',
+    'dask_executor',
     'run_uproot_job',
     'run_parsl_job',
     'run_spark_job',

--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -81,6 +81,22 @@ class value_accumulator(AccumulatorABC):
             self.value = self.value + other
 
 
+class list_accumulator(list, AccumulatorABC):
+    '''A list with accumulator semantics
+
+    See `list` for further info
+    '''
+    def identity(self):
+        return list()
+
+    def add(self, other):
+        '''Add another accumulator to this one in-place'''
+        if isinstance(other, list):
+            list.extend(self, other)
+        else:
+            raise ValueError
+
+
 class set_accumulator(set, AccumulatorABC):
     '''A set with accumulator semantics
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -339,8 +339,7 @@ def parsl_executor(items, function, accumulator, **kwargs):
         parsl.clear()
         parsl.load(config)
 
-    # wrap with timeout() ?
-    app = python_app(function)
+    app = timeout(python_app(function))
 
     futures = set(app(item) for item in items)
     _futures_handler(futures, accumulator, status, unit, desc, add_fn)

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -195,7 +195,7 @@ def dask_executor(items, function, accumulator, **kwargs):
     while len(futures) > 1:
         futures = client.map(
             reducer,
-            [futures[i * ntree:(i + 1) * ntree] for i in range(len(futures) // ntree + 1)],
+            [futures[i:i + ntree] for i in range(0, len(futures), ntree)],
             priority=1,
         )
     if status:
@@ -206,7 +206,7 @@ def dask_executor(items, function, accumulator, **kwargs):
 
 
 def parsl_executor(items, function, accumulator, **kwargs):
-    """Execute using parsl pyapp wrapper (TODO)
+    """Execute using parsl pyapp wrapper
 
     Parameters
     ----------
@@ -218,6 +218,8 @@ def parsl_executor(items, function, accumulator, **kwargs):
             An accumulator to collect the output of the function
         config : parsl.config.Config, optional
             A parsl DataFlow configuration object. Necessary if there is no active kernel
+
+            .. note:: In general, it is safer to construct the DFK with ``parsl.load(config)`` prior to calling this function
         status : bool
             If true (default), enable progress bar
         unit : str

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -7,6 +7,7 @@ import pickle
 import sys
 import math
 from tqdm.auto import tqdm
+from collections import defaultdict
 from cachetools import LRUCache
 import lz4.frame as lz4f
 from .processor import ProcessorABC
@@ -22,14 +23,8 @@ from .dataframe import (
 
 try:
     from collections.abc import Mapping, Sequence
-    from functools import lru_cache
 except ImportError:
     from collections import Mapping, Sequence
-
-    def lru_cache(maxsize):
-        def null_wrapper(f):
-            return f
-        return null_wrapper
 
 
 # instrument xrootd source
@@ -486,7 +481,7 @@ def run_uproot_job(fileset,
                 chunks.append(chunk)
     else:
         # get just enough file info to compute chunking
-        nchunks = {}
+        nchunks = defaultdict(int)
         while fileset:
             filemeta = fileset.pop()
             if nchunks[filemeta.dataset] >= maxchunks:

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -226,8 +226,8 @@ def run_uproot_job(fileset, treename, processor_instance, executor, executor_arg
             and performs some action equivalent to:
             ``for item in items: accumulator += function(item)``
         executor_args : dict, optional
-            Extra arguments to pass to executor.  See `iterative_executor` or
-            `futures_executor` for available options.  Some options that
+            Extra arguments to pass to executor.  See `iterative_executor`,
+            `futures_executor`, or `dask_executor` for available options.  Some options that
             affect the behavior of this function: 'pre_workers' specifies the
             number of parallel threads for calculating chunking (default: 4*workers);
             'savemetrics' saves some detailed metrics for xrootd processing (default False);

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import concurrent.futures
 from functools import partial
 import time

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -12,7 +12,7 @@ from parsl.channels import LocalChannel
 from parsl.config import Config
 from parsl.executors import HighThroughputExecutor
 
-from ..executor import futures_handler
+from ..executor import _futures_handler
 from .timeout import timeout
 
 try:
@@ -83,6 +83,6 @@ def _parsl_get_chunking(filelist, chunksize, status=True, timeout=10):
         for chunk in chunks:
             total.append((ds, chunk[0], treename, chunk[1], chunk[2]))
 
-    futures_handler(futures, items, status, 'files', 'Preprocessing', futures_accumulator=chunk_accumulator)
+    _futures_handler(futures, items, status, 'files', 'Preprocessing', add_fn=chunk_accumulator)
 
     return items

--- a/coffea/processor/parsl/parsl_executor.py
+++ b/coffea/processor/parsl/parsl_executor.py
@@ -12,7 +12,7 @@ import time
 
 from parsl.app.app import python_app
 from .timeout import timeout
-from ..executor import futures_handler
+from ..executor import _futures_handler
 
 lz4_clevel = 1
 
@@ -92,7 +92,7 @@ class ParslExecutor(object):
             total[1][dataset] += nevents
             total[0].add(pkl.loads(lz4f.decompress(blob)))
 
-        futures_handler(futures, (output, self._counts), status, unit, desc, futures_accumulator=pex_accumulator)
+        _futures_handler(futures, (output, self._counts), status, unit, desc, add_fn=pex_accumulator)
 
 
 parsl_executor = ParslExecutor()

--- a/coffea/processor/spark/detail.py
+++ b/coffea/processor/spark/detail.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     from collections import Sequence
 
-from ..executor import futures_handler
+from ..executor import _futures_handler
 
 # this is a reasonable local spark configuration
 _default_config = pyspark.sql.SparkSession.builder \
@@ -95,7 +95,7 @@ def _spark_make_dfs(spark, fileset, partitionsize, columns, thread_workers, file
                                       ana_cols, partitionsize, file_type,
                                       treeName) for ds, files in fileset.items())
 
-        futures_handler(futures, dfs, status, 'datasets', 'loading', futures_accumulator=dfs_accumulator)
+        _futures_handler(futures, dfs, status, 'datasets', 'loading', add_fn=dfs_accumulator)
 
     return dfs
 

--- a/coffea/processor/spark/spark_executor.py
+++ b/coffea/processor/spark/spark_executor.py
@@ -8,7 +8,7 @@ import lz4.frame as lz4f
 import numpy as np
 import pandas as pd
 
-from ..executor import futures_handler
+from ..executor import _futures_handler
 
 import pyspark
 import pyspark.sql.functions as fn
@@ -99,7 +99,7 @@ class SparkExecutor(object):
                 futures = set()
                 for ds, (df, counts) in dfslist.items():
                     futures.add(executor.submit(self._pruneandcache_data, ds, df, cols_w_ds, use_df_cache))
-                futures_handler(futures, self._cacheddfs, status, unit, cachedesc, futures_accumulator=spex_accumulator)
+                _futures_handler(futures, self._cacheddfs, status, unit, cachedesc, add_fn=spex_accumulator)
 
         with ThreadPoolExecutor(max_workers=thread_workers) as executor:
             futures = set()
@@ -107,7 +107,7 @@ class SparkExecutor(object):
                 futures.add(executor.submit(self._launch_analysis, ds, df, coffea_udf, cols_w_ds))
             # wait for the spark jobs to come in
             self._rawresults = {}
-            futures_handler(futures, self._rawresults, status, unit, desc, futures_accumulator=spex_accumulator)
+            _futures_handler(futures, self._rawresults, status, unit, desc, add_fn=spex_accumulator)
 
         for ds, bitstream in self._rawresults.items():
             if bitstream is None:

--- a/setup.py
+++ b/setup.py
@@ -71,11 +71,11 @@ INSTALL_REQUIRES = ['awkward>=0.8.4',
                     ]
 EXTRAS_REQUIRE = {}
 if six.PY3:
-    blobbing = ['cloudpickle', 'lz4']
     pandas = ['pandas']
     templates = ['jinja2']
-    EXTRAS_REQUIRE['spark'] = ['pyspark>=2.4.1', 'pyarrow>=0.10.0,!=0.14.0'] + blobbing + templates + pandas
-    EXTRAS_REQUIRE['parsl'] = ['parsl>=0.7.2'] + blobbing
+    EXTRAS_REQUIRE['spark'] = ['pyspark>=2.4.1', 'pyarrow>=0.10.0,!=0.14.0'] + templates + pandas
+    EXTRAS_REQUIRE['parsl'] = ['parsl>=0.7.2']
+    EXTRAS_REQUIRE['dask'] = ['dask>=2.6.0', 'distributed>=2.6.0', 'bokeh>=1.3.4']
 if six.PY2:
     EXTRAS_REQUIRE['striped'] = []
 

--- a/tests/test_accumulators.py
+++ b/tests/test_accumulators.py
@@ -15,6 +15,11 @@ def test_accumulators():
     assert np.array_equal(a.value, np.array([5.]))
     assert np.array_equal(a.identity().value, np.array([2.]))
 
+    l = processor.list_accumulator(range(4))
+    l += [3]
+    l += processor.list_accumulator([1, 2])
+    assert l == [0, 1, 2, 3, 3, 1, 2]
+
     b = processor.set_accumulator({'apples', 'oranges'})
     b += {'pears'}
     b += 'grapes'

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -28,7 +28,8 @@ def do_dask_job(client, filelist):
 
 def test_dask_local():
     distributed = pytest.importorskip("distributed", minversion="2.6.0")
-    client = distributed.Client()
+    # `python setup.py pytest` doesn't seem to play nicely with separate processses
+    client = distributed.Client(processes=False, dashboard_address=None)
     
     import os
     import os.path as osp

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -1,0 +1,50 @@
+from __future__ import print_function, division
+from coffea import processor
+
+import warnings
+
+import numpy as np
+
+import sys
+import pytest
+
+
+def do_dask_job(client, filelist):
+    treename='Events'
+    from coffea.processor.test_items import NanoTestProcessor
+    proc = NanoTestProcessor()
+    
+    hists = processor.run_uproot_job(filelist,
+                                     treename,
+                                     processor_instance=proc,
+                                     executor=processor.dask_executor,
+                                     executor_args={'client': client})
+    
+    assert( hists['cutflow']['ZJets_pt'] == 4 )
+    assert( hists['cutflow']['ZJets_mass'] == 1 )
+    assert( hists['cutflow']['Data_pt'] == 15 )
+    assert( hists['cutflow']['Data_mass'] == 5 )
+    
+
+def test_dask_local():
+    distributed = pytest.importorskip("distributed", minversion="2.6.0")
+    client = distributed.Client()
+    
+    import os
+    import os.path as osp
+
+    filelist = {
+        'ZJets': [osp.join(os.getcwd(),'tests/samples/nano_dy.root')],
+        'Data' : [osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')]
+    }
+
+    do_dask_job(client, filelist)
+
+    filelist = {
+        'ZJets': {'treename': 'Events', 'files': [osp.join(os.getcwd(),'tests/samples/nano_dy.root')]},
+        'Data' : {'treename': 'Events', 'files': [osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')]}
+    }
+        
+    do_dask_job(client, filelist)
+
+    client.close()

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -9,16 +9,20 @@ import sys
 import pytest
 
 
-def do_dask_job(client, filelist):
+def do_dask_job(client, filelist, compression=0):
     treename='Events'
     from coffea.processor.test_items import NanoTestProcessor
     proc = NanoTestProcessor()
     
+    exe_args = {
+        'client': client,
+        'compression': compression,
+    }
     hists = processor.run_uproot_job(filelist,
                                      treename,
                                      processor_instance=proc,
                                      executor=processor.dask_executor,
-                                     executor_args={'client': client})
+                                     executor_args=exe_args)
     
     assert( hists['cutflow']['ZJets_pt'] == 4 )
     assert( hists['cutflow']['ZJets_mass'] == 1 )
@@ -40,6 +44,7 @@ def test_dask_local():
     }
 
     do_dask_job(client, filelist)
+    do_dask_job(client, filelist, compression=2)
 
     filelist = {
         'ZJets': {'treename': 'Events', 'files': [osp.join(os.getcwd(),'tests/samples/nano_dy.root')]},

--- a/tests/test_hist_plot.py
+++ b/tests/test_hist_plot.py
@@ -47,7 +47,7 @@ def fill_lepton_kinematics():
     lepton_kinematics = hist.Hist("Events",
                                   hist.Cat("flavor", "Lepton flavor"),
                                   hist.Bin("pt", "$p_{T}$", 19, 10, 100),
-                                  hist.Bin("eta", "$\eta$", [-2.5, -1.4, 0, 1.4, 2.5]),
+                                  hist.Bin("eta", r"$\eta$", [-2.5, -1.4, 0, 1.4, 2.5]),
                                   )
 
     # Pass keyword arguments to fill, all arrays must be flat numpy arrays

--- a/tests/test_local_executors.py
+++ b/tests/test_local_executors.py
@@ -10,20 +10,24 @@ if sys.platform.startswith("win"):
     pytest.skip("skipping tests that only function in linux", allow_module_level=True)
 
 
-def template_analysis(filelist, executor, flatten):
+def template_analysis(filelist, executor, flatten, compression):
     from coffea.processor import run_uproot_job
     
     treename='Events'
 
     from coffea.processor.test_items import NanoTestProcessor
 
-    exe_args = {'workers': 1,
-                'pre_workers': 1,
-                'function_args': {'flatten': flatten}}
+    exe_args = {
+        'workers': 1,
+        'pre_workers': 1,
+        'flatten': flatten,
+        'compression': compression,
+    }
 
     hists = run_uproot_job(filelist, treename, NanoTestProcessor(), executor,
                            executor_args = exe_args)
 
+    print(hists)
     assert( hists['cutflow']['ZJets_pt'] == 4 )
     assert( hists['cutflow']['ZJets_mass'] == 1 )
     assert( hists['cutflow']['Data_pt'] == 15 )
@@ -38,16 +42,16 @@ def test_iterative_executor():
         'Data': [osp.abspath('tests/samples/nano_dimuon.root')]
     }
     
-    template_analysis(filelist, iterative_executor, True)
-    template_analysis(filelist, iterative_executor, False)
+    template_analysis(filelist, iterative_executor, flatten=True, compression=0)
+    template_analysis(filelist, iterative_executor, flatten=True, compression=1)
+    template_analysis(filelist, iterative_executor, flatten=False, compression=2)
 
     filelist = {
         'ZJets': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dy.root')]},
         'Data': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dimuon.root')]}
         }
 
-    template_analysis(filelist, iterative_executor, True)
-    template_analysis(filelist, iterative_executor, False)
+    template_analysis(filelist, iterative_executor, flatten=True, compression=0)
 
 
 def test_futures_executor():
@@ -58,13 +62,14 @@ def test_futures_executor():
         'Data': [osp.abspath('tests/samples/nano_dimuon.root')]
     }
 
-    template_analysis(filelist, futures_executor, True)
-    template_analysis(filelist, futures_executor, False)
+    template_analysis(filelist, futures_executor, flatten=True, compression=0)
+    template_analysis(filelist, futures_executor, flatten=False, compression=0)
+    template_analysis(filelist, futures_executor, flatten=False, compression=1)
 
     filelist = {
         'ZJets': {'treename': 'Events', 'files': [osp.abspath('tests/samples/nano_dy.root')]},
         'Data': {'treename':'Events', 'files': [osp.abspath('tests/samples/nano_dimuon.root')]}
     }
     
-    template_analysis(filelist, futures_executor, True)
-    template_analysis(filelist, futures_executor, False)
+    template_analysis(filelist, futures_executor, flatten=True, compression=2)
+    template_analysis(filelist, futures_executor, flatten=False, compression=0)

--- a/tests/test_parsl.py
+++ b/tests/test_parsl.py
@@ -2,59 +2,42 @@ from __future__ import print_function, division
 from coffea import processor
 
 import multiprocessing
-
-import warnings
-
-import numpy as np
-
 import sys
 import pytest
 
 
 def test_parsl_start_stop():
     parsl = pytest.importorskip("parsl", minversion="0.7.2")
-    
+
     from coffea.processor.parsl.detail import (_parsl_initialize,
                                                _parsl_stop,
                                                _default_cfg)
 
     _parsl_initialize(config=_default_cfg)
-    
+
     _parsl_stop()
 
 
-def do_parsl_job(parsl_config, filelist):
-    from coffea.processor.parsl.detail import (_parsl_initialize,
-                                               _parsl_stop)
-    from coffea.processor import run_parsl_job
-
-    import os
-    import os.path as osp
-    
+def do_parsl_job(filelist, flatten=False, compression=0):
     treename='Events'
 
     from coffea.processor.test_items import NanoTestProcessor
-    from coffea.processor.parsl.parsl_executor import parsl_executor
-    
-    _parsl_initialize(parsl_config)
-    
     proc = NanoTestProcessor()
-    
-    hists = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor)
-    
-    hists2 = run_parsl_job(filelist, treename, processor_instance = proc, executor=parsl_executor, executor_args={'flatten': False})
-    
-    _parsl_stop()
-    
+
+    exe_args = {
+        'flatten': flatten,
+        'compression': compression,
+    }
+    hists = processor.run_uproot_job(filelist,
+                                     treename,
+                                     processor_instance=proc,
+                                     executor=processor.executor.parsl_executor,
+                                     executor_args=exe_args)
+
     assert( hists['cutflow']['ZJets_pt'] == 4 )
     assert( hists['cutflow']['ZJets_mass'] == 1 )
     assert( hists['cutflow']['Data_pt'] == 15 )
     assert( hists['cutflow']['Data_mass'] == 5 )
-    
-    assert( hists2['cutflow']['ZJets_pt'] == 4 )
-    assert( hists2['cutflow']['ZJets_mass'] == 1 )
-    assert( hists2['cutflow']['Data_pt'] == 15 )
-    assert( hists2['cutflow']['Data_mass'] == 5 )
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='issue with parsl htex on macos')
@@ -85,38 +68,23 @@ def test_parsl_htex_executor():
         ],
         strategy=None,
     )
+    parsl.load(parsl_config)
 
     filelist = {
         'ZJets': [osp.join(os.getcwd(),'tests/samples/nano_dy.root')],
         'Data' : [osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')]
     }
 
-    do_parsl_job(parsl_config, filelist)
-
-    parsl_config = Config(
-        executors=[
-            HighThroughputExecutor(
-                label="coffea_parsl_default",
-                address=address_by_hostname(),
-                cores_per_worker=max(multiprocessing.cpu_count()//2, 1),
-                max_workers=1,
-                provider=LocalProvider(
-                    channel=LocalChannel(),
-                    init_blocks=1,
-                    max_blocks=1,
-                    nodes_per_block=1
-                ),
-            )
-        ],
-        strategy=None,
-    )
+    do_parsl_job(filelist)
+    do_parsl_job(filelist, compression=1)
 
     filelist = {
         'ZJets': {'treename': 'Events', 'files': [osp.join(os.getcwd(),'tests/samples/nano_dy.root')]},
         'Data' : {'treename': 'Events', 'files': [osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')]}
     }
-        
-    do_parsl_job(parsl_config, filelist)
+
+    do_parsl_job(filelist)
+    do_parsl_job(filelist, flatten=True)
 
 
 def test_parsl_funcs():
@@ -130,7 +98,7 @@ def test_parsl_funcs():
     treename = 'Events'
     chunksize = 20
     ds, tn, test = derive_chunks.func(filename, treename, chunksize, dataset)
-    
+
     assert(dataset == ds)
     assert(treename == tn)
     assert('nano_dy.root' in test[0][0])
@@ -142,9 +110,9 @@ def test_parsl_funcs():
     import pickle as pkl
     import cloudpickle as cpkl
     import lz4.frame as lz4f
-    
+
     procpkl = lz4f.compress(cpkl.dumps(NanoTestProcessor()))
-    
+
     out = coffea_pyapp.func('ZJets', filename, treename, chunksize, 0, procpkl)
 
     hists = pkl.loads(lz4f.decompress(out[0]))
@@ -153,11 +121,12 @@ def test_parsl_funcs():
     assert(out[1] == 10)
     assert(out[2] == 'ZJets')
 
+
 @pytest.mark.skipif(sys.platform.startswith('win'), reason='signals are different on windows')
 def test_timeout():
     from coffea.processor.parsl.timeout import timeout
     import signal
-    
+
     @timeout
     def too_long(timeout=None):
         import time
@@ -199,7 +168,7 @@ def test_parsl_slurm_cfg():
     fname = '/tmp/%s' % x509_proxy
     with open(fname, 'w+'):
         os.utime(fname, None)
-    
+
     from coffea.processor.parsl.slurm_config import slurm_config
 
     test = slurm_config()


### PR DESCRIPTION
Provides a new `dask_executor` suitable for use as an alternative executor in `run_uproot_job`.
For example, the muonspectrum demo notebook can run in a local dask cluster with minimal changes:
```python
from dask.distributed import Client
client = Client()

output = processor.run_uproot_job(fileset,
                                  treename='Events',
                                  processor_instance=FancyDimuonProcessor(),
                                  executor=processor.dask_executor,
                                  executor_args={'client': client, 'flatten': True},
                                  chunksize=100000,
                                 )
```

p.s. can parsl_executor be encapsulated this way?