### PR TITLE
Use `tqdm.auto` instead of `autonotebook`

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1,6 +1,6 @@
 import concurrent.futures
 import time
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 import uproot
 from . import ProcessorABC, LazyDataFrame
 from .accumulator import value_accumulator, set_accumulator, dict_accumulator


### PR DESCRIPTION
This should remove the warning introduced in #175