### PR TITLE
Enforce more modern dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,13 +56,13 @@ def get_description():
     return description[start:stop].strip()  # before + + after
 
 
-INSTALL_REQUIRES = ['awkward>=0.8.4',
+INSTALL_REQUIRES = ['awkward>=0.12.18',
                     'matplotlib<3' if six.PY2 else 'matplotlib>=3',
                     'numba>=0.43.1',
                     'numpy>=1.16.0',
                     'scipy>=1.1.0',
-                    'uproot-methods>=0.4.3',
-                    'uproot>=3.4.5',
+                    'uproot-methods>=0.7.2',
+                    'uproot>=3.11.0',
                     'futures; python_version == "2.7"',
                     'tqdm>=4.27.0',
                     'lz4',


### PR DESCRIPTION
Since many users only bother with `pip install --upgrade coffea` (if that!) then they don't necessarily receive useful updates to the uproot/uproot-methods/awkward stack.  This updates the stack to the latest and greatest as of now.