### PR TITLE
Add normal interval to plotratio

### DIFF
--- a/coffea/hist/plot.py
+++ b/coffea/hist/plot.py
@@ -88,7 +88,7 @@ def normal_interval(pw, tw, pw2, tw2, coverage=_coverage1sd):
 
     prob = 0.5 * (1 - coverage)
     delta = np.zeros_like(sigma)
-    delta[sigma != 0] = -scipy.stats.norm.ppf(prob, scale=sigma[sigma != 0])
+    delta[sigma != 0] = scipy.stats.norm.ppf(prob, scale=sigma[sigma != 0])
 
     lo = eff - np.minimum(eff + delta, np.ones_like(eff))
     hi = np.maximum(eff - delta, np.zeros_like(eff)) - eff

--- a/coffea/hist/plot.py
+++ b/coffea/hist/plot.py
@@ -77,15 +77,16 @@ def clopper_pearson_interval(num, denom, coverage=_coverage1sd):
     interval[1, num == denom] = 1.
     return interval
 
+
 def normal_interval(pw, tw, pw2, tw2, coverage=_coverage1sd):
     # see https://root.cern.ch/doc/master/TEfficiency_8cxx_source.html#l02515
 
-    eff = pw/tw
+    eff = pw / tw
 
-    variance = ( pw2 * (1 - 2*eff) + tw2 * eff**2 ) / (tw**2)
+    variance = (pw2 * (1 - 2 * eff) + tw2 * eff**2) / (tw**2)
     sigma = np.sqrt(variance)
 
-    prob = 0.5*(1-_coverage1sd)
+    prob = 0.5 * (1 - _coverage1sd)
     delta = np.zeros_like(sigma)
     delta[sigma != 0] = -scipy.stats.norm.ppf(prob, scale=sigma[sigma != 0])
 

--- a/coffea/hist/plot.py
+++ b/coffea/hist/plot.py
@@ -86,7 +86,7 @@ def normal_interval(pw, tw, pw2, tw2, coverage=_coverage1sd):
     variance = (pw2 * (1 - 2 * eff) + tw2 * eff**2) / (tw**2)
     sigma = np.sqrt(variance)
 
-    prob = 0.5 * (1 - _coverage1sd)
+    prob = 0.5 * (1 - coverage)
     delta = np.zeros_like(sigma)
     delta[sigma != 0] = -scipy.stats.norm.ppf(prob, scale=sigma[sigma != 0])
 

--- a/tests/test_hist_plot.py
+++ b/tests/test_hist_plot.py
@@ -241,3 +241,47 @@ def test_clopper_pearson_interval():
     threshold = 1e-6
     assert(all((interval[1, :] / ref_hi) - 1 < threshold))
     assert(all((interval[0, :] / ref_lo) - 1 < threshold))
+
+def test_normal_interval():
+    from coffea.hist.plot import normal_interval
+
+    # Reference weighted efficiency and error from ROOTs TEfficiency
+
+    denom = np.array([  89.01457591590004, 2177.066076428943  , 6122.5256890981855 ,
+              0.              ,  100.27757990710668])
+    num = np.array([  75.14287743709515, 2177.066076428943  , 5193.454723043864  ,
+              0.              ,   84.97723540536361])
+    denom_sumw2 = np.array([   94.37919737476827, 10000.              ,  6463.46795877633   ,
+               0.              ,   105.90898005417333])
+    num_sumw2 = np.array([   67.2202147680005 , 10000.              ,  4647.983931785646  ,
+               0.              ,    76.01275761253757])
+    ref_hi = np.array([0.0514643476600107, 0.                , 0.0061403263960343,
+                          np.nan, 0.0480731185500146])
+    ref_lo = np.array([0.0514643476600107, 0.                , 0.0061403263960343,
+                          np.nan, 0.0480731185500146])
+
+    interval = normal_interval(num, denom, num_sumw2, denom_sumw2)
+    threshold = 1e-6
+
+    lo, hi = interval
+
+    assert len(ref_hi) == len(hi)
+    assert len(ref_lo) == len(lo)
+
+    for i in range(len(ref_hi)):
+        if np.isnan(ref_hi[i]):
+            assert np.isnan(ref_hi[i])
+        elif ref_hi[i] == 0.0:
+            assert hi[i] == 0.0
+        else:
+            assert np.abs(hi[i] / ref_hi[i] - 1) < threshold
+
+        if np.isnan(ref_lo[i]):
+            assert np.isnan(ref_lo[i])
+        elif ref_lo[i] == 0.0:
+            assert lo[i] == 0.0
+        else:
+            assert np.abs(lo[i] / ref_lo[i] - 1) < threshold
+
+
+


### PR DESCRIPTION
I was thinking about adding the efficiency error calculation as is implemented in TEfficiency. Before I write comments and/or tests, I wanted to ask/discuss if this makes sense, since there is already the num method.

One thing I noticed with the way the errors are calculated (see https://root.cern.ch/doc/master/TEfficiency_8cxx_source.html#l02515 and below) is that if `num==denom` then the error will be 0. Does that even make sense? Technically, `scipy.stats.norm.ppf` complains if it is called with `sigma = 0`, so I'm masking out zero elements and *manually* set those to zero errors.

Thoughts?