### PR TITLE
fix pre_executor for run_uproot_job

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -727,7 +727,7 @@ def run_uproot_job(fileset,
                 'worker_affinity': False,
             }
             pre_args.update(pre_arg_override)
-            executor(to_get, metadata_fetcher, out, **pre_args)
+            pre_executor(to_get, metadata_fetcher, out, **pre_args)
             while out:
                 item = out.pop()
                 metadata_cache[item] = item.metadata


### PR DESCRIPTION
The `pre_executor` argument was unused in `run_uproot_job`.