### PR TITLE
speed up btag SF initialization

### DIFF
--- a/coffea/btag_tools/btagscalefactor.py
+++ b/coffea/btag_tools/btagscalefactor.py
@@ -210,8 +210,8 @@ class BTagScaleFactor:
             if isinstance(func, float):
                 out[where] = func
             else:
-                tmp = func(var)
-                out[where] = tmp[where]
+                tmp = func(var[where])
+                out[where] = tmp
 
         if jin is not None:
             out = jin.copy(content=out)

--- a/coffea/btag_tools/btagscalefactor.py
+++ b/coffea/btag_tools/btagscalefactor.py
@@ -206,8 +206,7 @@ class BTagScaleFactor:
                 var = numpy.clip(discr, corr[2][0], corr[2][-1])
             else:
                 var = numpy.clip(pt, corr[1][0], corr[1][-1])
-            
-            where=(mapidx == ifunc)
+            where = (mapidx == ifunc)
             if isinstance(func, float):
                 out[where] = func
             else:


### PR DESCRIPTION
Improves the initialization time of BTagScaleFactor for the RESHAPE option (4min -> 8s for one file).

Seems like `numba.vectorize` is rather slow in compilation time and simple `numba.jit` works as well, if we take care of masks, thanks @nsmith- for the tip.