### PR TITLE
btag sf: Allow wp="reshape" as string

### DIFF
--- a/coffea/btag_tools/btagscalefactor.py
+++ b/coffea/btag_tools/btagscalefactor.py
@@ -26,7 +26,7 @@ class BTagScaleFactor:
     _formulaCache = {}
     _btvflavor = numpy.array([0, 1, 2, 3])
     _flavor = numpy.array([0, 4, 5, 6])
-    _wpString = {'loose': LOOSE, 'medium': MEDIUM, 'tight': TIGHT}
+    _wpString = {'loose': LOOSE, 'medium': MEDIUM, 'tight': TIGHT, 'reshape': RESHAPE}
     _expectedColumns = [
         'OperatingPoint', 'measurementType', 'sysType', 'jetFlavor', 'etaMin',
         'etaMax', 'ptMin', 'ptMax', 'discrMin', 'discrMax', 'formula'


### PR DESCRIPTION
Tiny modification to allow

```python
BTagScaleFactor(workingpoint="reshape",...)
```

as equivalent to

```python
BTagScaleFactor(workingpoint=3,...)
```

to be consistent with the convention for other values of `workingpoint`