### PR TITLE
Update executor to uproot4 and switch to using NanoEventsFactory

### DIFF
--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -78,9 +78,9 @@ class NanoEventsFactory:
         elif isinstance(file, uproot.reading.ReadOnlyDirectory):
             tree = file[treepath]
         elif "<class 'uproot.rootio.ROOTDirectory'>" == str(type(file)):
-            raise RuntimeError("The file intance (%s) is an uproot3 type, but this module is only compatible with uproot4 or higher" % (str(type(file))))
+            raise RuntimeError("The file instance (%r) is an uproot3 type, but this module is only compatible with uproot4 or higher" % file)
         else:
-            raise RuntimeError("Invalid file instance (%s)" % (str(type(file))))
+            raise TypeError("Invalid file type (%s)" % (str(type(file))))
         if entry_start is None or entry_start < 0:
             entry_start = 0
         if entry_stop is None or entry_stop > tree.num_entries:

--- a/coffea/nanoevents/schemas.py
+++ b/coffea/nanoevents/schemas.py
@@ -295,6 +295,17 @@ class NanoAODSchema(BaseSchema):
 
 
 class TreeMakerSchema(BaseSchema):
+    """TreeMaker schema builder
+
+    The TreeMaker schema is built from all branches found in the supplied file, based on
+    the naming pattern of the branches. From those arrays, TreeMaker collections are formed
+    as collections of branches grouped by name, where:
+
+    FIX ME
+
+    All collections are then zipped into one `base.NanoEvents` record and returned.
+    """
+
     def __init__(self, base_form):
         super().__init__(base_form)
         self._form["contents"] = self._build_collections(self._form["contents"])
@@ -362,6 +373,7 @@ class TreeMakerSchema(BaseSchema):
             "GenMuons",
             "GenParticles",
             "GenTaus",
+            "GenVertices",
             "Jets",
             "JetsAK8",
             "JetsAK8_subjets",
@@ -379,9 +391,9 @@ class TreeMakerSchema(BaseSchema):
                 continue
             if cname == "JetsAK8":
                 items = [k for k in items if not k.startswith("JetsAK8_subjets")]
-                items.append("JetsAK8_subjetsOffsets")  # FIXME: actually counts
+                items.append("JetsAK8_subjetsCounts")
             if cname == "JetsAK8_subjets":
