### PR TITLE
add ipywidgets as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ INSTALL_REQUIRES = ['awkward>=0.12.18',
                     'six',
                     'cloudpickle',
                     'mplhep>=0.0.16',
-                    'packaging'
+                    'packaging',
+                    'ipywidgets'
                     ]
 EXTRAS_REQUIRE = {}
 if six.PY3:


### PR DESCRIPTION
Fixes #254 

Solve tqdm autonotebook dependency in case of using ipykernel install separately from jupyter.