### PR TITLE
Add FsrPhoton support to NanoEvent

### DIFF
--- a/coffea/nanoaod/methods/__init__.py
+++ b/coffea/nanoaod/methods/__init__.py
@@ -5,7 +5,7 @@ types of NanoAOD collections, as well as a default mapping for collection
 names to methods.
 """
 from .common import METVector, LorentzVector, Candidate
-from .leptons import Electron, Muon, Photon, Tau
+from .leptons import Electron, Muon, Photon, FsrPhoton, Tau
 from .jets import Jet, FatJet
 from .generator import GenParticle, GenVisTau
 
@@ -40,6 +40,7 @@ collection_methods = {
     'Photon': Photon,
     'Tau': Tau,
     'GenVisTau': GenVisTau,
+    'FsrPhoton': FsrPhoton,
     # special
     'GenPart': GenParticle,
 }
@@ -51,6 +52,7 @@ __all__ = [
     'Electron',
     'Muon',
     'Photon',
+    'FsrPhoton',
     'Tau',
     'Jet',
     'FatJet',

--- a/coffea/nanoaod/methods/leptons.py
+++ b/coffea/nanoaod/methods/leptons.py
@@ -88,6 +88,19 @@ class Muon(LeptonCommon):
     '''NanoAOD muon object'''
     def _finalize(self, name, events):
         super(Muon, self)._finalize(name, events)
+        if 'FsrPhoton' in events.columns:
+            photons = events['FsrPhoton']
+            reftype = awkward.type.ArrayType(float('inf'), awkward.type.OptionType(photons.type.to.to))
+            reftype.check = False
+            embedded_photon = type(photons)(
+                self._lazy_crossref,
+                args=(self._getcolumn('fsrPhotonIdx'), photons),
+                type=reftype,
+            )
+            embedded_photon.__doc__ = photons.__doc__
+            self['matched_fsrPhoton'] = embedded_photon
+            del self['fsrPhotonIdx']
+
 
 
 class Photon(LeptonCommon):

--- a/coffea/nanoaod/methods/leptons.py
+++ b/coffea/nanoaod/methods/leptons.py
@@ -131,6 +131,28 @@ class Photon(LeptonCommon):
             del self['electronIdx']
 
 
+class FsrPhoton(Candidate):
+    '''NanoAOD fsr photon object'''
+
+    def _finalize(self, name, events):
+        del self['mass']
+        if 'Muon' in events.columns:
+            muons = events['Muon']
+            reftype = awkward.type.ArrayType(float('inf'), awkward.type.OptionType(muons.type.to.to))
+            reftype.check = False
+            embedded_muon = type(muons)(
+                self._lazy_crossref,
+                args=(self._getcolumn('muonIdx'), muons),
+                type=reftype,
+            )
+            embedded_muon.__doc__ = muons.__doc__
+            self['matched_muon'] = embedded_muon
+            del self['muonIdx']
+
+        # disable this type check due to cyclic reference through jets
+        self.type.check = False
+
+
 class Tau(LeptonCommon):
     '''NanoAOD tau object'''
     def _finalize(self, name, events):

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -68,6 +68,7 @@ class NanoEventsFactory:
         "Electron": "Electron",
         "Muon": "Muon",
         "Photon": "Photon",
+        "FsrPhoton": "FsrPhoton",
         "Tau": "Tau",
         "GenVisTau": "GenVisTau",
         # special

--- a/coffea/nanoevents/methods/__init__.py
+++ b/coffea/nanoevents/methods/__init__.py
@@ -18,6 +18,7 @@ from coffea.nanoevents.methods.lepton import (
     Muon,
     Tau,
     Photon,
+    FsrPhoton,
 )
 from coffea.nanoevents.methods.jetmet import Jet, FatJet, MissingET
 from coffea.nanoevents.methods.generic import PtEtaPhiMCollection

--- a/coffea/nanoevents/methods/lepton.py
+++ b/coffea/nanoevents/methods/lepton.py
@@ -99,3 +99,12 @@ class Photon(PtEtaPhiMCandidate, NanoCollection, CommonMatched):
     @property
     def matched_electron(self):
         return apply_global_index(self.electronIdxG, self._events().Electron)
+
+
+@mixin_class
+class FsrPhoton(PtEtaPhiMCandidate, NanoCollection):
+    """NanoAOD fsr photon object"""
+
+    @property
+    def matched_muon(self):
+        return apply_global_index(self.muonIdxG, self._events().Muon)

--- a/coffea/nanoevents/methods/lepton.py
+++ b/coffea/nanoevents/methods/lepton.py
@@ -60,6 +60,10 @@ class Electron(PtEtaPhiMCandidate, NanoCollection, CommonMatched):
 class Muon(PtEtaPhiMCandidate, NanoCollection, CommonMatched):
     """NanoAOD muon object"""
 
+    @property
+    def matched_fsrPhoton(self):
+        return apply_global_index(self.fsrPhotonIdxG, self._events().FsrPhoton)
+
 
 @mixin_class
 class Tau(PtEtaPhiMCandidate, NanoCollection, CommonMatched):


### PR DESCRIPTION
This PR adds FsrPhoton handling to NanoEvent v0 and v1.

The FsrPhoton collection has existed since NanoAODv6 (I think).
It has match to muons (only, so far) that is also added (and no match to jet/gen, hence the removal of the Common lepton mixin).