### PR TITLE
work_queue_executor: fixed issue with absolute path names for the environment file argument

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -417,7 +417,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             coffea_command = 'python {} {} {} {}'.format(basename(command_path), basename(infile_function), basename(infile_item), basename(outfile))
             wrapped_command = './{}'.format(basename(wrapper))
             wrapped_command += ' --environment {}'.format(basename(env_file))
-            wrapped_command += ' --unpack-to "$WORK_QUEUE_SANDBOX"/{}-env {}'.format(env_file, coffea_command)
+            wrapped_command += ' --unpack-to "$WORK_QUEUE_SANDBOX"/{}-env {}'.format(basename(env_file), coffea_command)
 
             t = wq.Task(wrapped_command)
             t.specify_category('default')


### PR DESCRIPTION
The work_queue_executor contained a bug in which it would not allow an absolute pathname to be specified for the environment file argument to the executor. 

Fixed with a simple call to basename().