### PR TITLE
Allow specification of axes by positional list or by kwarg sequence

### DIFF
--- a/coffea/hist/hist_tools.py
+++ b/coffea/hist/hist_tools.py
@@ -669,16 +669,16 @@ class Hist(AccumulatorABC):
                              coffea.hist.Bin("y", "y coordinate [m]", 20, -5, 5),
                              )
 
-        or
+        # or
 
         h = coffea.hist.Hist("Observed bird count",
                              axes=(coffea.hist.Cat("species", "Bird species"),
                                    coffea.hist.Bin("x", "x coordinate [m]", 20, -5, 5),
                                    coffea.hist.Bin("y", "y coordinate [m]", 20, -5, 5),
-                                   )
+                                  )
                              )
 
-        or
+        # or
 
         h = coffea.hist.Hist("Observed bird count",
                              axes=[coffea.hist.Cat("species", "Bird species"),

--- a/coffea/hist/hist_tools.py
+++ b/coffea/hist/hist_tools.py
@@ -653,8 +653,10 @@ class Hist(AccumulatorABC):
     ----------
         label : str
             A description of the meaning of the sum of weights
-        ``*axes`` or ``axes``
-            positional list or kwarg of `Cat` or `Bin` objects, denoting the axes of the histogram
+        ``*axes``
+            positional list of `Cat` or `Bin` objects, denoting the axes of the histogram
+        axes : collections.abc.Sequence
+            list of `Cat` or `Bin` objects, denoting the axes of the histogram (overridden by ``*axes``)
         dtype : str
             Underlying numpy dtype to use for storing sum of weights
 
@@ -671,7 +673,7 @@ class Hist(AccumulatorABC):
 
         # or
 
-        h = coffea.hist.Hist("Observed bird count",
+        h = coffea.hist.Hist(label="Observed bird count",
                              axes=(coffea.hist.Cat("species", "Bird species"),
                                    coffea.hist.Bin("x", "x coordinate [m]", 20, -5, 5),
                                    coffea.hist.Bin("y", "y coordinate [m]", 20, -5, 5),
@@ -680,11 +682,11 @@ class Hist(AccumulatorABC):
 
         # or
 
-        h = coffea.hist.Hist("Observed bird count",
-                             axes=[coffea.hist.Cat("species", "Bird species"),
+        h = coffea.hist.Hist(axes=[coffea.hist.Cat("species", "Bird species"),
                                    coffea.hist.Bin("x", "x coordinate [m]", 20, -5, 5),
                                    coffea.hist.Bin("y", "y coordinate [m]", 20, -5, 5),
-                                  ]
+                                  ],
+                             label="Observed bird count",
                              )
 
     which produces:
@@ -704,7 +706,12 @@ class Hist(AccumulatorABC):
         self._dtype = kwargs.pop('dtype', Hist.DEFAULT_DTYPE)  # Much nicer in python3 :(
         self._axes = axes
         if len(axes) == 0 and 'axes' in kwargs:
+            if not isinstance(kwargs['axes'], Sequence):
+                raise TypeError('axes must be a sequence type! (tuple, list, etc.)')
             self._axes = tuple(kwargs['axes'])
+        elif len(axes) != 0 and 'axes' in kwargs:
+            warnings.warn('axes defined by both positional arguments and keyword argument, using positional arguments')
+
         if not all(isinstance(ax, Axis) for ax in self._axes):
             del self._axes
             raise TypeError("All axes must be derived from Axis class")

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -48,6 +48,28 @@ def test_hist():
                           # weight is a reserved keyword
                           hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),
                         )
+    
+    h_mascots_2 = hist.Hist("fermi mascot showdown",
+                          axes=(animal,
+                                vocalization,
+                                height,
+                                # weight is a reserved keyword
+                                hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),)
+                           )
+                           
+    h_mascots_3 = hist.Hist("fermi mascot showdown",
+                         axes=[animal,
+                               vocalization,
+                               height,
+                               # weight is a reserved keyword
+                               hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),]
+                          )
+    assert h_mascots_1._dense_shape == h_mascots_2._dense_shape
+    assert h_mascots_2._dense_shape == h_mascots_3._dense_shape
+    
+    assert h_mascots_1._axes == h_mascots_2._axes
+    assert h_mascots_2._axes == h_mascots_3._axes
+                        
     adult_bison_h = np.random.normal(loc=2.5, scale=0.2, size=40)
     adult_bison_w = np.random.normal(loc=700, scale=100, size=40)
     h_mascots_1.fill(animal="bison", vocalization="huff", height=adult_bison_h, mass=adult_bison_w)

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -57,18 +57,37 @@ def test_hist():
                                 hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),)
                            )
                            
-    h_mascots_3 = hist.Hist("fermi mascot showdown",
+    h_mascots_3 = hist.Hist(
                          axes=[animal,
                                vocalization,
                                height,
                                # weight is a reserved keyword
-                               hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),]
+                               hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),],
+                            label="fermi mascot showdown"
                           )
+                          
+    h_mascots_4 = hist.Hist(
+                            "fermi mascot showdown",
+                            animal,
+                            vocalization,
+                            height,
+                            # weight is a reserved keyword
+                            hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),
+                         axes=[animal,
+                               vocalization,
+                               height,
+                               # weight is a reserved keyword
+                               hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),],
+                         
+                       )
+                          
     assert h_mascots_1._dense_shape == h_mascots_2._dense_shape
     assert h_mascots_2._dense_shape == h_mascots_3._dense_shape
+    assert h_mascots_3._dense_shape == h_mascots_4._dense_shape
     
     assert h_mascots_1._axes == h_mascots_2._axes
     assert h_mascots_2._axes == h_mascots_3._axes
+    assert h_mascots_3._axes == h_mascots_4._axes
                         
     adult_bison_h = np.random.normal(loc=2.5, scale=0.2, size=40)
     adult_bison_w = np.random.normal(loc=700, scale=100, size=40)


### PR DESCRIPTION
This was brought up in discussions with @andrzejnovak / @kratsg / @nsmith- that syntax like:
```
h = coffea.hist.Hist("Observed bird count",
                     axes=(coffea.hist.Cat("species", "Bird species"),
                           coffea.hist.Bin("x", "x coordinate [m]", 20, -5, 5),
                           coffea.hist.Bin("y", "y coordinate [m]", 20, -5, 5),
                           )
                     )
```

is much more clear to new users than the positional list syntax that we've been using so far.

This PR allows both styles of histogram instantiation. 