### PR TITLE
Fix recursion error in LazyDataFrame

### DIFF
--- a/coffea/processor/dataframe.py
+++ b/coffea/processor/dataframe.py
@@ -9,7 +9,9 @@ except ImportError:
 class LazyDataFrame(MutableMapping):
     """Simple delayed uproot reader (a la lazyarrays)
 
-    Keeps track of values accessed, for later parsing.
+    One can access branches either through ``df["bname"]`` or ``df.bname``, although
+    the latter is restricted to branches that do not start with a leading underscore.
+    Keeps track of values accessed, in the `materialized` attribute.
 
     Parameters
     ----------
@@ -52,6 +54,8 @@ class LazyDataFrame(MutableMapping):
             raise KeyError(key)
 
     def __getattr__(self, key):
+        if key.startswith("_"):
+            raise AttributeError(key)
         try:
             return self.__getitem__(key)
         except KeyError:
@@ -129,6 +133,8 @@ class PreloadedDataFrame(MutableMapping):
         return self._dict[key]
 
     def __getattr__(self, key):
+        if key.startswith("_"):
+            raise AttributeError(key)
         try:
             return self.__getitem__(key)
         except KeyError:

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -228,6 +228,12 @@ def test_lazy_dataframe_getattr():
     with pytest.raises(AttributeError):
         x = df.notthere
 
+    import copy
+    df2 = copy.copy(df)
+    pt = df2.Muon_pt
+    with pytest.raises(AttributeError):
+        df2.notthere
+
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason='problems with paths on windows')
 def test_preloaded_dataframe():


### PR DESCRIPTION
Encountered when python attempts dunder methods on a __new__-initialized
instance, e.g. during copy.copy() calls.
Fixes #299