### PR TITLE
hist.Hist.fill method performance boost

### DIFF
--- a/coffea/hist/hist_tools.py
+++ b/coffea/hist/hist_tools.py
@@ -963,13 +963,8 @@ class Hist(AccumulatorABC):
                 self._sumw2[sparse_key] = np.zeros(shape=self._dense_shape, dtype=self._dtype)
 
         if self.dense_dim() > 0:
-            dense_indices = ()
-            for d in self._axes:
-                if isinstance(d, DenseAxis):
-                    if not isinstance(values[d.name], np.ndarray):
-                        raise Exception("Values in DenseAxes need to be numpy arrays. Got '{}' (type: {})".format(values[d.name], type(values[d.name])))
-                    dense_indices += (d.index(values[d.name]),)
-            xy = np.ravel_multi_index(dense_indices, self._dense_shape)
+            dense_indices = tuple(d.index(values[d.name]) for d in self._axes if isinstance(d, DenseAxis))
+            xy = np.atleast_1d(np.ravel_multi_index(dense_indices, self._dense_shape))
             if "weight" in values:
                 self._sumw[sparse_key][:] += np.bincount(
                     xy, weights=values["weight"], minlength=np.array(self._dense_shape).prod()

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -27,7 +27,7 @@ def test_hist():
     # bin x=1, y=2
     assert h_reduced.integrate("x", slice(20, 30)).values()[()][2] == count_some_bin
     assert h_reduced.integrate("y", slice(0, 0.3)).values()[()][1] == count_some_bin
-    h_reduced.fill(x=23, y=0.1)
+    h_reduced.fill(x=np.array([23]), y=np.array([0.1]))
     assert h_reduced.integrate("x", slice(20, 30)).values()[()][2] == count_some_bin + 1
     assert h_reduced.integrate("y", slice(0, 0.3)).values()[()][1] == count_some_bin + 1
 
@@ -50,7 +50,7 @@ def test_hist():
                           # weight is a reserved keyword
                           hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),
                         )
-    
+
     h_mascots_2 = hist.Hist("fermi mascot showdown",
                           axes=(animal,
                                 vocalization,
@@ -58,7 +58,7 @@ def test_hist():
                                 # weight is a reserved keyword
                                 hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),)
                            )
-                           
+
     h_mascots_3 = hist.Hist(
                          axes=[animal,
                                vocalization,
@@ -67,7 +67,7 @@ def test_hist():
                                hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),],
                             label="fermi mascot showdown"
                           )
-                          
+
     h_mascots_4 = hist.Hist(
                             "fermi mascot showdown",
                             animal,
@@ -80,17 +80,17 @@ def test_hist():
                                height,
                                # weight is a reserved keyword
                                hist.Bin("mass", "weight (g=9.81m/s**2) [kg]", np.power(10., np.arange(5)-1)),],
-                         
+
                        )
-                          
+
     assert h_mascots_1._dense_shape == h_mascots_2._dense_shape
     assert h_mascots_2._dense_shape == h_mascots_3._dense_shape
     assert h_mascots_3._dense_shape == h_mascots_4._dense_shape
-    
+
     assert h_mascots_1._axes == h_mascots_2._axes
     assert h_mascots_2._axes == h_mascots_3._axes
     assert h_mascots_3._axes == h_mascots_4._axes
-                        
+
     adult_bison_h = np.random.normal(loc=2.5, scale=0.2, size=40)
     adult_bison_w = np.random.normal(loc=700, scale=100, size=40)
     h_mascots_1.fill(animal="bison", vocalization="huff", height=adult_bison_h, mass=adult_bison_w)
@@ -103,15 +103,15 @@ def test_hist():
 
     with pytest.raises(ValueError):
         h_mascots_1.fill(beast="crane", yelling="none", tallness=crane_h, heavitivity=crane_w)
-    
-    
+
+
     h_mascots_2 = h_mascots_1.copy()
     h_mascots_2.clear()
     baby_bison_h = np.random.normal(loc=.5, scale=0.1, size=20)
     baby_bison_w = np.random.normal(loc=200, scale=10, size=20)
     baby_bison_cutefactor = 2.5*np.ones_like(baby_bison_w)
     h_mascots_2.fill(animal="bison", vocalization="baa", height=baby_bison_h, mass=baby_bison_w, weight=baby_bison_cutefactor)
-    h_mascots_2.fill(animal="fox", vocalization="none", height=1., mass=30.)
+    h_mascots_2.fill(animal="fox", vocalization="none", height=np.array([1.]), mass=np.array([30.]))
 
     h_mascots = h_mascots_1 + h_mascots_2
     assert h_mascots.integrate("vocalization", "h*").sum("height", "mass", "animal").values()[()] == 1040.
@@ -159,7 +159,7 @@ def test_export1d():
     import uproot
     import os
     from coffea.hist import export1d
-    
+
 
     counts, test_eta, test_pt = dummy_jagged_eta_pt()
     h_regular_bins = hist.Hist("regular_joe", hist.Bin("x", "x", 20, 0, 200))
