### PR TITLE
fix genJetIdx handling

### DIFF
--- a/coffea/nanoaod/methods/jets.py
+++ b/coffea/nanoaod/methods/jets.py
@@ -139,7 +139,6 @@ class Jet(LorentzVector):
             )
             embedded_genjet.__doc__ = genjet.__doc__
             self['matched_gen'] = embedded_genjet
-            del self['genJetIdx']
 
         if 'JetPFCands' in events.columns:
             pfcand_link = events['JetPFCands']

--- a/coffea/nanoaod/nanoevents.py
+++ b/coffea/nanoaod/nanoevents.py
@@ -131,7 +131,7 @@ class NanoCollection(awkward.VirtualArray):
         index.type.takes = self.array.offsets[-1]
         index = awkward.JaggedArray.fromoffsets(self.array.offsets, content=index)
         globalindex = (index + destination.array.starts).flatten()
-        invalid = (index < 0).flatten()
+        invalid = ((destination.array.counts <= index) | (index < 0)).flatten()
         if any(invalid):
             globalindex[invalid] = -1
             # note: parent virtual must derive from this type

--- a/coffea/nanoevents/transforms.py
+++ b/coffea/nanoevents/transforms.py
@@ -109,6 +109,7 @@ def local2global(stack):
     target_offsets = stack.pop()
     index = stack.pop()
     index = index.mask[index >= 0] + target_offsets[:-1]
+    index = index.mask[index < target_offsets[1:]]
     out = numpy.array(awkward1.flatten(awkward1.fill_none(index, -1)))
     if out.dtype != numpy.int64:
         raise RuntimeError


### PR DESCRIPTION
`genJetIdx` may point beyond the available `GenJet`s, since the latter are 
truncated according to a minimum pT.
A non-negative `genJetIdx` indicates the existence of a `GenJet` and may 
be used to infer their pT ordering (in case the corresponding `GenJet`s 
were truncated), thus it should be kept available to the user.