### PR TITLE
spark.read.parquet expects multiple args, not list

### DIFF
--- a/coffea/processor/spark/detail.py
+++ b/coffea/processor/spark/detail.py
@@ -56,13 +56,9 @@ def _read_df(spark, dataset, files_or_dirs, ana_cols, partitionsize, file_type, 
         flist = files_or_dirs['files']
     if not isinstance(flist, Sequence):
         raise ValueError('spark dataset file list must be a Sequence (like list())')
-    df = None
-    if file_type == 'parquet':
-        df = spark.read.parquet(*flist)
-    else:
-        df = spark.read.format(file_type) \
-                       .option('tree', tname) \
-                       .load(flist)
+    df = spark.read.format(file_type) \
+                   .option('tree', tname) \
+                   .load(flist)
     count = df.count()
 
     df_cols = set(df.columns)

--- a/coffea/processor/spark/detail.py
+++ b/coffea/processor/spark/detail.py
@@ -58,7 +58,7 @@ def _read_df(spark, dataset, files_or_dirs, ana_cols, partitionsize, file_type, 
         raise ValueError('spark dataset file list must be a Sequence (like list())')
     df = None
     if file_type == 'parquet':
-        df = spark.read.parquet(flist)
+        df = spark.read.parquet(*flist)
     else:
         df = spark.read.format(file_type) \
                        .option('tree', tname) \


### PR DESCRIPTION
Since we stopped reading parquet files in our test this interface wasn't checked.
It may be better to just use the `format` interface at the end of the day... I don't think there's any advantage of `spark.read.parquet` over `spark.read.format('parquet')`.

@perilousapricot ?