### PR TITLE
Fix requirements, move mplhep import, improve spark/arrow compat checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 - pip -q install codecov
 - PY_MAJ=`python -c 'import sys; print(sys.version_info[0])'`
 - PY_MIN=`python -c 'import sys; print(sys.version_info[1])'`
-- pip -q install numpy scipy numba tqdm matplotlib pytest pytest-runner flake8 mplhep --upgrade
+- pip -q install numpy packaging scipy numba tqdm matplotlib pytest pytest-runner flake8 mplhep --upgrade
 - pip -q install pandas pyarrow cloudpickle lz4 jinja2 pyspark dask distributed --upgrade
 - if [ $PY_MAJ -eq 3 ]; then pip -q install https://github.com/Parsl/parsl/zipball/master; fi
 - pip -q install ${AWKWARD}

--- a/coffea/hist/plot.py
+++ b/coffea/hist/plot.py
@@ -6,7 +6,6 @@ import copy
 import warnings
 import numbers
 from .hist_tools import SparseAxis, DenseAxis, overflow_behavior, Interval, StringBin
-import mplhep as hep
 
 # Plotting is always terrible
 # Let's try our best to follow matplotlib idioms
@@ -168,6 +167,7 @@ def plot1d(hist, ax=None, clear=True, overlay=None, stack=False, overflow='none'
         ax : matplotlib.axes.Axes
             A matplotlib `Axes <https://matplotlib.org/3.1.1/api/axes_api.html>`_ object
     """
+    import mplhep as hep
     import matplotlib.pyplot as plt
     if ax is None:
         ax = plt.gca()
@@ -323,6 +323,7 @@ def plotratio(num, denom, ax=None, clear=True, overflow='none', error_opts=None,
         ax : matplotlib.axes.Axes
             A matplotlib `Axes <https://matplotlib.org/3.1.1/api/axes_api.html>`_ object
     """
+    import mplhep as hep
     import matplotlib.pyplot as plt
     if ax is None:
         fig, ax = plt.subplots(1, 1)
@@ -429,6 +430,7 @@ def plot2d(hist, xaxis, ax=None, clear=True, xoverflow='none', yoverflow='none',
         ax : matplotlib.axes.Axes
             A matplotlib `Axes <https://matplotlib.org/3.1.1/api/axes_api.html>`_ object
     """
+    import mplhep as hep
     import matplotlib.pyplot as plt
     if ax is None:
         fig, ax = plt.subplots(1, 1)
@@ -534,6 +536,7 @@ def plotgrid(h, figure=None, row=None, col=None, overlay=None, row_overflow='non
         axes : numpy.ndarray
             An array of matplotlib `Axes <https://matplotlib.org/3.1.1/api/axes_api.html>`_ objects
     """
+    import mplhep as hep
     import matplotlib.pyplot as plt
     haxes = set(ax.name for ax in h.axes())
     nrow, ncol = 1, 1

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -682,9 +682,13 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
     from packaging import version
     import pyarrow as pa
     import warnings
+    arrow_env = ('ARROW_PRE_0_15_IPC_FORMAT', '1')
     if (version.parse(pa.__version__) >= version.parse('0.15.0') and
         version.parse(pyspark.__version__) < version.parse('3.0.0')):
-        warnings.warn('If you are using pyarrow >= 0.15.0, make sure to set ARROW_PRE_0_15_IPC_FORMAT=1 in your environment!')
+        import os
+        if (arrow_env[0] not in os.environ or
+            os.environ[arrow_env[0]] != arrow_env[1]):
+            warnings.warn('If you are using pyarrow >= 0.15.0, make sure to set %s=%s in your environment!' % arrow_env)
 
     import pyspark.sql
     from .spark.spark_executor import SparkExecutor

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ INSTALL_REQUIRES = ['awkward>=0.8.4',
                     'six',
                     'cloudpickle',
                     'mplhep>=0.0.16',
+                    'packaging'
                     ]
 EXTRAS_REQUIRE = {}
 if six.PY3:


### PR DESCRIPTION
- add the 'packaging' package to our requirements
- move `import mplhep as hep` into plotting routines otherwise you grab it along with hist.Hist
- Make arrow environment variable checks less noisy