@@ -168,7 +168,7 @@ def test_export1d():
     hout = export1d(h_regular_bins)
 
     filename = 'test_export1d.root'
-    
+
     with uproot.create(filename) as fout:
         fout['regular_joe'] = hout
         fout.close()
@@ -197,11 +197,11 @@ def test_hist_serdes():
     h_regular_bins.sum('x').identifiers('y')
 
     spkl = pickle.dumps(h_regular_bins)
-    
+
     hnew = pickle.loads(spkl)
-    
+
     hnew.sum('x').identifiers('y')
-    
+
     assert(h_regular_bins._dense_shape == hnew._dense_shape)
     assert(h_regular_bins._axes == hnew._axes)
 
@@ -213,9 +213,9 @@ def test_hist_serdes_labels():
     h.identifiers('asdf')
 
     spkl = pickle.dumps(h)
-    
+
     hnew = pickle.loads(spkl)
-    
+
     for old, new in zip(h.identifiers('asdf'), hnew.identifiers('asdf')):
         assert(old.label == new.label)
 
@@ -225,9 +225,9 @@ def test_hist_serdes_labels():
 @pytest.mark.skipif(sys.version_info < (3, 4), reason="requires python3.4 or higher, test file is pickle proto 4")
 def test_hist_compat():
     from coffea.util import load
-    
+
     test = load('tests/samples/old_hist_format.coffea')
-    
+
     expected_bins = np.array([ -np.inf, 0.,   20.,   40.,   60.,   80.,  100.,  120.,  140.,
                                160.,  180.,  200.,  220.,  240.,  260.,  280.,  300.,  320.,
                                340.,  360.,  380.,  400.,  420.,  440.,  460.,  480.,  500.,

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -27,7 +27,7 @@ def test_hist():
     # bin x=1, y=2
     assert h_reduced.integrate("x", slice(20, 30)).values()[()][2] == count_some_bin
     assert h_reduced.integrate("y", slice(0, 0.3)).values()[()][1] == count_some_bin
-    h_reduced.fill(x=np.array([23]), y=np.array([0.1]))
+    h_reduced.fill(x=23, y=0.1)
     assert h_reduced.integrate("x", slice(20, 30)).values()[()][2] == count_some_bin + 1
     assert h_reduced.integrate("y", slice(0, 0.3)).values()[()][1] == count_some_bin + 1
 
@@ -111,7 +111,7 @@ def test_hist():
     baby_bison_w = np.random.normal(loc=200, scale=10, size=20)
     baby_bison_cutefactor = 2.5*np.ones_like(baby_bison_w)
     h_mascots_2.fill(animal="bison", vocalization="baa", height=baby_bison_h, mass=baby_bison_w, weight=baby_bison_cutefactor)
-    h_mascots_2.fill(animal="fox", vocalization="none", height=np.array([1.]), mass=np.array([30.]))
+    h_mascots_2.fill(animal="fox", vocalization="none", height=1., mass=30.)
 
     h_mascots = h_mascots_1 + h_mascots_2
     assert h_mascots.integrate("vocalization", "h*").sum("height", "mass", "animal").values()[()] == 1040.


### PR DESCRIPTION
Dear coffea developers,

this PR basically substitutes the `np.add.at` DenseAxis filling with `np.bincount`. This results in a significant performance boost:
![image (1)](https://user-images.githubusercontent.com/18463582/87653953-90e0fc00-c756-11ea-809f-a35ea75e4e2c.png)
Here the `fill` method is the current version, while the `fast_fill` method is the `np.bincount` implementation (this method naming is just for the performance showcase).

Real world performance gain:
In our full analysis setup we are processing chunks of 100k events and fill O(100k) 1D-histograms per chunk. With the new `fill` (with `np.bincount`) we were able to speed up the filling of those histograms from ~80seconds to ~5seconds (while selection, reconstruction, etc. is just about ~10 seconds) per chunk. This significantly improves the runtime for a analysis at scale!
Have a look at our performance measures in our analysis case ("Histogramming").
with  `np.add.at`:
![image (2)](https://user-images.githubusercontent.com/18463582/87654673-8ffc9a00-c757-11ea-8bad-96e65a67a37a.png)
with `np.bincount`:
![image (3)](https://user-images.githubusercontent.com/18463582/87654709-9ab72f00-c757-11ea-9cc3-0c78e8d4d213.png)

This implementation is also very close to the `np.histogramdd` implementation: https://github.com/numpy/numpy/blob/v1.19.0/numpy/lib/histograms.py#L942-L1128

I know this PR affects a very central method, which under no circumstances should break. I've made plenty of local tests successfully, also the unittests were successful. Therefore I'd like to request a careful review, especially regarding corner cases, which I might not have catched/tested.

One downside: The values, which are filled into the DenseAxes have to be of type `np.ndarray`! I've put an Exception to catch this in the code.

Thank you very much for reviewing!
Best, Peter