-                items = [k for k in items if not k.endswith("Offsets")]
+                items = [k for k in items if not k.endswith("Counts")]
             if cname not in branch_forms:
                 collection = zip_forms(
                     {k[len(cname) + 1]: branch_forms.pop(k) for k in items}, cname
@@ -402,9 +414,10 @@ class TreeMakerSchema(BaseSchema):
         nest_jagged_forms(
             branch_forms["JetsAK8"],
             branch_forms.pop("JetsAK8_subjets"),
-            "subjetsOffsets",
+            "subjetsCounts",
             "subjets",
         )
+
         return branch_forms
 
     @property

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -27,6 +27,13 @@ from .accumulator import (
     defaultdict_accumulator,
     column_accumulator,
 )
+from ..nanoevents.schemas import (
+    NanoAODSchema,
+    TreeMakerSchema,
+)
+from ..nanoaod.nanoevents import (
+    NanoEvents,
+)
 
 __all__ = [
     'ProcessorABC',
@@ -49,4 +56,7 @@ __all__ = [
     'dict_accumulator',
     'defaultdict_accumulator',
     'column_accumulator',
+    'NanoAODSchema',
+    'TreeMakerSchema',
+    'NanoEvents',
 ]

--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -27,11 +27,11 @@ from .accumulator import (
     defaultdict_accumulator,
     column_accumulator,
 )
-from ..nanoevents.schemas import (
+from coffea.nanoevents.schemas import (
     NanoAODSchema,
     TreeMakerSchema,
 )
-from ..nanoaod.nanoevents import (
+from coffea.nanoaod.nanoevents import (
     NanoEvents,
 )
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -3,7 +3,6 @@ import concurrent.futures
 from functools import partial
 from itertools import repeat
 import time
-import uproot
 import pickle
 import sys
 import math
@@ -30,6 +29,7 @@ from .dataframe import (
     LazyDataFrame,
 )
 from ..nanoaod import NanoEvents
+from ..nanoevents import NanoEventsFactory, schemas
 from ..util import _hash
 
 try:
@@ -739,7 +739,7 @@ def parsl_executor(items, function, accumulator, **kwargs):
 
 
 def _work_function(item, processor_instance, flatten=False, savemetrics=False,
-                   mmap=False, nano=False, cachestrategy=None, skipbadfiles=False,
+                   mmap=False, schema=None, cachestrategy=None, skipbadfiles=False,
                    retries=0, xrootdtimeout=None):
     if processor_instance == 'heavy':
         item, processor_instance = item
@@ -762,8 +762,7 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
             from uproot.source.xrootd import XRootDSource
             xrootdsource = XRootDSource.defaults
             xrootdsource['timeout'] = xrootdtimeout
-            file = uproot.open(item.filename, localsource=localsource, xrootdsource=xrootdsource)
-            if nano:
+            if schema is not None:
                 cache = None
                 if cachestrategy == 'dask-worker':
                     from distributed import get_worker
@@ -774,18 +773,38 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                     except KeyError:
                         # emit warning if not found?
                         pass
-                df = NanoEvents.from_file(
-                    file=file,
-                    treename=item.treename,
-                    entrystart=item.entrystart,
-                    entrystop=item.entrystop,
-                    metadata={
-                        'dataset': item.dataset,
-                        'filename': item.filename
-                    },
-                    cache=cache,
-                )
+                if issubclass(schema, schemas.BaseSchema):
+                    file = uproot.open(item.filename)
+                    factory = NanoEventsFactory.from_file(
+                        file=file,
+                        treepath=item.treename,
+                        entry_start=item.entrystart,
+                        entry_stop=item.entrystop,
+                        runtime_cache=cache,
+                        schemaclass=schema,
+                        metadata={
+                            'dataset': item.dataset,
+                            'filename': item.filename,
+                        },
+                    )
+                    df = factory.events()
+                elif issubclass(schema, NanoEvents):
+                    file = uproot.open(item.filename, localsource=localsource, xrootdsource=xrootdsource)
+                    df = NanoEvents.from_file(
+                        file=file,
+                        treename=item.treename,
+                        entrystart=item.entrystart,
+                        entrystop=item.entrystop,
+                        metadata={
+                            'dataset': item.dataset,
+                            'filename': item.filename,
+                        },
+                        cache=cache,
+                    )
+                else:
+                    raise ValueError("Expected schema to derive from BaseSchema or be an instance of NanoEvents (%s)" % (str(schema.__name__)))
             else:
+                file = uproot.open(item.filename, localsource=localsource, xrootdsource=xrootdsource)
                 tree = file[item.treename]
                 df = LazyDataFrame(tree, item.entrystart, item.entrystop, flatten=flatten)
                 df['dataset'] = item.dataset
@@ -802,7 +821,12 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                 metrics['entries'] = value_accumulator(int, df.size)
                 metrics['processtime'] = value_accumulator(float, toc - tic)
             wrapped_out = dict_accumulator({'out': out, 'metrics': metrics})
-            file.source.close()
+            if hasattr(uproot, 'reading') and isinstance(file, uproot.reading.ReadOnlyDirectory):
+                file.close()
+            elif hasattr(uproot, 'rootio') and isinstance(file, uproot.rootio.ROOTDirectory):
+                file.source.close()
+            else:
+                raise ValueError("Expected either a ROOTDirectory (uproot3) or ReadOnlyDirectory (uproot4)")
             break
         # catch xrootd errors and optionally skip
         # or retry to read the file
@@ -866,7 +890,10 @@ def _get_metadata(item, skipbadfiles=False, retries=0, xrootdtimeout=None, align
             xrootdsource = {"timeout": xrootdtimeout, "chunkbytes": 32 * 1024, "limitbytes": 1024**2, "parallel": False}
             file = uproot.open(item.filename, xrootdsource=xrootdsource)
             tree = file[item.treename]
-            metadata = {'numentries': tree.numentries, 'uuid': file._context.uuid}
+            if isinstance(file, uproot.rootio.ROOTDirectory):
+                metadata = {'numentries': tree.numentries, 'uuid': file._context.uuid}
+            else:
+                metadata = {'numentries': tree.num_entries, 'uuid': file.file.fUUID}
             if align_clusters:
                 metadata['clusters'] = [0] + list(c[1] for c in tree.clusters())
             out = set_accumulator([FileMeta(item.dataset, item.filename, item.treename, metadata)])
@@ -934,7 +961,8 @@ def run_uproot_job(fileset,
             Some options that affect the behavior of this function:
             'savemetrics' saves some detailed metrics for xrootd processing (default False);
             'flatten' removes any jagged structure from the input files (default False);
-            'nano' builds the dataframe as a `NanoEvents` object rather than `LazyDataFrame` (default False);
+            'schema' builds the dataframe as a `NanoEvents` object rather than `LazyDataFrame` (default ``None``);
+                schema options include `NanoEvents`, `NanoAODSchema` and `TreeMakerSchema`
             'processor_compression' sets the compression level used to send processor instance to workers (default 1).
             'skipbadfiles' instead of failing on a bad file, skip it (default False)
             'retries' optionally retry n times (default 0)
@@ -1042,7 +1070,7 @@ def run_uproot_job(fileset,
     savemetrics = executor_args.pop('savemetrics', False)
     flatten = executor_args.pop('flatten', False)
     mmap = executor_args.pop('mmap', False)
-    nano = executor_args.pop('nano', False)
+    schema = executor_args.pop('schema', None)
     cachestrategy = executor_args.pop('cachestrategy', None)
     pi_compression = executor_args.pop('processor_compression', 1)
     if pi_compression is None:
@@ -1054,7 +1082,7 @@ def run_uproot_job(fileset,
         flatten=flatten,
         savemetrics=savemetrics,
         mmap=mmap,
-        nano=nano,
+        schema=schema,
         cachestrategy=cachestrategy,
         skipbadfiles=skipbadfiles,
         retries=retries,
@@ -1234,7 +1262,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
     executor_args.setdefault('laurelin_version', '1.1.1')
     executor_args.setdefault('treeName', 'Events')
     executor_args.setdefault('flatten', False)
-    executor_args.setdefault('nano', False)
+    executor_args.setdefault('schema', None)
     executor_args.setdefault('cache', True)
     executor_args.setdefault('skipbadfiles', False)
     executor_args.setdefault('retries', 0)
@@ -1242,7 +1270,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
     file_type = executor_args['file_type']
     treeName = executor_args['treeName']
     flatten = executor_args['flatten']
-    nano = executor_args['nano']
+    schema = executor_args['schema']
     use_cache = executor_args['cache']
 
     if executor_args['config'] is None:
@@ -1266,7 +1294,7 @@ def run_spark_job(fileset, processor_instance, executor, executor_args={},
                                   thread_workers, file_type, treeName)
 
     output = processor_instance.accumulator.identity()
-    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache, flatten, nano)
+    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache, flatten, schema)
     processor_instance.postprocess(output)
 
     if killSpark:

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -985,6 +985,9 @@ def run_uproot_job(fileset,
             (about 1MB depending on the length of filenames, etc.)  If you edit an input file
             (please don't) during a session, the session can be restarted to clear the cache.
     '''
+
+    import warnings
+
     if not isinstance(fileset, (Mapping, str)):
         raise ValueError("Expected fileset to be a mapping dataset: list(files) or filename")
     if not isinstance(processor_instance, ProcessorABC):
@@ -1071,6 +1074,10 @@ def run_uproot_job(fileset,
     flatten = executor_args.pop('flatten', False)
     mmap = executor_args.pop('mmap', False)
     schema = executor_args.pop('schema', None)
+    nano = executor_args.pop('nano', False)
+    if nano:
+        warnings.warn("Please use 'schema': processor.NanoEvents rather than 'nano': True to enable awkward0 NanoEvents processing", DeprecationWarning)
+        schema = NanoEvents
     cachestrategy = executor_args.pop('cachestrategy', None)
     pi_compression = executor_args.pop('processor_compression', 1)
     if pi_compression is None:

--- a/coffea/processor/spark/spark_executor.py
+++ b/coffea/processor/spark/spark_executor.py
@@ -115,7 +115,7 @@ class SparkExecutor(object):
                     if issubclass(schema, NanoEvents):
                         co_udf = coffea_udf_nano
                     elif issubclass(schema, schemas.BaseSchema):
-                        raise ValueError("The uproot4 version of NanoEvents (%s) has not been implemented yet" % (str(schema.__name__)))
+                        raise NotImplementedError("The uproot4 version of NanoEvents (%s) has not been implemented yet" % (str(schema.__name__)))
                     else:
                         raise ValueError("Expected schema to derive from BaseSchema or be an instance of NanoEvents (%s)" % (str(schema.__name__)))
                 futures.add(executor.submit(self._launch_analysis, ds, df, co_udf, cols_w_ds))

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -1,4 +1,5 @@
 from coffea import (hist,processor)
+from coffea.processor.executor import uproot
 
 import warnings
 
@@ -48,7 +49,7 @@ def test_spark_executor():
                 'Data'  : {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')], 'treename': 'Events'}
                 }
 
-    from coffea.processor.test_items import NanoTestProcessor, NanoEventsProcessor
+    from coffea.processor.test_items import NanoTestProcessor
     from coffea.processor.spark.spark_executor import spark_executor
 
     columns = ['nMuon','Muon_pt','Muon_eta','Muon_phi','Muon_mass', 'Muon_charge']
@@ -71,10 +72,44 @@ def test_spark_executor():
     assert( hists['cutflow']['ZJets_mass'] == 6 )
     assert( hists['cutflow']['Data_pt'] == 84 )
     assert( hists['cutflow']['Data_mass'] == 66 )
+
+    _spark_stop(spark)
+
+
+@pytest.mark.skipif(int(uproot.version.version_info[0])<=3, reason="NanoEventsProcessor requires uproot4 or higher")
+def test_spark_executor_NanoEvents():
+    pyspark = pytest.importorskip("pyspark", minversion="2.4.1")
+    from pyarrow.compat import guid
     
+    from coffea.processor.spark.detail import (_spark_initialize,
+                                               _spark_make_dfs,
+                                               _spark_stop)
+    from coffea.processor import run_spark_job
+
+    import os
+    import os.path as osp
+
+    import pyspark.sql
+    spark_config = pyspark.sql.SparkSession.builder \
+        .appName('spark-executor-test-%s' % guid()) \
+        .master('local[*]') \
+        .config('spark.sql.execution.arrow.enabled','true') \
+        .config('spark.executor.x509proxyname','x509_u12409') \
+        .config('spark.sql.execution.arrow.maxRecordsPerBatch', 200000)
+
+    spark = _spark_initialize(config=spark_config,log_level='ERROR',spark_progress=False)
+
+    filelist = {'ZJets': {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dy.root')], 'treename': 'Events' },
+                'Data'  : {'files': ['file:'+osp.join(os.getcwd(),'tests/samples/nano_dimuon.root')], 'treename': 'Events'}
+                }
+
+    from coffea.processor.test_items import NanoEventsProcessor
+    from coffea.processor.spark.spark_executor import spark_executor
+
+    columns = ['nMuon','Muon_pt','Muon_eta','Muon_phi','Muon_mass', 'Muon_charge']
     proc = NanoEventsProcessor(columns=columns)
     hists = run_spark_job(filelist, processor_instance=proc, executor=spark_executor, spark=spark, thread_workers=1,
-                          executor_args={'file_type': 'root', 'nano': True})
+                          executor_args={'file_type': 'root', 'schema': processor.NanoAODSchema})
 
     _spark_stop(spark)
 


### PR DESCRIPTION
Make it so that the executor/processor can use the NanoEventsFactory (uproot4/awkward1) module in addition to the NanoEvents (uproot3/awkward0) module. The NanoEventsFactory works with multiple flat ntuple schemas; the primary one being the NanoAODSchema, but also comes with the TreeMakerShema. An example call to the executor using the new schema option will look like:
```python
    output = processor.run_uproot_job(sample_dict,
                                      treename='TreeMaker2/PreSelection',
                                      processor_instance=SampleProcessor(),
                                      executor=processor.iterative_executor,
                                      executor_args={
                                          'skipbadfiles':True,
                                          'schema': processor.NanoAODSchema, 
                                          'flatten':True, 
                                          'workers': 4},
                                      chunksize=50000, maxchunks=100
                                     )
```
While I believe the code is in good shape, this PR will need #350 to be fully functional. This was initially tested using the TreeMakerSchema and successfully rendered all of the branches and processed multiple files. However, that test included some code which transitioned more of the processor to uproot4/awkward1, which didn't go into this PR. Without those changes, we can see no obvious signs of failure, but not enough of the code has been transitioned in order to perform a full test.