### PR TITLE
Make NanoEvents work with spark executor

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1238,9 +1238,10 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
 
     executor_args.setdefault('config', None)
     executor_args.setdefault('file_type', 'parquet')
-    executor_args.setdefault('laurelin_version', '0.3.0')
+    executor_args.setdefault('laurelin_version', '1.1.1')
     executor_args.setdefault('treeName', 'Events')
     executor_args.setdefault('flatten', False)
+    executor_args.setdefault('nano', False)
     executor_args.setdefault('cache', True)
     executor_args.setdefault('skipbadfiles', False)
     executor_args.setdefault('retries', 0)
@@ -1248,6 +1249,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
     file_type = executor_args['file_type']
     treeName = executor_args['treeName']
     flatten = executor_args['flatten']
+    nano = executor_args['nano']
     use_cache = executor_args['cache']
 
     if executor_args['config'] is None:
@@ -1271,7 +1273,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
                                   thread_workers, file_type, treeName)
 
     output = processor_instance.accumulator.identity()
-    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache, flatten)
+    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache, flatten, nano)
     processor_instance.postprocess(output)
 
     if killSpark:

--- a/coffea/processor/templates/spark.py.tmpl
+++ b/coffea/processor/templates/spark.py.tmpl
@@ -1,5 +1,4 @@
-global coffea_udf
-
+global coffea_udf, coffea_udf_flat, coffea_udf_nano
 
 @fn.pandas_udf(BinaryType(), fn.PandasUDFType.SCALAR)
 def coffea_udf(dataset, {% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
@@ -29,6 +28,64 @@ def coffea_udf(dataset, {% for col in cols %}{{col}}{{ "," if not loop.last }}{%
 
     df = processor.PreloadedDataFrame(size=size, items=items)
     df['dataset'] = dataset[0]
+    
+    vals = processor_instance.process(df)
+    
+    valsblob = lz4f.compress(pkl.dumps(vals), compression_level=lz4_clevel)
+    
+    outs = np.full(shape=(size, ), fill_value=b'', dtype='O')
+    outs[0] = valsblob
+    
+    return pd.Series(outs)
+
+@fn.pandas_udf(BinaryType(), fn.PandasUDFType.SCALAR)
+def coffea_udf_nano(dataset, {% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}):
+    global processor_instance, lz4_clevel
+    
+    columns = [{% for col in cols %}{{col}}{{ "," if not loop.last }}{% endfor %}]
+    names = [{% for col in cols %}{{"'"|safe+col+"'"|safe}}{{ "," if not loop.last }}{% endfor %}]
+
+    size = dataset.size
+    items = {}
+    vitems = {}
+
+    offsets_store = {}
+    cache = {}
+
+    def inarray_func(*args, **kwargs):
+        if kwargs['flatten']:
+            return items[args[0]].flatten()
+        return items[args[0]]
+
+    for i, col in enumerate(columns):
+        # numpy array
+        if columns[i].array[0].base is None:
+            item = columns[i].values
+            items[names[i]] = item
+            virtualtype = awkward.type.ArrayType(item.size, item.dtype)
+        else:
+            prefix = names[i].split('_')[0] # this is specific to nanoaod, sadness            
+            if prefix not in offsets_store.keys():
+                counts = columns[i].str.len().values
+                offsets_store[prefix] = np.zeros(shape=(counts.size + 1, ), dtype=np.int64)
+                offsets_store[prefix][1:] = np.cumsum(counts)
+            offsets = offsets_store[prefix]
+            contents = np.squeeze(columns[i].array[0].base)
+            items[names[i]] = awkward.JaggedArray.fromoffsets(offsets, contents)
+            virtualtype = awkward.type.ArrayType(float('inf'), contents.dtype)
+
+        array = awkward.VirtualArray(
+            partial(inarray_func, names[i]),
+            (),
+            {'flatten': True},
+            type=virtualtype,
+            persistentkey=';'.join(str(x) for x in (names[i], )),
+            cache=cache,
+        )
+        vitems[names[i]] = array
+
+    metadata = {'dataset': dataset[0]}
+    df = NanoEvents.from_arrays(arrays=vitems, metadata=metadata)
     
     vals = processor_instance.process(df)
     

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -48,14 +48,33 @@ def test_spark_executor():
                 'Data'  : {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')], 'treename': 'Events'}
                 }
 
-    from coffea.processor.test_items import NanoTestProcessor
+    from coffea.processor.test_items import NanoTestProcessor, NanoEventsProcessor
     from coffea.processor.spark.spark_executor import spark_executor
 
-    columns = ['nMuon','Muon_pt','Muon_eta','Muon_phi','Muon_mass']
+    columns = ['nMuon','Muon_pt','Muon_eta','Muon_phi','Muon_mass', 'Muon_charge']
     proc = NanoTestProcessor(columns=columns)
 
     hists = run_spark_job(filelist, processor_instance=proc, executor=spark_executor, spark=spark, thread_workers=1,
                           executor_args={'file_type': 'root'})
+
+    assert( sum(spark_executor.counts.values()) == 80 )
+    assert( hists['cutflow']['ZJets_pt'] == 18 )
+    assert( hists['cutflow']['ZJets_mass'] == 6 )
+    assert( hists['cutflow']['Data_pt'] == 84 )
+    assert( hists['cutflow']['Data_mass'] == 66 )
+
+    hists = run_spark_job(filelist, processor_instance=proc, executor=spark_executor, spark=spark, thread_workers=1,
+                          executor_args={'file_type': 'root', 'flatten': True})
+    
+    assert( sum(spark_executor.counts.values()) == 80 )
+    assert( hists['cutflow']['ZJets_pt'] == 18 )
+    assert( hists['cutflow']['ZJets_mass'] == 6 )
+    assert( hists['cutflow']['Data_pt'] == 84 )
+    assert( hists['cutflow']['Data_mass'] == 66 )
+    
+    proc = NanoEventsProcessor(columns=columns)
+    hists = run_spark_job(filelist, processor_instance=proc, executor=spark_executor, spark=spark, thread_workers=1,
+                          executor_args={'file_type': 'root', 'nano': True})
 
     _spark_stop(spark)
 


### PR DESCRIPTION
- adds a `nano` option to the spark executor, much like the other ones.

Seems a bit wasteful to me, but it works.

@nsmith- Do you see a better way to implement this?