### PR TITLE
fix: filemeta not respecting skipbadfiles

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1070,11 +1070,11 @@ def run_uproot_job(fileset,
             filemeta = fileset.pop()
             if nchunks[filemeta.dataset] >= maxchunks:
                 continue
+            if skipbadfiles and not filemeta.populated(clusters=align_clusters):
+                continue
             if not filemeta.populated(clusters=align_clusters):
                 filemeta.metadata = metadata_fetcher(filemeta).pop().metadata
                 metadata_cache[filemeta] = filemeta.metadata
-            if skipbadfiles and not filemeta.populated(clusters=align_clusters):
-                continue
             for chunk in filemeta.chunks(chunksize, align_clusters):
                 chunks.append(chunk)
                 nchunks[filemeta.dataset] += 1

--- a/tests/test_local_executors.py
+++ b/tests/test_local_executors.py
@@ -7,14 +7,16 @@ if sys.platform.startswith("win"):
     pytest.skip("skipping tests that only function in linux", allow_module_level=True)
 
 
+@pytest.mark.parametrize("maxchunks", [None, 1000])
 @pytest.mark.parametrize("compression", [None, 0, 2])
 @pytest.mark.parametrize(
     "executor", [processor.iterative_executor, processor.futures_executor]
 )
-def test_nanoevents_analysis(executor, compression):
+def test_nanoevents_analysis(executor, compression, maxchunks):
     from coffea.processor.test_items import NanoEventsProcessor
 
     filelist = {
+        "DummyBad": [osp.abspath("tests/samples/non_existent.root")],
         "ZJets": [osp.abspath("tests/samples/nano_dy.root")],
         "Data": [osp.abspath("tests/samples/nano_dimuon.root")],
     }
@@ -22,12 +24,14 @@ def test_nanoevents_analysis(executor, compression):
 
     exe_args = {
         "workers": 1,
+        "skipbadfiles":True, 
         "schema": processor.NanoAODSchema,
         "compression": compression,
     }
 
     hists = processor.run_uproot_job(
-        filelist, treename, NanoEventsProcessor(), executor, executor_args=exe_args
+        filelist, treename, NanoEventsProcessor(), executor, executor_args=exe_args,
+        maxchunks=maxchunks,
     )
 
     assert hists["cutflow"]["ZJets_pt"] == 18


### PR DESCRIPTION
`run_uproot_job` was crashing when `maxchunks` was set and bad files were present along with `skipbadfiles` turned on, due to misordered logic

This fixes it and piggy backs a test on `test_nanoevents_analysis`, let me know if I should write a separate test instead

