### PR TITLE
Work Queue Executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
       run: |
         coverage run --source=coffea/ setup.py pytest
     - name: Test work_queue
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.6
+      if: matrix.os == 'ubuntu-latest'
       shell: bash -l {0}
       run: |
-        conda create --name coffea-env python=3.6
-        conda activate coffea-env
+        conda create --name coffea-env-${{ matrix.python-version }} python=${{ matrix.python-version }}
+        conda activate coffea-env-${{ matrix.python-version }}
         conda install -c conda-forge ndcctools dill six
         python -m pip install -I .
         cd tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java-version }}
+    - name: Set up Conda (Linux/MacOS)
+      if: matrix.os != 'windows-latest'
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        update-conda: true
+        python-version: ${{ matrix.python-version }}
+        miniconda-version: 'latest'
     - name: Install dependencies (Linux/MacOS)
       if: matrix.os != 'windows-latest'
       run: |
@@ -76,6 +83,16 @@ jobs:
         ARROW_PRE_0_15_IPC_FORMAT: 1
       run: |
         coverage run --source=coffea/ setup.py pytest
+    - name: Test work_queue
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.6
+      shell: bash -l {0}
+      run: |
+        conda create --name coffea-env python=3.6
+        conda activate coffea-env
+        conda install -c conda-forge ndcctools dill six
+        python -m pip install -I .
+        cd tests
+        python wq.py
     - name: Upload codecov
       if: success() && matrix.os == 'ubuntu-latest' && matrix.python-version == 3.6      
       run: |

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -13,6 +13,7 @@ from .executor import (
     futures_executor,
     dask_executor,
     parsl_executor,
+    work_queue_executor,
     run_uproot_job,
     run_parsl_job,
     run_spark_job
@@ -37,6 +38,7 @@ __all__ = [
     'futures_executor',
     'dask_executor',
     'parsl_executor',
+    'work_queue_executor',
     'run_uproot_job',
     'run_parsl_job',
     'run_spark_job',

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -225,7 +225,7 @@ def _coffea_fn_as_file_wrapper(tmpdir):
     The file output is created (or overwritten), with the dilled result of the function call.
     The wrapper created is created/deleted according to the lifetime of the work_queue_executor."""
 
-    name=os.path.join(tmpdir, 'fn_as_file')
+    name = os.path.join(tmpdir, 'fn_as_file')
 
     with open(name, mode='w') as f:
         f.write("""

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -8,8 +8,13 @@ import pickle
 import sys
 import math
 import copy
+import shutil
 import json
 import cloudpickle
+import uproot
+import subprocess
+import re
+import os
 from tqdm.auto import tqdm
 from collections import defaultdict
 from cachetools import LRUCache
@@ -211,6 +216,286 @@ def _futures_handler(futures_set, output, status, unit, desc, add_fn, tailtimeou
         for job in futures_set:
             _cancel(job)
         raise
+
+
+def _coffea_fn_as_file_wrapper(tmpdir):
+    """ Writes a wrapper script to run dilled python functions and arguments.
+    The wrapper takes as arguments the name of three files: function, argument, and output.
+    The files function and argument have the dilled function and argument, respectively.
+    The file output is created (or overwritten), with the dilled result of the function call.
+    The wrapper created is created/deleted according to the lifetime of the work_queue_executor."""
+
+    name=os.path.join(tmpdir, 'fn_as_file')
+
+    with open(name, mode='w') as f:
+        f.write("""
+#!/usr/bin/env python3
+import os
+import sys
+import dill
+import coffea
+
+(fn, arg, out) = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(fn, "rb") as f:
+    exec_function = dill.load(f)
+with open(arg, "rb") as f:
+    exec_item = dill.load(f)
+
+pickle_out = exec_function(exec_item)
+with open(out, "wb") as f:
+    dill.dump(pickle_out, f) """)
+
+    return name
+
+
+def work_queue_executor(items, function, accumulator, **kwargs):
+    """Execute using Work Queue
+
+    Work Queue is a production framework used to build large scale master-
+    worker applications, developed by the Cooperative Computing Laboratory
+    (CCL) at the University of Notre Dame. This executor functions as the
+    master program which submits chunks of data as tasks. A remote worker,
+    which can be run on cluster and cloud systems, will be able to execute
+    the task.
+
+    python_package_run is the necessary wrapper script. This script is
+    installed with work queue. The executor will try to find this wrapper in
+    PATH. Also, The location of this script can be specified with the 'wrapper'
+    argument.
+
+    Currently, this executor only works with Python 3.6 and 3.7 (not 3.8).
+
+    To set up Work Queue, the following procedure can be used:
+
+    $ conda create --name conda-coffea-wq-env python=3.6
+    $ conda activate conda-coffea-wq-env
+    $ pip install six coffea dill
+    $ conda install -y -c conda-forge xrootd
+    $ conda deactivate
+    $ conda activate base
+    $ pip install conda-pack
+    $ python -c 'import conda_pack; conda_pack.pack(name="conda-coffea-wq-env", output="conda-coffea-wq-env.tar.gz")'
+    $ conda activate conda-coffea-wq-env
+    $ ... run coffea + wq code!
+
+    For further information about Work Queue, please visit the documentation
+    at: https://cctools.readthedocs.io/en/latest/work_queue/
+
+    Parameters
+    ----------
+        items : list
+            List of input arguments
+        function : callable
+            A function to be called on each input, which returns an accumulator instance
+        accumulator : AccumulatorABC
+            An accumulator to collect the output of the function
+        status : bool
+            If true (default), enable progress bar
+        unit : str
+            Label of progress bar unit
+        desc : str
+            Label of progress bar description
+        compression : int, optional
+            Compress accumulator outputs in flight with LZ4, at level specified (default 1)
+            Set to ``None`` for no compression.
+        # work queue specific options:
+        environment-file : str
+            Python environment to use. Required.
+        cores : int
+            Number of cores for work queue task. If unset, use a whole worker.
+        memory : int
+            Amount of memory (in MB) for work queue task. If unset, use a whole worker.
+        disk : int
+            Amount of disk space (in MB) for work queue task. If unset, use a whole worker.
+        resources-mode : one of 'fixed', or 'auto'. Default is 'fixed'.
+            'fixed' - allocate cores, memory, and disk specified for each task.
+            'auto'  - use cores, memory, and disk as maximum values to allocate.
+                      Useful when the resources used by a task are not known, as
+                      it lets work queue find an efficient value for maximum
+                      throughput.
+        debug-log : str
+            Filename for debug output
+        stats-log : str
+            Filename for tasks statistics output
+        transactions-log : str
+            Filename for tasks lifetime reports output
+        master-name : str
+            Name to refer to this work queue master.
+            Sets port to 0 (any available port) if port not given.
+        port : int
+            Port number for work queue master program. Defaults to 9123 if
+            master-name not given.
+        wrapper : str
+            Wrapper script to run/open python environment tarball. Defaults to python_package_run found in PATH.
+        print-stdout : bool
+            If true (default), print the standard output of work queue task on completion.
+    """
+    try:
+        import work_queue as wq
+        import tempfile
+        import dill
+        import os
+        from os.path import basename
+    except ImportError as e:
+        print('You must have Work Queue and dill installed to use work_queue_executor!')
+        raise e
+
+    unit = kwargs.pop('unit', 'items')
+    status = kwargs.pop('status', True)
+    desc = kwargs.pop('desc', 'Processing')
+    clevel = kwargs.pop('compression', 1)
+    filepath = kwargs.pop('filepath', '.')
+    output = kwargs.pop('print-stdout', False)
+
+    if clevel is not None:
+        function = _compression_wrapper(clevel, function)
+
+    # work queue specific options:
+    env_file = kwargs.pop('environment-file', None)
+    wrapper = kwargs.pop('wrapper', shutil.which('python_package_run'))
+
+    if not env_file:
+        raise TypeError("environment-file argument missing. It should name a conda environment as a tar file.")
+    elif not os.path.exists(env_file):
+        raise ValueError("environment-file does not name an existing conda environment as a tar file.")
+
+    if not wrapper:
+        raise ValueError("Location of python_package_run could not be determined automatically.\nUse 'wrapper' argument to the work_queue_executor.")
+
+    # fixed, or auto
+    resources_mode = kwargs.pop('resources-mode', 'fixed')
+    cores = kwargs.pop('cores', None)
+    memory = kwargs.pop('memory', None)
+    disk = kwargs.pop('disk', None)
+
+    default_resources = {}
+    if cores:
+        default_resources['cores'] = cores
+    if memory:
+        default_resources['memory'] = memory
+    if disk:
+        default_resources['disk'] = disk
+
+    debug_log = kwargs.pop('debug-log', None)
+    stats_log = kwargs.pop('stats-log', None)
+    trans_log = kwargs.pop('transactions-log', None)
+
+    master_name = kwargs.pop('master-name', None)
+    port = kwargs.pop('port', None)
+    if port is None:
+        if master_name:
+            port = 0
+        else:
+            port = 9123
+
+    with tempfile.TemporaryDirectory(prefix="wq-executor-tmp-", dir=filepath) as tmpdir:
+        # Pickle function
+        with open(os.path.join(tmpdir, 'function.p'), 'wb') as wf:
+            dill.dump(function, wf)
+
+        # Set up Work Queue
+        command_path = _coffea_fn_as_file_wrapper(tmpdir)
+
+        try:
+            q = wq.WorkQueue(port, name=master_name, debug_log=debug_log, stats_log=stats_log, transactions_log=trans_log)
+        except Exception:
+            print('Instantiation of Work Queue failed')
+            sys.exit(1)
+
+        print('Listening for work queue workers on port {}...'.format(q.port))
+
+        q.enable_monitoring()
+        q.specify_category_max_resources('default', default_resources)
+        if resources_mode == 'auto':
+            q.tune('category-steady-n-tasks', 3)
+            q.specify_category_max_resources('default', {})
+            q.specify_category_mode('default', wq.WORK_QUEUE_ALLOCATION_MODE_MAX_THROUGHPUT)
+
+        # Define function input here
+        infile_function = os.path.join(tmpdir, 'function.p')
+
+        # Dictionary to keep track of output file corresponding to task id
+        id_output = {}
+
+        # Iterative Executor Specifications
+        if len(items) == 0:
+            return accumulator
+
+        add_fn = _iadd
+
+        for i, item in tqdm(enumerate(items), disable=not status, unit=unit, total=len(items), desc=desc):
+            with open(os.path.join(tmpdir, 'item_{}.p'.format(i)), 'wb') as wf:
+                dill.dump(item, wf)
+
+            infile_item = os.path.join(tmpdir, 'item_{}.p'.format(i))
+            outfile = os.path.join(tmpdir, 'output_{}.p'.format(i))
+
+            coffea_command = 'python {} {} {} {}'.format(basename(command_path), basename(infile_function), basename(infile_item), basename(outfile))
+            wrapped_command = './{}'.format(basename(wrapper))
+            wrapped_command += ' --environment {}'.format(basename(env_file))
+            wrapped_command += ' --unpack-to "$WORK_QUEUE_SANDBOX"/{}-env {}'.format(env_file, coffea_command)
+
+            t = wq.Task(wrapped_command)
+            t.specify_category('default')
+
+            t.specify_input_file(command_path, cache=True)
+            t.specify_input_file(infile_function, cache=False)
+            t.specify_input_file(infile_item, cache=False)
+
+            # conda environment files
+            t.specify_input_file(env_file, cache=True)
+            t.specify_input_file(wrapper, cache=True)
+
+            if re.search('://', item.filename):
+                # This looks like an URL. Not transfering file.
+                pass
+            else:
+                t.specify_input_file(item.filename, remote_name=item.filename, cache=True)
+
+            t.specify_output_file(outfile, cache=False)
+
+            task_id = q.submit(t)
+            # Add pair to dict
+            id_output['{}'.format(task_id)] = outfile
+
+            print('Submitted task (id #{}): {}'.format(task_id, wrapped_command))
+
+        print('Waiting for tasks to complete...')
+
+        while not q.empty():
+            t = q.wait(5)
+            if t:
+                print('Task (id #{}) complete: {} (return code {})'.format(t.id, t.command, t.return_status))
+
+                if output:
+                    print('Output:\n{}'.format(t.output))
+                    print('allocated cores: {}, memory: {} MB, disk: {} MB'.format(
+                        t.resources_allocated.cores,
+                        t.resources_allocated.memory,
+                        t.resources_allocated.disk))
+                    if t.resources_measured:
+                        print('measured cores: {}, memory: {} MB, disk {} MB, runtime {}'.format(
+                            t.resources_measured.cores,
+                            t.resources_measured.memory,
+                            t.resources_measured.disk,
+                            t.resources_measured.wall_time / 1000000))
+
+                if t.result != 0:
+                    print('Task id #{} failed with code: {}'.format(t.id, t.result))
+                    print('Stopping execution')
+                    break
+
+                # Unpickle output, add to accumulator
+                with open(id_output['{}'.format(t.id)], 'rb') as rf:
+                    unpickle_output = dill.load(rf)
+
+                add_fn(accumulator, unpickle_output)
+
+        if os.path.exists(command_path):
+            os.remove(command_path)
+
+        return accumulator
 
 
 def iterative_executor(items, function, accumulator, **kwargs):

--- a/tests/wq.py
+++ b/tests/wq.py
@@ -1,0 +1,99 @@
+import sys
+import os
+import os.path as osp
+
+
+from coffea import hist, processor
+
+try:
+    import work_queue as wq
+    work_queue_port = 9123
+except ImportError:
+    print("work_queue is not installed. Omiting test.")
+    sys.exit(0)
+
+def template_analysis(environment_file, filelist, executor, flatten, compression):
+    from coffea.processor import run_uproot_job
+    treename = 'Events'
+    from coffea.processor.test_items import NanoTestProcessor
+
+    exe_args = {
+        'flatten': flatten,
+        'compression': compression,
+        'environment-file': environment_file,
+        'resources-mode': 'fixed',
+        'cores': 2,
+        'memory': 500,  # MB
+        'disk': 1000,   # MB
+        'master-name': 'coffea-test',
+        'port': work_queue_port,
+        'print-stdout' : True
+    }
+
+    hists = run_uproot_job(filelist, treename, NanoTestProcessor(), executor, executor_args = exe_args)
+
+    print(hists)
+    assert(hists['cutflow']['ZJets_pt'] == 18)
+    assert(hists['cutflow']['ZJets_mass'] == 6)
+    assert(hists['cutflow']['Data_pt'] == 84)
+    assert(hists['cutflow']['Data_mass'] == 66)
+
+def work_queue_example(environment_file):
+    from coffea.processor import work_queue_executor
+
+    # Work Queue does not allow absolute paths
+    filelist = {
+        'ZJets': ['./samples/nano_dy.root'],
+        'Data': ['./samples/nano_dimuon.root']
+    }
+
+    workers = wq.Factory(batch_type='local', master_host_port='localhost:{}'.format(work_queue_port))
+    workers.max_workers = 1
+    workers.min_workers = 1
+    workers.cores  = 4
+    workers.memory = 1000  # MB
+    workers.disk   = 4000  # MB
+
+    with workers:
+        #template_analysis(environment_file, filelist, work_queue_executor, flatten=False, compression=0)
+        #template_analysis(environment_file, filelist, work_queue_executor, flatten=True, compression=0)
+        #template_analysis(environment_file, filelist, work_queue_executor, flatten=False, compression=2)
+        template_analysis(environment_file, filelist, work_queue_executor, flatten=True, compression=2)
+
+def create_conda_environment(env_file, py_version):
+    """ Generate a conda environment file 'env_file' to send along the tasks. """
+
+    if os.path.exists(env_file):
+        print("conda environment file '{}' already exists. Not generating again.".format(env_file))
+        return
+
+    print("creating conda environment file '{}'...".format(env_file))
+    import subprocess
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode='w') as conda_recipe, tempfile.TemporaryDirectory() as tmp_env:
+        conda_recipe.write("""
+#! /bin/bash
+set -e
+conda create -y --prefix {tmp_env} python={py_version} conda six dill
+source {tmp_env}/bin/activate
+conda install -y -c conda-forge xrootd conda-pack
+pip install ..
+python -c 'import conda_pack; conda_pack.pack(prefix="{tmp_env}", output="{env_file}")'
+""".format(env_file=env_file, tmp_env=tmp_env, py_version=py_version))
+
+        conda_recipe.flush()
+
+        subprocess.check_call(['/bin/bash', conda_recipe.name])
+        print("done creating conda environment '{}'".format(env_file))
+
+
+if __name__ == '__main__':
+    py_version = "{}.{}".format(sys.version_info[0], sys.version_info[1])  # 3.6 or 3.7, or etc.
+
+    environment_file = 'conda-coffea-wq-env-py{}.tar.gz'.format(py_version)
+
+    create_conda_environment(environment_file, py_version)
+
+    work_queue_example(environment_file)
+


### PR DESCRIPTION
This PR adds support for an executor using Work Queue (from the [cctools](https://github.com/cooperative-computing-lab/cctools) package).

Code for the executor (in coffea/processor/executor.py) and a test script (tests/test_work_queue.py) is included in the changes. This setup should be sufficient for use with WQ's command line `work_queue_worker` submission, but HTCondor clusters will require additional environment packaging files to be installed (referenced in line 238 of coffea/processor/executor.py).