### PR TITLE
Fix Cornercases: Empty formula and multiple formulas for btag SF

### DIFF
--- a/coffea/lookup_tools/csv_converters.py
+++ b/coffea/lookup_tools/csv_converters.py
@@ -58,11 +58,26 @@ def convert_btag_csv_file(csvFilePath):
         for i, eta_bin in enumerate(etaBins[:-1]):
             for j, pt_bin in enumerate(ptBins[:-1]):
                 for k, discr_bin in enumerate(discrBins[:-1]):
-                    this_bin = np.where((all_names == label) &
-                                        (corrections[columns[4]] == eta_bin) &
-                                        (corrections[columns[6]] == pt_bin) &
-                                        (corrections[columns[8]] == discr_bin))
-                    vals[k, j, i] = corrections[this_bin][columns[10]][0]
+                    this_bin = np.where(
+                        (all_names == label)
+                        & (corrections[columns[4]] == eta_bin)
+                        & (corrections[columns[6]] == pt_bin)
+                        & (corrections[columns[8]] == discr_bin)
+                    )[0]
+                    if len(this_bin) == 1:
+                        vals[k, j, i] = corrections[this_bin][columns[10]][0]
+                    elif len(this_bin) > 1:
+                        raise Exception(
+                            'Multiple formulas for the same bin: label={label} eta_bin={eta_bin} pt_bin={pt_bin} discr_bin={discr_bin}'.format(
+                                label=label,
+                                eta_bin=eta_bin,
+                                pt_bin=pt_bin,
+                                discr_bin=discr_bin,
+                            )
+                        )
+                    else:
+                        warnings.warn('Bin without formula. Setting scale factor to 1', RuntimeWarning)
+                        vals[k, j, i] = '1.'
         label_decode = []
         for i in range(len(label)):
             label_decode.append(label[i])

--- a/coffea/lookup_tools/csv_converters.py
+++ b/coffea/lookup_tools/csv_converters.py
@@ -58,12 +58,10 @@ def convert_btag_csv_file(csvFilePath):
         for i, eta_bin in enumerate(etaBins[:-1]):
             for j, pt_bin in enumerate(ptBins[:-1]):
                 for k, discr_bin in enumerate(discrBins[:-1]):
-                    this_bin = np.where(
-                        (all_names == label)
-                        & (corrections[columns[4]] == eta_bin)
-                        & (corrections[columns[6]] == pt_bin)
-                        & (corrections[columns[8]] == discr_bin)
-                    )[0]
+                    this_bin = np.where((all_names == label) &
+                                        (corrections[columns[4]] == eta_bin) &
+                                        (corrections[columns[6]] == pt_bin) &
+                                        (corrections[columns[8]] == discr_bin))[0]
                     if len(this_bin) == 1:
                         vals[k, j, i] = corrections[this_bin][columns[10]][0]
                     elif len(this_bin) > 1:


### PR DESCRIPTION
Dear coffea developers,

this PR implements fixes for two corner cases:

1. set the default scale factor formula to "1." in case the `this_bin` mask is empty
2. raise an Exception in case multiple formulas are found for the same bin

Thanks a lot in advance for reviewing!

PS:
I stumbled over the first corner case with the current deep flavour btag csv file in CMS (2017), where i just got an index out of bound error, since the `this_bin` mask was an empty array. 