### PR TITLE
JetMET tools that work with awkward1

### DIFF
--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -1,0 +1,370 @@
+from .JECStack import JECStack
+from coffea.util import awkward
+from coffea.util import awkward1
+from coffea.util import numpy as np
+from collections import namedtuple
+import warnings
+from copy import copy
+from functools import partial
+
+_stack_parts = ['jec', 'junc', 'jer', 'jersf']
+_MIN_JET_ENERGY = 1e-2
+
+
+def rand_gauss_ak0(arr, var):
+    item = arr[var]
+    wrap, _ = awkward.util.unwrap_jagged(item,
+                                         item.JaggedArray,
+                                         (item, ))
+    return wrap(np.random.normal(size=item.content.size))
+
+
+def rand_gauss_ak1(arr, var):
+    item = arr[var]
+
+    def getfunction(layout, depth):
+        if (isinstance(layout, awkward1.layout.NumpyArray)
+            or not isinstance(layout, (awkward1.layout.Content,
+                                       awkward1.partition.PartitionedArray)
+           )):
+            return lambda: awkward1.layout.NumpyArray(np.random.normal(size=awkward1.count(item)))
+        return None
+
+    out = awkward1._util.recursively_apply(
+        awkward1.operations.convert.to_layout(item),
+        getfunction)
+    assert out is not None
+    return awkward1._util.wrap(out, awkward1._util.behaviorof(item))
+
+
+def jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
+    pt_gen = arr[ptGenJet] if not forceStochastic else None
+    jetPt = arr[ptJet]
+
+    if isinstance(jetPt, awkward.array.base.AwkwardArray):
+        if forceStochastic:
+            wrap, arrays = awkward.util.unwrap_jagged(jetPt,
+                                                      jetPt.JaggedArray,
+                                                      (jetPt, ))
+            pt_gen = wrap(np.zeros_like(arrays[0]))
+    elif isinstance(jetPt, awkward1.highlevel.Array):
+        def getfunction(layout, depth):
+            if (isinstance(layout, awkward1.layout.NumpyArray)
+                or not isinstance(layout, (awkward1.layout.Content,
+                                           awkward1.partition.PartitionedArray)
+               )):
+                return lambda: awkward1.layout.NumpyArray(np.zeros_like(size=awkward1.count(jetPt)))
+            return None
+        if forceStochastic:
+            pt_gen = awkward1._util.recursively_apply(
+                awkward1.operations.convert.to_layout(jetPt),
+                getfunction)
+            pt_gen = awkward1._util.wrap(pt_gen, awkward1._util.behaviorof(jetPt))
+    else:
+        raise Exception('\'arr\' must be an awkward array of some kind!')
+
+    jersmear = arr['jet_energy_resolution'] * arr['jet_resolution_rand_gauss']
+    jersf = arr['jet_energy_resolution_scale_factor'][:, :, variation]
+    doHybrid = pt_gen > 0.
+
+    detSmear = 1. + (jersf - 1.) * (-pt_gen + jetPt) / jetPt  # because of #367
+    stochSmear = 1. + np.sqrt(np.maximum(jersf**2 - 1., 0.)) * jersmear
+
+    min_jet_pt = _MIN_JET_ENERGY / np.cosh(arr[etaJet])
+    min_jet_pt_corr = min_jet_pt / jetPt
+
+    smearfact = None
+    if isinstance(arr, awkward.array.base.AwkwardArray):
+        wrap, arrays = awkward.util.unwrap_jagged(jetPt,
+                                                  jetPt.JaggedArray,
+                                                  (jetPt, min_jet_pt_corr))
+        smearfact = np.where(doHybrid.content, detSmear.content, stochSmear.content)
+        smearfact = np.where((smearfact * arrays[0]) < arrays[1], arrays[1], smearfact)
+        smearfact = wrap(smearfact)
+    elif isinstance(arr, awkward1.highlevel.Array):
+        smearfact = awkward1.where(awkward1.flatten(doHybrid),
+                                   awkward1.flatten(detSmear),
+                                   awkward1.flatten(stochSmear))
+        smearfact = awkward1.where((smearfact * awkward1.flatten(jetPt)) < awkward1.flatten(min_jet_pt),
+                                   awkward1.flatten(min_jet_pt_corr),
+                                   smearfact)
+
+        def getfunction(layout, depth):
+            if (isinstance(layout, awkward1.layout.NumpyArray)
+                or not isinstance(layout, (awkward1.layout.Content,
+                                           awkward1.partition.PartitionedArray)
+               )):
+                return lambda: awkward1.layout.NumpyArray(smearfact)
+            return None
+        smearfact = awkward1._util.recursively_apply(
+            awkward1.operations.convert.to_layout(jetPt),
+            getfunction)
+        smearfact = awkward1._util.wrap(smearfact, awkward1._util.behaviorof(jetPt))
+    else:
+        raise Exception('\'arr\' must be an awkward array of some kind!')
+
+    return smearfact
+
+
+class JetUncertainty:
+    def __init__(self, jets, has_jer, forceStochastic, name_map, VirtualType, uncertainty, lazy_cache):
+        self.jets = jets
+        self.has_jer = has_jer
+        self.forceStochastic = forceStochastic
+        self.name_map
+        self.VirtualType = VirtualType
+        self.uncertainty = uncertainty
+        self.lazy_cache = lazy_cache
+        if uncertainty is None:  # JER uncertainty are [central, up, down]
+            self.UP = 1
+            self.DOWN = 2
+        else:  # JES uncertainties are [up, down]
+            self.UP = 0
+            self.DOWN = 1
+
+    def build_unc(self, up_down):
+        out = None
+        if isinstance(self.jets, awkward.array.base.AwkwardArray):
+            out = self.jets.copy()
+        elif isinstance(self.jets, awkward1.highlevel.Array):
+            out = copy(self.jets)
+        else:
+            raise Exception('\'jets\' must be an awkward array of some kind!')
+
+        if self.uncertainty is None:  # JER uncertainties
+            def jer_smeared_corr(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
+                return jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet)
+
+            out['jet_energy_resolution_correction'] = self.VirtualType(jer_smeared_corr,
+                                                                       args=(out, up_down, self.forceStochastic,
+                                                                             self.name_map['ptGenJet'],
+                                                                             self.name_map['JetPt'],
+                                                                             self.name_map['JetEta']),
+                                                                       length=len(out),
+                                                                       cache=self.lazy_cache)
+
+            def jer_smeared_val(arr, varName):
+                return arr['jet_energy_resolution_correction'] * arr['jet_energy_correction'] * arr[varName]
+
+            out[self.name_map['JetPt']] = self.VirtualType(jer_smeared_corr,
+                                                           args=(out, self.name_map['ptRaw']),
+                                                           length=len(out),
+                                                           cache=self.lazy_cache)
+            out[self.name_map['JetMass']] = self.VirtualType(jer_smeared_corr,
+                                                             args=(out, self.name_map['massRaw']),
+                                                             length=len(out),
+                                                             cache=self.lazy_cache)
+        else:  # JES uncertainties
+            out['jet_energy_uncertainty'] = self.uncertainty
+
+            def junc_smeared_val(arr, up_down, has_jer, varName):
+                base = arr['jet_energy_correction'] * arr[varName]
+                if has_jer:
+                    base = arr['jet_energy_resolution_correction'] * base
+                return out['jet_energy_uncertainty'][up_down] * base
+
+            out[self.name_map['JetPt']] = self.VirtualType(jer_smeared_corr,
+                                                           args=(out, up_down, self.has_jer,
+                                                                 self.name_map['ptRaw'],
+                                                                 ),
+                                                           length=len(out),
+                                                           cache=self.lazy_cache)
+            out[self.name_map['JetMass']] = self.VirtualType(jer_smeared_corr,
+                                                             args=(out, up_down, self.has_jer,
+                                                                   self.name_map['massRaw']
+                                                                   ),
+                                                             length=len(out),
+                                                             cache=self.lazy_cache)
+
+        return out
+
+    def up(self):
+        return self.build_unc(self.UP)
+
+    def down(self):
+        return self.build_unc(self.DOWN)
+
+
+class JetUncertaintyHandler:
+    def __init__(self, jets, has_jer, forceStochastic, name_map, VirtualType, uncertainties=None, lazy_cache=None):
+        self.jets = jets
+        self.has_jer = has_jer
+        self.forceStochastic = forceStochastic
+        self.name_map = name_map
+        self.uncertainties = None
+        self.lazy_cache = lazy_cache
+        self.VirtualType = VirtualType
+        if uncertainties is not None:
+            self.uncertainties = {k: v for k, v in uncertainties}
+
+    def keys(self):
+        out = []
+        if self.has_jer:
+            out += ['JER']
+        if self.uncertainties is not None:
+            out += list(self.uncertainties.keys())
+        return out
+
+    def __getitem__(self, key):
+        if ((key == 'JER' and not self.has_jer) or
+            (self.uncertainties is not None and key not in self.uncertainties)):
+            raise Exception(f'{key} is not an available uncertainty!')
+        func = None
+        if self.uncertainties is not None:
+            func = self.uncertainties[key]
+
+        return JetUncertainty(self.jets, self.has_jer, self.forceStochastic, self.name_map, self.VirtualType, func, self.lazy_cache)
+
+
+class CorrectedJetsFactory(object):
+
+    def __init__(self, name_map, jec_stack):
+        # from PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L283
+        self.forceStochastic = False
+
+        if 'ptRaw' not in name_map or name_map['ptRaw'] is None:
+            warnings.warn('There is no name mapping for ptRaw,'
+                          ' CorrectedJets will assume that <object>.pt is raw pt!')
+            name_map['ptRaw'] = name_map['JetPt'] + '_raw'
+        self.treat_pt_as_raw = 'ptRaw' not in name_map
+
+        if 'massRaw' not in name_map or name_map['massRaw'] is None:
+            warnings.warn('There is no name mapping for massRaw,'
+                          ' CorrectedJets will assume that <object>.mass is raw pt!')
+            name_map['ptRaw'] = name_map['JetMass'] + '_raw'
+
+        total_signature = set()
+        for part in _stack_parts:
+            attr = getattr(jec_stack, part)
+            if part is not None:
+                total_signature.update(attr.signature)
+
+        missing = total_signature - set(name_map.keys())
+        if len(missing) > 0:
+            raise Exception(f'Missing mapping of {missing} in name_map!' +
+                            ' Cannot evaluate jet corrections!' +
+                            ' Please supply mappings for these variables!')
+
+        if 'ptGenJet' not in name_map:
+            warnings.warn('Input JaggedCandidateArray must have "ptGenJet" in order to apply hybrid JER smearing method. Stochastic smearing will be applied.')
+            self.forceStochastic = True
+
+        self.real_sig = [v for k, v in name_map.items()]
+        self.name_map = name_map
+        self.jec_stack = jec_stack
+
+    def build(self, jets, lazy_cache=None):
+        fields = None
+        out = None
+        VirtualType = None
+        rand_gauss_func = None
+        if isinstance(jets, awkward.array.base.AwkwardArray):
+            fields = jets.columns
+            if len(jets.columns) == 0:
+                raise Exception('Detected awkward0: \'jets\' must have attributes specified in jets.columns!')
+            out = jets.copy()
+            VirtualType = awkward.VirtualArray
+            rand_gauss_func = rand_gauss_ak0
+        elif isinstance(jets, awkward1.highlevel.Array):
+            fields = awkward1.keys(jets)
+            if len(fields) == 0:
+                raise Exception('Detected awkward1: \'jets\' must have attributes specified by keys!')
+            out = copy(jets)
+            VirtualType = awkward1.virtual
+            rand_gauss_func = rand_gauss_ak1
+        else:
+            raise Exception('\'jets\' must be an awkward array of some kind!')
+
+        if len(fields) == 0:
+            raise Exception('Empty record, please pass a jet object with at least {self.real_sig} defined!')
+
+        # take care of nominal JEC (no JER if available)
+        out[self.name_map['JetPt'] + '_old'] = out[self.name_map['JetPt']]
+        out[self.name_map['JetMass'] + '_old'] = out[self.name_map['JetMass']]
+        if self.treat_pt_as_raw:
+            out[self.name_map['ptRaw']] = out[self.name_map['JetPt']]
+            out[self.name_map['massRaw']] = out[self.name_map['JetMass']]
+
+        # here we render the args to pass to the jec so the switches should have been done
+        jec_args = {k: out[self.name_map[k]] for k in self.jec_stack.jec.signature}
+        out['jet_energy_correction'] = self.jec_stack.jec.getCorrection(**jec_args, lazy_cache=lazy_cache)
+
+        # finally the lazy binding to the JEC
+        def jec_var_corr(arr, varName):
+            print('calling jec_var_corr')
+            return arr['jet_energy_correction'] * arr[varName]
+
+        out[self.name_map['JetPt']] = VirtualType(jec_var_corr, args=(out, self.name_map['ptRaw']),
+                                                  length=len(out), cache=lazy_cache)
+        out[self.name_map['JetMass']] = VirtualType(jec_var_corr, args=(out, self.name_map['massRaw']),
+                                                    length=len(out), cache=lazy_cache)
+
+        if self.jec_stack.jer is not None and self.jec_stack.jersf is not None:
+            jerargs = {k: out[self.name_map[k]] for k in self.jec_stack.jer.signature}
+            out['jet_energy_resolution'] = self.jec_stack.jer.getResolution(**jerargs, lazy_cache=lazy_cache)
+
+            jersfargs = {k: out[self.name_map[k]] for k in self.jec_stack.jersf.signature}
+            out['jet_energy_resolution_scale_factor'] = self.jec_stack.jersf.getScaleFactor(**jersfargs, lazy_cache=lazy_cache)
+
+            out['jet_resolution_rand_gauss'] = VirtualType(rand_gauss_func, args=(out, self.name_map['JetPt']),
+                                                           length=len(out), cache=lazy_cache)
+
+            def jer_smeared_corr(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
+                print('calling jer_smeared_corr')
+                return jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet)
+
+            out['jet_energy_resolution_correction'] = VirtualType(jer_smeared_corr,
+                                                                  args=(out, 0, self.forceStochastic,
+                                                                        self.name_map['ptGenJet'],
+                                                                        self.name_map['JetPt'],
+                                                                        self.name_map['JetEta']),
+                                                                  length=len(out),
+                                                                  cache=lazy_cache)
+
+            def jer_smeared_val(arr, varName):
+                print('calling jer_smeared_val')
+                return arr['jet_energy_resolution_correction'] * arr['jet_energy_correction'] * arr[varName]
+
+            out[self.name_map['JetPt']] = VirtualType(jer_smeared_val, args=(out, self.name_map['ptRaw']),
+                                                      length=len(out), cache=lazy_cache)
+            out[self.name_map['JetMass']] = VirtualType(jer_smeared_val, args=(out, self.name_map['massRaw']),
+                                                        length=len(out), cache=lazy_cache)
+
+        return out
+
+        def build_uncertainties(self, corrected_jets, lazy_cache=None):
+            fields = None
+            VirtualType = None
+            if isinstance(corrected_jets, awkward.array.base.AwkwardArray):
+                if not isinstance(jets, awkward.Table):
+                    raise Exception('Detected awkward0: \'corrected_jets\' must be an awkward.Table!')
+                fields = list(jets.columns.keys())
+                VirtualType = awkward.VirtualArray
+            elif isinstance(corrected_jets, awkward1.highlevel.Array):
+                if not isinstance(awkward1.type(jets.layout), awkward1.types.RecordType):
+                    raise Exception('Detected awkward1: \'corrected_jets\' must be a RecordType!')
+                fields = awkward1.keys(jets)
+                VirtualType = awkward1.virtual
+            else:
+                raise Exception('\'corrected_jets\' must be an awkward array of some kind!')
+
+            if 'jet_energy_correction' not in fields:
+                raise Exception('corrected_jets does not contain jet energy corrections! '
+                                'Please run CorrectedJetsFactory.build() on them first!')
+
+            has_jer = False
+            if 'jet_energy_resolution_correction' in fields:
+                has_jer = True
+
+            juncs = None
+            if self.jec_stack.juncs is not None:
+                juncargs = {k: corrected_jets[self.name_map[k]] for k in self.jec_stack.junc.signature}
+                juncs = self.jec_stack.juncs.getUncertainty(**juncargs)
+
+            return JetUncertaintyHandler(corrected_jets,
+                                         has_jer=has_jer,
+                                         forceStochastic=self.forceStochastic,
+                                         name_map=self.name_map,
+                                         VirtualType=VirtualType,
+                                         uncertainties=juncs,
+                                         lazy_cache=lazy_cache)

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -150,7 +150,7 @@ class CorrectedJetsFactory(object):
         total_signature = set()
         for part in _stack_parts:
             attr = getattr(jec_stack, part)
-            if part is not None:
+            if attr is not None:
                 total_signature.update(attr.signature)
 
         missing = total_signature - set(name_map.keys())
@@ -211,8 +211,11 @@ class CorrectedJetsFactory(object):
         jec_name_map.update(self.name_map)
         jec_name_map['JetPt'] = jec_name_map['ptRaw']
         jec_name_map['JetMass'] = jec_name_map['ptRaw']
-        jec_args = {k: out[jec_name_map[k]] for k in self.jec_stack.jec.signature}
-        out['jet_energy_correction'] = self.jec_stack.jec.getCorrection(**jec_args, form=form, lazy_cache=lazy_cache)
+        if self.jec_stack.jec is not None:
+            jec_args = {k: out[jec_name_map[k]] for k in self.jec_stack.jec.signature}
+            out['jet_energy_correction'] = self.jec_stack.jec.getCorrection(**jec_args, form=form, lazy_cache=lazy_cache)
+        else:
+            out['jet_energy_correction'] = awkward1.ones_like(out[self.name_map['JetPt']])
 
         # finally the lazy binding to the JEC
         def jec_var_corr(arr, varName):

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -1,7 +1,7 @@
-from .JECStack import JECStack
-from coffea.util import awkward
-from coffea.util import awkward1
-from coffea.util import numpy as np
+from coffea.jetmet_tools.JECStack import JECStack
+import awkward
+import awkward1
+import numpy as np
 from collections import namedtuple
 import warnings
 from copy import copy
@@ -44,7 +44,7 @@ def rand_gauss_ak1(arr, var):
             or not isinstance(layout, (awkward1.layout.Content,
                                        awkward1.partition.PartitionedArray)
            )):
-            return lambda: awkward1.layout.NumpyArray(np.random.normal(size=awkward1.count(item)))
+            return lambda: awkward1.layout.NumpyArray(np.random.normal(size=len(layout)))
         return None
 
     out = awkward1._util.recursively_apply(
@@ -70,7 +70,7 @@ def jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
                 or not isinstance(layout, (awkward1.layout.Content,
                                            awkward1.partition.PartitionedArray)
                )):
-                return lambda: awkward1.layout.NumpyArray(np.zeros_like(size=awkward1.count(jetPt)))
+                return lambda: awkward1.layout.NumpyArray(np.zeros_like(size=len(jetPt)))
             return None
         if forceStochastic:
             pt_gen = awkward1._util.recursively_apply(

--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -2,16 +2,24 @@ from coffea.jetmet_tools.JECStack import JECStack
 import awkward
 import awkward1
 import numpy as np
-from collections import namedtuple
 import warnings
 from copy import copy
 from functools import partial
 
-from coffea.nanoevents.methods.nanoaod import Jet as Ak1Jet
 
 _stack_parts = ['jec', 'junc', 'jer', 'jersf']
-_MIN_JET_ENERGY = 1e-2
-
+_MIN_JET_ENERGY = np.array(1e-2, dtype=np.float32)
+_ONE_F32 = np.array(1., dtype=np.float32)
+_ZERO_F32 = np.array(0., dtype=np.float32)
+_JERSF_FORM = {
+    "class": "NumpyArray",
+    "inner_shape": [
+        3
+    ],
+    "itemsize": 4,
+    "format": "f",
+    "primitive": "float32"
+}
 
 # we're gonna assume that the first record array we encounter is the flattened data
 def rewrap_recordarray(layout, depth, data):
@@ -33,7 +41,7 @@ def rand_gauss_ak0(arr, var):
     wrap, _ = awkward.util.unwrap_jagged(item,
                                          item.JaggedArray,
                                          (item, ))
-    return wrap(np.random.normal(size=item.content.size))
+    return wrap(np.random.normal(size=item.content.size).astype(np.float32))
 
 
 def rand_gauss_ak1(arr, var):
@@ -44,7 +52,7 @@ def rand_gauss_ak1(arr, var):
             or not isinstance(layout, (awkward1.layout.Content,
                                        awkward1.partition.PartitionedArray)
            )):
-            return lambda: awkward1.layout.NumpyArray(np.random.normal(size=len(layout)))
+            return lambda: awkward1.layout.NumpyArray(np.random.normal(size=len(layout)).astype(np.float32))
         return None
 
     out = awkward1._util.recursively_apply(
@@ -63,14 +71,14 @@ def jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
             wrap, arrays = awkward.util.unwrap_jagged(jetPt,
                                                       jetPt.JaggedArray,
                                                       (jetPt, ))
-            pt_gen = wrap(np.zeros_like(arrays[0]))
+            pt_gen = wrap(np.zeros_like(arrays[0], dtype=np.float32))
     elif isinstance(jetPt, awkward1.highlevel.Array):
         def getfunction(layout, depth):
             if (isinstance(layout, awkward1.layout.NumpyArray)
                 or not isinstance(layout, (awkward1.layout.Content,
                                            awkward1.partition.PartitionedArray)
                )):
-                return lambda: awkward1.layout.NumpyArray(np.zeros_like(size=len(jetPt)))
+                return lambda: awkward1.layout.NumpyArray(np.zeros_like(size=len(jetPt), dtype=np.float32))
             return None
         if forceStochastic:
             pt_gen = awkward1._util.recursively_apply(
@@ -82,11 +90,10 @@ def jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
 
     jersmear = arr['jet_energy_resolution'] * arr['jet_resolution_rand_gauss']
     jersf = arr['jet_energy_resolution_scale_factor'][:, variation]
-    print('jersf', arr['jet_energy_resolution_scale_factor'])
-    doHybrid = pt_gen > 0.
+    doHybrid = pt_gen > 0
 
-    detSmear = 1. + (jersf - 1.) * (-pt_gen + jetPt) / jetPt  # because of awkward1.0#367
-    stochSmear = 1. + np.sqrt(np.maximum(jersf**2 - 1., 0.)) * jersmear
+    detSmear = 1 + (jersf - 1) * (jetPt - pt_gen) / jetPt  # because of awkward1.0#367
+    stochSmear = 1 + np.sqrt(np.maximum(jersf**2 - 1, 0)) * jersmear
 
     min_jet_pt = _MIN_JET_ENERGY / np.cosh(arr[etaJet])
     min_jet_pt_corr = min_jet_pt / jetPt
@@ -159,28 +166,30 @@ class CorrectedJetsFactory(object):
         self.name_map = name_map
         self.jec_stack = jec_stack
 
+    def uncertainties(self):
+        out = ['JER'] if self.jec_stack.jer is not None else []
+        if self.jec_stack.junc is not None:
+            out.extend(['JES_{0}'.format(unc) for unc in self.jec_stack.junc.levels])
+        return out
+
     def build(self, jets, lazy_cache=None):
         fields = None
         out = None
         wrap = None
         VirtualType = None
         isak1 = False
+        form = None
         if isinstance(jets, awkward.array.base.AwkwardArray):
-            fields = jets.columns
-            if len(fields) == 0:
-                raise Exception('Detected awkward0: \'jets\' must have attributes specified in jets.columns!')
-            wrap, out = awkward.util.unwrap_jagged(jets.copy())
-            assert(len(out) == 1)
-            out = out[0]
-            VirtualType = awkward.VirtualArray
+            raise Exception('Awkward0 not supported by CorrectedJetsFactory, please use the JetTransformer or awkward1')
         elif isinstance(jets, awkward1.highlevel.Array):
             isak1 = True
-            fields = awkward1.keys(jets)
+            fields = awkward1.fields(jets)
             if len(fields) == 0:
                 raise Exception('Detected awkward1: \'jets\' must have attributes specified by keys!')
             out = awkward1.flatten(jets)
             wrap = partial(awkward1_rewrap, like_what=jets, gfunc=rewrap_recordarray)
             VirtualType = awkward1.virtual
+            form = out[self.name_map['ptRaw']].layout.form
         else:
             raise Exception('\'jets\' must be an awkward array of some kind!')
 
@@ -199,24 +208,22 @@ class CorrectedJetsFactory(object):
         jec_name_map['JetPt'] = jec_name_map['ptRaw']
         jec_name_map['JetMass'] = jec_name_map['ptRaw']
         jec_args = {k: out[jec_name_map[k]] for k in self.jec_stack.jec.signature}
-        out['jet_energy_correction'] = self.jec_stack.jec.getCorrection(**jec_args, lazy_cache=lazy_cache)
-
+        out['jet_energy_correction'] = self.jec_stack.jec.getCorrection(**jec_args, form=form, lazy_cache=lazy_cache)
         # finally the lazy binding to the JEC
         def jec_var_corr(arr, varName):
             return arr['jet_energy_correction'] * arr[varName]
 
         init_pt = partial(VirtualType, jec_var_corr, args=(out, self.name_map['ptRaw']), cache=lazy_cache)
         init_mass = partial(VirtualType, jec_var_corr, args=(out, self.name_map['massRaw']), cache=lazy_cache)
-        out[self.name_map['JetPt']] = init_pt(length=len(out)) if isak1 else init_pt()
-        out[self.name_map['JetMass']] = init_mass(length=len(out)) if isak1 else init_mass()
+        
+        out[self.name_map['JetPt']] = init_pt(length=len(out), form=form) if isak1 else init_pt()
+        out[self.name_map['JetMass']] = init_mass(length=len(out), form=form) if isak1 else init_mass()
 
-        out[self.name_map['JetPt'] + '_jec'] = init_pt(length=len(out)) if isak1 else init_pt()
-        out[self.name_map['JetMass'] + '_jec'] = init_mass(length=len(out)) if isak1 else init_mass()
+        out[self.name_map['JetPt'] + '_jec'] = init_pt(length=len(out), form=form) if isak1 else init_pt()
+        out[self.name_map['JetMass'] + '_jec'] = init_mass(length=len(out), form=form) if isak1 else init_mass()
 
         # in jer we need to have a stash for the intermediate JEC products
         has_jer = False
-        out_orig = copy(out)
-        systs = {}
         if self.jec_stack.jer is not None and self.jec_stack.jersf is not None:
             has_jer = True
             jer_name_map = {}
@@ -225,119 +232,115 @@ class CorrectedJetsFactory(object):
             jer_name_map['JetMass'] = jer_name_map['JetMass'] + '_jec'
 
             jerargs = {k: out[jer_name_map[k]] for k in self.jec_stack.jer.signature}
-            out['jet_energy_resolution'] = self.jec_stack.jer.getResolution(**jerargs, lazy_cache=lazy_cache)
+            out['jet_energy_resolution'] = self.jec_stack.jer.getResolution(**jerargs, form=form, lazy_cache=lazy_cache)
 
             jersfargs = {k: out[jer_name_map[k]] for k in self.jec_stack.jersf.signature}
-            out['jet_energy_resolution_scale_factor'] = self.jec_stack.jersf.getScaleFactor(**jersfargs, lazy_cache=lazy_cache)
+            out['jet_energy_resolution_scale_factor'] = self.jec_stack.jersf.getScaleFactor(**jersfargs, form=_JERSF_FORM, lazy_cache=lazy_cache)
 
             init_rand_gauss = partial(VirtualType, args=(out, jer_name_map['JetPt']), cache=lazy_cache)
-            out['jet_resolution_rand_gauss'] = init_rand_gauss(rand_gauss_ak1, length=len(out)) if isak1 else init_rand_gauss(rand_gauss_ak0)
-
-            def jer_smeared_corr(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet):
-                return jer_smear(arr, variation, forceStochastic, ptGenJet, ptJet, etaJet)
+            out['jet_resolution_rand_gauss'] = init_rand_gauss(rand_gauss_ak1, length=len(out), form=form) if isak1 else init_rand_gauss(rand_gauss_ak0)
 
             init_jerc = partial(VirtualType,
-                                jer_smeared_corr,
+                                jer_smear,
                                 args=(out, 0, self.forceStochastic,
                                       jer_name_map['ptGenJet'],
                                       jer_name_map['JetPt'],
                                       jer_name_map['JetEta']),
                                 cache=lazy_cache
                                 )
-            out['jet_energy_resolution_correction'] = init_jerc(length=len(out)) if isak1 else init_jerc()
+            out['jet_energy_resolution_correction'] = init_jerc(length=len(out), form=form) if isak1 else init_jerc()
 
-            def jer_smeared_val(arr, varName):
-                return arr['jet_energy_resolution_correction'] * arr[varName]
+            def jer_smeared_val(arr, base, varName):
+                return arr['jet_energy_resolution_correction'] * base[varName]
 
-            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(out, jer_name_map['JetPt']), cache=lazy_cache)
-            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(out, jer_name_map['JetPt']), cache=lazy_cache)
-            out[self.name_map['JetPt']] = init_pt_jer(length=len(out)) if isak1 else init_pt_jer()
-            out[self.name_map['JetMass']] = init_mass_jer(length=len(out)) if isak1 else init_mass_jer()
+            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(out, out, jer_name_map['JetPt']), cache=lazy_cache)
+            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(out, out, jer_name_map['JetPt']), cache=lazy_cache)
+            out[self.name_map['JetPt']] = init_pt_jer(length=len(out), form=form) if isak1 else init_pt_jer()
+            out[self.name_map['JetMass']] = init_mass_jer(length=len(out), form=form) if isak1 else init_mass_jer()
 
-            out[self.name_map['JetPt'] + '_jer'] = init_pt_jer(length=len(out)) if isak1 else init_pt_jer()
-            out[self.name_map['JetMass'] + '_jer'] = init_mass_jer(length=len(out)) if isak1 else init_mass_jer()
-
-            out_orig = copy(out)
+            out[self.name_map['JetPt'] + '_jer'] = init_pt_jer(length=len(out), form=form) if isak1 else init_pt_jer()
+            out[self.name_map['JetMass'] + '_jer'] = init_mass_jer(length=len(out), form=form) if isak1 else init_mass_jer()
 
             # JER systematics
             jerc_up = partial(VirtualType,
-                              jer_smeared_corr,
+                              jer_smear,
                               args=(out, 1, self.forceStochastic,
                                     jer_name_map['ptGenJet'],
                                     jer_name_map['JetPt'],
                                     jer_name_map['JetEta']),
                               cache=lazy_cache
                               )
-            up = copy(out)
-            up['jet_energy_resolution_correction'] = jerc_up(length=len(up)) if isak1 else jerc_up()
-            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(up, jer_name_map['JetPt']), cache=lazy_cache)
-            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(up, jer_name_map['JetPt']), cache=lazy_cache)
-            up[self.name_map['JetPt']] = init_pt_jer(length=len(up)) if isak1 else init_pt_jer()
-            up[self.name_map['JetMass']] = init_mass_jer(length=len(up)) if isak1 else init_mass_jer()
+            up = awkward1.flatten(jets)
+            up['jet_energy_resolution_correction'] = jerc_up(length=len(out), form=form) if isak1 else jerc_up()
+            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(up, out, jer_name_map['JetPt']), cache=lazy_cache)
+            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(up, out, jer_name_map['JetPt']), cache=lazy_cache)
+            up[self.name_map['JetPt']] = init_pt_jer(length=len(out), form=form) if isak1 else init_pt_jer()
+            up[self.name_map['JetMass']] = init_mass_jer(length=len(out), form=form) if isak1 else init_mass_jer()
 
             jerc_down = partial(VirtualType,
-                                jer_smeared_corr,
+                                jer_smear,
                                 args=(out, 2, self.forceStochastic,
                                       jer_name_map['ptGenJet'],
                                       jer_name_map['JetPt'],
                                       jer_name_map['JetEta']),
                                 cache=lazy_cache
                                 )
-            down = copy(out)
-            down['jet_energy_resolution_correction'] = jerc_down(length=len(down)) if isak1 else jerc_down()
-            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(down, jer_name_map['JetPt']), cache=lazy_cache)
-            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(down, jer_name_map['JetPt']), cache=lazy_cache)
-            down[self.name_map['JetPt']] = init_pt_jer(length=len(down)) if isak1 else init_pt_jer()
-            down[self.name_map['JetMass']] = init_mass_jer(length=len(down)) if isak1 else init_mass_jer()
-            systs['JER'] = awkward1.zip({'up': up, 'down': down}, depth_limit=1, with_name='JetSystematic')
+            down = awkward1.flatten(jets)
+            down['jet_energy_resolution_correction'] = jerc_down(length=len(out), form=form) if isak1 else jerc_down()
+            init_pt_jer = partial(VirtualType, jer_smeared_val, args=(down, out, jer_name_map['JetPt']), cache=lazy_cache)
+            init_mass_jer = partial(VirtualType, jer_smeared_val, args=(down, out, jer_name_map['JetPt']), cache=lazy_cache)
+            down[self.name_map['JetPt']] = init_pt_jer(length=len(out), form=form) if isak1 else init_pt_jer()
+            down[self.name_map['JetMass']] = init_mass_jer(length=len(out), form=form) if isak1 else init_mass_jer()
+            out['JER'] = awkward1.zip({'up': up, 'down': down}, depth_limit=1, with_name='JetSystematic')
 
-        if self.jec_stack.junc:
-            juncargs = {}
-            juncargs.update(self.name_map)
+        if self.jec_stack.junc is not None:
+            juncnames = {}
+            juncnames.update(self.name_map)
             if has_jer:
-                juncargs['JetPt'] = juncargs['JetPt'] + '_jer'
+                juncnames['JetPt'] = juncnames['JetPt'] + '_jer'
+                juncnames['JetMass'] = juncnames['JetMass'] + '_jer'
             else:
-                juncargs['JetPt'] = juncargs['JetPt'] + '_jec'
-            juncargs = {k: out[juncargs[k]] for k in self.jec_stack.junc.signature}
+                juncnames['JetPt'] = juncnames['JetPt'] + '_jec'
+                juncnames['JetMass'] = juncnames['JetMass'] + '_jec'
+            juncargs = {k: out[juncnames[k]] for k in self.jec_stack.junc.signature}
             juncs = self.jec_stack.junc.getUncertainty(**juncargs)
             for name, func in juncs:
                 out[f'jet_energy_uncertainty_{name}'] = func
 
-                def junc_smeared_val(arr, up_down, varName):
-                    return arr[f'jet_energy_uncertainty_{name}'][:, up_down] * arr[varName]
+                def junc_smeared_val(arr, up_down, uncname, varName):
+                    return arr[f'jet_energy_uncertainty_{uncname}'][:, up_down] * arr[varName]
 
-                up = copy(out_orig)
+                up = awkward1.flatten(jets)
                 up[self.name_map['JetPt']] = VirtualType(junc_smeared_val,
-                                                         args=(out, 0,
-                                                               juncargs['JetPt'],
+                                                         args=(out, 0, name,
+                                                               juncnames['JetPt'],
                                                                ),
                                                          length=len(out),
+                                                         form=form,
                                                          cache=lazy_cache)
                 up[self.name_map['JetMass']] = VirtualType(junc_smeared_val,
-                                                           args=(out, 0,
-                                                                 juncargs['JetPt'],
+                                                           args=(out, 0, name,
+                                                                 juncnames['JetMass'],
                                                                  ),
                                                            length=len(out),
+                                                           form=form,
                                                            cache=lazy_cache)
 
-                down = copy(out_orig)
+                down = awkward1.flatten(jets)
                 down[self.name_map['JetPt']] = VirtualType(junc_smeared_val,
-                                                           args=(out, 0,
-                                                                 juncargs['JetPt'],
+                                                           args=(out, 1, name,
+                                                                 juncnames['JetPt'],
                                                                  ),
                                                            length=len(out),
+                                                           form=form,
                                                            cache=lazy_cache)
                 down[self.name_map['JetMass']] = VirtualType(junc_smeared_val,
-                                                             args=(out, 0,
-                                                                   juncargs['JetPt'],
+                                                             args=(out, 1, name,
+                                                                   juncnames['JetMass'],
                                                                    ),
                                                              length=len(out),
+                                                             form=form,
                                                              cache=lazy_cache)
-                systs[f'JES_{name}'] = awkward1.zip({'up': up, 'down': down}, depth_limit=1, with_name='JetSystematic')
-
-        outdict = {key: out_orig[key] for key in awkward1.keys(out_orig)}
-        outdict.update(systs)
-
-        out = awkward1.zip(outdict, depth_limit=1, with_name='Jet')
+                out[f'JES_{name}'] = awkward1.zip({'up': up, 'down': down}, depth_limit=1, with_name='JetSystematic')
 
         return wrap(out)

--- a/coffea/jetmet_tools/CorrectedMETFactory.py
+++ b/coffea/jetmet_tools/CorrectedMETFactory.py
@@ -1,0 +1,161 @@
+from coffea.jetmet_tools.JECStack import JECStack
+import awkward
+import awkward1
+import numpy as np
+import warnings
+from copy import copy
+
+
+class CorrectedMETFactory(object):
+
+    def __init__(self, name_map):
+        if 'xMETRaw' not in name_map or name_map['xMETRaw'] is None:
+            warnings.warn('There is no name mapping for ptRaw,'
+                          ' CorrectedJets will assume that <object>.x is raw pt!')
+            name_map['xMETRaw'] = name_map['METx'] + '_raw'
+        self.treat_pt_as_raw = 'ptRaw' not in name_map
+
+        if 'yMETRaw' not in name_map or name_map['yMETRaw'] is None:
+            warnings.warn('There is no name mapping for massRaw,'
+                          ' CorrectedJets will assume that <object>.x is raw pt!')
+            name_map['yMETRaw'] = name_map['METy'] + '_raw'
+
+        self.name_map = name_map
+
+    def build(self, MET, corrected_jets, lazy_cache):
+        if lazy_cache is None:
+            raise Exception('CorrectedMETFactory requires a awkward-array cache to function correctly.')
+        if (isinstance(MET, awkward.array.base.AwkwardArray) or
+            isinstance(corrected_jets, awkward.array.base.AwkwardArray)):
+            raise Exception('Awkward0 not supported by CorrectedMETFactory, please use the JetTransformer or awkward1')
+        elif (not isinstance(MET, awkward1.highlevel.Array) or
+              not isinstance(corrected_jets, awkward1.highlevel.Array)):
+            raise Exception('\'MET\' must be an awkward array of some kind!')
+
+        out = copy(MET)
+
+        form = out[self.name_map['METpt']].layout.form
+        length = len(out)
+
+        orig_jets = copy(corrected_jets)
+        orig_jets[self.name_map['JetPt']] = orig_jets[self.name_map['ptRaw']]
+        orig_jets[self.name_map['JetMass']] = orig_jets[self.name_map['massRaw']]
+
+        out['x_orig'] = getattr(out, self.name_map['METx'])
+        out['y_orig'] = getattr(out, self.name_map['METy'])
+
+        out[self.name_map['METpt'] + '_orig'] = out[self.name_map['METpt']]
+        out[self.name_map['METphi'] + '_orig'] = out[self.name_map['METphi']]
+
+        def corrected_met_cartesian(met, rawJets, corrJets, dim):
+            return met[f'{dim}_orig'] - np.sum(getattr(rawJets, dim) - getattr(corrJets, dim))
+
+        def corrected_met_cartesian_unc(met, rawJets, corrJets, dimMET, dimJets):
+            return getattr(met, dimMET) - np.sum(getattr(rawJets, dimJets) - getattr(corrJets, dimJets))
+
+        out['corrected_met_x'] = awkward1.virtual(
+            corrected_met_cartesian,
+            args=(out, orig_jets, corrected_jets, self.name_map['JETx']),
+            length=length, form=form, cache=lazy_cache
+        )
+        out['corrected_met_y'] = awkward1.virtual(
+            corrected_met_cartesian,
+            args=(out, orig_jets, corrected_jets, self.name_map['JETy']),
+            length=length, form=form, cache=lazy_cache
+        )
+
+        out[self.name_map['METpt']] = awkward1.virtual(
+            lambda met: np.hypot(met['corrected_met_x'], met['corrected_met_y']),
+            args=(out, ),
+            length=length,
+            form=form,
+            cache=lazy_cache
+        )
+        out[self.name_map['METphi']] = awkward1.virtual(
+            lambda met: np.arctan2(met['corrected_met_y'], met['corrected_met_x']),
+            args=(out, ),
+            length=length,
+            form=form,
+            cache=lazy_cache
+        )
+
+        def make_unclustered_variant(themet, op, deltaX, deltaY):
+            variant = copy(themet)
+            variant['corrected_met_x'] = awkward1.virtual(
+                lambda met: op(out['corrected_met_x'], out[f'{deltaX}']),
+                args=(out, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            variant['corrected_met_y'] = awkward1.virtual(
+                lambda met: op(out['corrected_met_y'], out[f'{deltaY}']),
+                args=(out, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            variant[self.name_map['METpt']] = awkward1.virtual(
+                lambda met: np.hypot(out['corrected_met_x'], out['corrected_met_y']),
+                args=(variant, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            variant[self.name_map['METphi']] = awkward1.virtual(
+                lambda met: np.arctan2(out['corrected_met_y'], out['corrected_met_x']),
+                args=(variant, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            return variant
+
+        unclus_up = make_unclustered_variant(MET, lambda x, y: x + y,
+                                             self.name_map['UnClusteredEnergyDeltaX'],
+                                             self.name_map['UnClusteredEnergyDeltaY'])
+        unclus_down = make_unclustered_variant(MET, lambda x, y: x - y,
+                                               self.name_map['UnClusteredEnergyDeltaX'],
+                                               self.name_map['UnClusteredEnergyDeltaY'])
+        out['MET_UnclusteredEnergy'] = awkward1.zip({'up': unclus_up, 'down': unclus_down},
+                                                    depth_limit=1,
+                                                    with_name='METSystematic')
+
+        def make_variant(name, variation):
+            variant = copy(MET)
+            variant['corrected_met_x'] = awkward1.virtual(
+                corrected_met_cartesian_unc,
+                args=(out, orig_jets, variation, self.name_map['METx'], self.name_map['JETx']),
+                length=length, form=form, cache=lazy_cache
+            )
+            variant['corrected_met_y'] = awkward1.virtual(
+                corrected_met_cartesian_unc,
+                args=(out, orig_jets, variation, self.name_map['METy'], self.name_map['JETy']),
+                length=length, form=form, cache=lazy_cache
+            )
+            variant[self.name_map['METpt']] = awkward1.virtual(
+                lambda met: np.hypot(met['corrected_met_x'], met['corrected_met_y']),
+                args=(variant, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            variant[self.name_map['METphi']] = awkward1.virtual(
+                lambda met: np.arctan2(met['corrected_met_y'], met['corrected_met_x']),
+                args=(variant, ),
+                length=length,
+                form=form,
+                cache=lazy_cache
+            )
+            return variant
+
+        for unc in filter(lambda x: x.startswith(('JER', 'JES')), awkward1.fields(corrected_jets)):
+            up = make_variant(unc, corrected_jets[unc].up)
+            down = make_variant(unc, corrected_jets[unc].down)
+            out[unc] = awkward1.zip({'up': up, 'down': down},
+                                    depth_limit=1,
+                                    with_name='METSystematic')
+        return out
+
+    def uncertainties(self):
+        return ['MET_UnclusteredEnergy']

--- a/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -1,9 +1,9 @@
 from ..lookup_tools.jme_standard_function import jme_standard_function
 import warnings
 import re
-from ..util import awkward
-from ..util import awkward1
-from ..util import numpy as np
+import awkward
+import awkward1
+import numpy as np
 from copy import deepcopy
 from functools import reduce
 

--- a/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -150,7 +150,7 @@ class FactorizedJetCorrector(object):
         if isinstance(first_arg, awkward.array.base.AwkwardArray):
             out = awkward.VirtualArray(total_corr, args=(self, ), kwargs=kwargs, cache=cache)
         elif isinstance(first_arg, np.ndarray):
-            out = total_corr()  # np is non-lazy
+            out = total_corr(self, **kwargs)  # np is non-lazy
         elif isinstance(first_arg, awkward1.highlevel.Array):
             out = awkward1.virtual(total_corr, args=(self, ), kwargs=kwargs, length=len(first_arg), cache=cache)
         else:

--- a/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -145,7 +145,7 @@ class FactorizedJetCorrector(object):
 
         def total_corr(jec, **kwargs):
             corrs = jec.getSubCorrections(**kwargs)
-            return reduce(lambda x, y: y * x, corrs, 1.0)
+            return reduce(lambda x, y: y * x , corrs, 1.0)
 
         out = None
         if isinstance(first_arg, awkward.array.base.AwkwardArray):
@@ -184,8 +184,10 @@ class FactorizedJetCorrector(object):
         corrections = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
-            cumCorr = reduce(lambda x, y: y * x, corrections, np.array(1., dtype=np.float32))
-            fargs = tuple(cumCorr * corrVars[arg] if arg in corrVars.keys() else kwargs[arg] for arg in sig)
+            cumCorr = reduce(lambda x, y: y * x, corrections, 1.0)
+            print(i, cumCorr)
+            print(corrVars)
+            fargs = tuple((cumCorr * corrVars[arg]) if arg in corrVars.keys() else kwargs[arg] for arg in sig)
 
             if isinstance(fargs[0], awkward.array.base.AwkwardArray):
                 corrections.append(awkward.VirtualArray(func, args=fargs, cache=cache))

--- a/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -153,6 +153,7 @@ class FactorizedJetCorrector(object):
             #'jecs' will be formatted like [[jec_jet1 jec_jet2 ...] ...]
 
         """
+        cache = kwargs.pop('lazy_cache', None)
         corrVars = {}
         if 'JetPt' in kwargs.keys():
             corrVars['JetPt'] = kwargs['JetPt']
@@ -166,7 +167,6 @@ class FactorizedJetCorrector(object):
         corrections = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
-            print(self._levels[i])
             cumCorr = reduce(lambda x, y: y * x, corrections, 1.0)
             fargs = tuple(cumCorr * corrVars[arg] if arg in corrVars.keys() else kwargs[arg] for arg in sig)
 
@@ -175,7 +175,7 @@ class FactorizedJetCorrector(object):
             elif isinstance(fargs[0], np.ndarray):
                 corrections.append(func(*fargs))  # np is non-lazy
             elif isinstance(fargs[0], awkward1.highlevel.Array):
-                corrections.append(awkward1.virtual(func, args=fargs))
+                corrections.append(awkward1.virtual(func, args=fargs, length=len(fargs[0]), cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,7 +1,7 @@
-from .FactorizedJetCorrector import FactorizedJetCorrector, _levelre
-from .JetResolution import JetResolution
-from .JetResolutionScaleFactor import JetResolutionScaleFactor
-from .JetCorrectionUncertainty import JetCorrectionUncertainty
+from coffea.jetmet_tools.FactorizedJetCorrector import FactorizedJetCorrector, _levelre
+from coffea.jetmet_tools.JetResolution import JetResolution
+from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFactor
+from coffea.jetmet_tools.JetCorrectionUncertainty import JetCorrectionUncertainty
 
 _singletons = ['jer', 'jersf']
 _nicenames = ['JES Uncertainty Calculator',

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -1,0 +1,113 @@
+from .FactorizedJetCorrector import FactorizedJetCorrector, _levelre
+from .JetResolution import JetResolution
+from .JetResolutionScaleFactor import JetResolutionScaleFactor
+from .JetCorrectionUncertainty import JetCorrectionUncertainty
+
+_singletons = ['jer', 'jersf']
+_nicenames = ['JES Uncertainty Calculator',
+              'Jet Resolution Calculator',
+              'Jet Resolution Scale Factor Calculator']
+
+
+class JECStack(object):
+
+    def __init__(self, corrections, jec=None, junc=None, jer=None, jersf=None):
+        '''
+        corrections is a dict-like of function names and functions
+        we expect JEC names to be formatted as their filenames
+        jecs, etc. can be overridden by passing in the appropriate corrector class.
+        '''
+        self._jec = None
+        self._junc = None
+        self._jer = None
+        self._jersf = None
+
+        assembled = {'jec': {}, 'junc': {}, 'jer': {}, 'jersf': {}}
+        for key in corrections.keys():
+            if 'Uncertainty' in key:
+                assembled['junc'][key] = corrections[key]
+            elif 'SF' in key:
+                assembled['jersf'][key] = corrections[key]
+            elif 'Resolution' in key and 'SF' not in key:
+                assembled['jer'][key] = corrections[key]
+            elif len(_levelre.findall(key)) > 0:
+                assembled['jec'][key] = corrections[key]
+
+        for corrtype, nname in zip(_singletons, _nicenames):
+            Noftype = len(assembled[corrtype])
+            if Noftype > 1:
+                raise Exception(f'JEC Stack has at most one {nname}, {Noftype} are present')
+
+        if jec is None:
+            if len(assembled['jec']) == 0:
+                raise Exception('JECStack must have a JEC specified in the input corrections list or as an argument!')
+            else:
+                self._jec = FactorizedJetCorrector(**{name: corrections[name] for name in assembled['jec']})
+        else:
+            if isinstance(jec, FactorizedJetCorrector):
+                self._jec = jec
+            else:
+                raise Exception('JECStack needs a FactorizedJetCorrector passed as "jec"' +
+                                ' got object of type {}'.format(type(jec)))
+
+        if junc is None:
+            if len(assembled['junc']) > 0:
+                self._junc = JetCorrectionUncertainty(**{name: corrections[name] for name in assembled['junc']})
+        else:
+            if isinstance(junc, JetCorrectionUncertainty):
+                self._junc = junc
+            else:
+                raise Exception('JECStack needs a JetCorrectionUncertainty passed as "junc"' +
+                                ' got object of type {}'.format(type(junc)))
+
+        if jer is None:
+            if len(assembled['jer']) > 0:
+                self._jer = JetResolution(**{name: corrections[name] for name in assembled['jer']})
+        else:
+            if isinstance(jer, JetResolution):
+                self._jer = jer
+            else:
+                raise Exception('"jer" must be of type "JetResolution"' +
+                                ' got {}'.format(type(jer)))
+
+        if jersf is None:
+            if len(assembled['jersf']) > 0:
+                self._jersf = JetResolutionScaleFactor(**{name: corrections[name] for name in assembled['jersf']})
+        else:
+            if isinstance(jer, JetResolutionScaleFactor):
+                self._jersf = jersf
+            else:
+                raise Exception('"jer" must be of type "JetResolutionScaleFactor"' +
+                                ' got {}'.format(type(jer)))
+
+        if (self.jer is None) != (self.jersf is None):
+            raise Exception('Cannot apply JER-SF without an input JER, and vice-versa!')
+
+    @property
+    def blank_name_map(self):
+        out = {'massRaw', 'ptRaw', 'JetMass', 'JetPt'}
+        for name in self._jec.signature:
+            out.add(name)
+        for name in self._junc.signature:
+            out.add(name)
+        for name in self._jer.signature:
+            out.add(name)
+        for name in self._jersf.signature:
+            out.add(name)
+        return {name: None for name in out}
+
+    @property
+    def jec(self):
+        return self._jec
+
+    @property
+    def junc(self):
+        return self._junc
+
+    @property
+    def jer(self):
+        return self._jer
+
+    @property
+    def jersf(self):
+        return self._jersf

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -4,8 +4,7 @@ from coffea.jetmet_tools.JetResolutionScaleFactor import JetResolutionScaleFacto
 from coffea.jetmet_tools.JetCorrectionUncertainty import JetCorrectionUncertainty
 
 _singletons = ['jer', 'jersf']
-_nicenames = ['JES Uncertainty Calculator',
-              'Jet Resolution Calculator',
+_nicenames = ['Jet Resolution Calculator',
               'Jet Resolution Scale Factor Calculator']
 
 
@@ -40,7 +39,7 @@ class JECStack(object):
 
         if jec is None:
             if len(assembled['jec']) == 0:
-                raise Exception('JECStack must have a JEC specified in the input corrections list or as an argument!')
+                self._jec = None  # allow for no JEC
             else:
                 self._jec = FactorizedJetCorrector(**{name: corrections[name] for name in assembled['jec']})
         else:
@@ -89,8 +88,9 @@ class JECStack(object):
                'METpt', 'METphi', 'METx', 'METy', 'JETx', 'JETy',
                'xMETRaw', 'yMETRaw',
                'UnClusteredEnergyDeltaX', 'UnClusteredEnergyDeltaY'}
-        for name in self._jec.signature:
-            out.add(name)
+        if self._jec is not None:
+            for name in self._jec.signature:
+                out.add(name)
         for name in self._junc.signature:
             out.add(name)
         for name in self._jer.signature:

--- a/coffea/jetmet_tools/JECStack.py
+++ b/coffea/jetmet_tools/JECStack.py
@@ -85,7 +85,10 @@ class JECStack(object):
 
     @property
     def blank_name_map(self):
-        out = {'massRaw', 'ptRaw', 'JetMass', 'JetPt'}
+        out = {'massRaw', 'ptRaw', 'JetMass', 'JetPt',
+               'METpt', 'METphi', 'METx', 'METy', 'JETx', 'JETy',
+               'xMETRaw', 'yMETRaw',
+               'UnClusteredEnergyDeltaX', 'UnClusteredEnergyDeltaY'}
         for name in self._jec.signature:
             out.add(name)
         for name in self._junc.signature:

--- a/coffea/jetmet_tools/JetCorrectionUncertainty.py
+++ b/coffea/jetmet_tools/JetCorrectionUncertainty.py
@@ -158,7 +158,7 @@ class JetCorrectionUncertainty(object):
             args = tuple(kwargs[input] for input in sig)
 
             if isinstance(args[0], awkward.array.base.AwkwardArray):
-                uncs.append(awkward.VirtualArray(func, args=args))
+                uncs.append(awkward.VirtualArray(func, args=args, cache=cache))
             elif isinstance(args[0], np.ndarray):
                 uncs.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):

--- a/coffea/jetmet_tools/JetCorrectionUncertainty.py
+++ b/coffea/jetmet_tools/JetCorrectionUncertainty.py
@@ -151,6 +151,7 @@ class JetCorrectionUncertainty(object):
             #in a zip iterator
 
         """
+        cache = kwargs.pop('lazy_cache', None)
         uncs = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
@@ -161,7 +162,7 @@ class JetCorrectionUncertainty(object):
             elif isinstance(args[0], np.ndarray):
                 uncs.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):
-                uncs.append(awkward1.virtual(func, args=args))
+                uncs.append(awkward1.virtual(func, args=args, length=len(args[0]), cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JetResolution.py
+++ b/coffea/jetmet_tools/JetResolution.py
@@ -135,6 +135,7 @@ class JetResolution(object):
             jrs = reso.getResolution(JetProperty1=jet.property1,...)
 
         """
+        cache = kwargs.pop('lazy_cache', None)
         resos = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
@@ -145,7 +146,7 @@ class JetResolution(object):
             elif isinstance(args[0], np.ndarray):
                 resos.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):
-                resos.append(awkward1.virtual(func, args=args))
+                resos.append(awkward1.virtual(func, args=args, length=len(args[0]), cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JetResolution.py
+++ b/coffea/jetmet_tools/JetResolution.py
@@ -142,7 +142,7 @@ class JetResolution(object):
             args = tuple(kwargs[input] for input in sig)
 
             if isinstance(args[0], awkward.array.base.AwkwardArray):
-                resos.append(awkward.VirtualArray(func, args=args))
+                resos.append(awkward.VirtualArray(func, args=args, cache=cache))
             elif isinstance(args[0], np.ndarray):
                 resos.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):

--- a/coffea/jetmet_tools/JetResolution.py
+++ b/coffea/jetmet_tools/JetResolution.py
@@ -136,6 +136,7 @@ class JetResolution(object):
 
         """
         cache = kwargs.pop('lazy_cache', None)
+        form = kwargs.pop('form', None)
         resos = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
@@ -146,7 +147,7 @@ class JetResolution(object):
             elif isinstance(args[0], np.ndarray):
                 resos.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):
-                resos.append(awkward1.virtual(func, args=args, length=len(args[0]), cache=cache))
+                resos.append(awkward1.virtual(func, args=args, length=len(args[0]), form=form, cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JetResolutionScaleFactor.py
+++ b/coffea/jetmet_tools/JetResolutionScaleFactor.py
@@ -135,6 +135,7 @@ class JetResolutionScaleFactor(object):
             jersfs = jersf.getScaleFactor(JetProperty1=jet.property1,...)
 
         """
+        cache = kwargs.pop('lazy_cache', None)
         sfs = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
@@ -145,7 +146,7 @@ class JetResolutionScaleFactor(object):
             elif isinstance(args[0], np.ndarray):
                 sfs.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):
-                sfs.append(awkward1.virtual(func, args=args))
+                sfs.append(awkward1.virtual(func, args=args, length=len(args[0]), cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JetResolutionScaleFactor.py
+++ b/coffea/jetmet_tools/JetResolutionScaleFactor.py
@@ -136,6 +136,7 @@ class JetResolutionScaleFactor(object):
 
         """
         cache = kwargs.pop('lazy_cache', None)
+        form = kwargs.pop('form', None)
         sfs = []
         for i, func in enumerate(self._funcs):
             sig = func.signature
@@ -146,7 +147,7 @@ class JetResolutionScaleFactor(object):
             elif isinstance(args[0], np.ndarray):
                 sfs.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):
-                sfs.append(awkward1.virtual(func, args=args, length=len(args[0]), cache=cache))
+                sfs.append(awkward1.virtual(func, args=args, length=len(args[0]), form=form, cache=cache))
             else:
                 raise Exception('Unknown array library for inputs.')
 

--- a/coffea/jetmet_tools/JetResolutionScaleFactor.py
+++ b/coffea/jetmet_tools/JetResolutionScaleFactor.py
@@ -142,7 +142,7 @@ class JetResolutionScaleFactor(object):
             args = tuple(kwargs[input] for input in sig)
 
             if isinstance(args[0], awkward.array.base.AwkwardArray):
-                sfs.append(awkward.VirtualArray(func, args=args))
+                sfs.append(awkward.VirtualArray(func, args=args, cache=cache))
             elif isinstance(args[0], np.ndarray):
                 sfs.append(func(*args))  # np is non-lazy
             elif isinstance(args[0], awkward1.highlevel.Array):

--- a/coffea/jetmet_tools/__init__.py
+++ b/coffea/jetmet_tools/__init__.py
@@ -8,6 +8,9 @@ from .JetResolution import JetResolution
 from .JetResolutionScaleFactor import JetResolutionScaleFactor
 from .JetCorrectionUncertainty import JetCorrectionUncertainty
 from .JetTransformer import JetTransformer
+
+from .JECStack import JECStack
+from .CorrectedJets import CorrectedJets
 # from .MetUncertaintyCalculator import calculateType1MetXY
 
 __all__ = [
@@ -16,4 +19,6 @@ __all__ = [
     'JetResolutionScaleFactor',
     'JetCorrectionUncertainty',
     'JetTransformer',
+    'JECStack',
+    'CorrectedJets'
 ]

--- a/coffea/jetmet_tools/__init__.py
+++ b/coffea/jetmet_tools/__init__.py
@@ -11,7 +11,7 @@ from .JetTransformer import JetTransformer
 
 from .JECStack import JECStack
 from .CorrectedJetsFactory import CorrectedJetsFactory
-# from .MetUncertaintyCalculator import calculateType1MetXY
+from .CorrectedMETFactory import CorrectedMETFactory
 
 __all__ = [
     'FactorizedJetCorrector',
@@ -20,5 +20,6 @@ __all__ = [
     'JetCorrectionUncertainty',
     'JetTransformer',
     'JECStack',
-    'CorrectedJetsFactory'
+    'CorrectedJetsFactory',
+    'CorrectedMETFactory'
 ]

--- a/coffea/jetmet_tools/__init__.py
+++ b/coffea/jetmet_tools/__init__.py
@@ -10,7 +10,7 @@ from .JetCorrectionUncertainty import JetCorrectionUncertainty
 from .JetTransformer import JetTransformer
 
 from .JECStack import JECStack
-from .CorrectedJets import CorrectedJets
+from .CorrectedJetsFactory import CorrectedJetsFactory
 # from .MetUncertaintyCalculator import calculateType1MetXY
 
 __all__ = [
@@ -20,5 +20,5 @@ __all__ = [
     'JetCorrectionUncertainty',
     'JetTransformer',
     'JECStack',
-    'CorrectedJets'
+    'CorrectedJetsFactory'
 ]

--- a/coffea/lookup_tools/jec_uncertainty_lookup.py
+++ b/coffea/lookup_tools/jec_uncertainty_lookup.py
@@ -99,7 +99,7 @@ class jec_uncertainty_lookup(lookup_base):
         )
 
         # get clamp values and clip the inputs
-        outs = np.ones(shape=(args[0].size, 2), dtype=np.float)
+        outs = np.ones(shape=(args[0].size, 2), dtype=np.float32)
         for i in np.unique(dim1_indices):
             mask = np.where(dim1_indices == i)
             vals = np.clip(

--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -65,17 +65,17 @@ def _parse_jme_formatted_file(
     offset = 1
     for i in range(nBinnedVars):
         columns.extend(["%s%s" % (layout[i + offset], mm) for mm in minMax])
-        dtypes.extend(["<f8", "<f8"])
+        dtypes.extend(["<f4", "<f4"])
     columns.append("NVars")
     dtypes.append("<i8")
     offset += nBinnedVars + 1
     if not interpolatedFunc:
         for i in range(nEvalVars):
             columns.extend(["%s%s" % (layout[i + offset], mm) for mm in minMax])
-            dtypes.extend(["<f8", "<f8"])
+            dtypes.extend(["<f4", "<f4"])
     for i in range(nParms):
         columns.append("p%i" % i)
-        dtypes.append("<f8")
+        dtypes.append("<f4")
 
     for f in funcs_to_cap:
         formula = formula.replace(f, f.upper())
@@ -96,7 +96,7 @@ def _parse_jme_formatted_file(
         nParms = pars.shape[1] - len(columns)
         for i in range(nParms):
             columns.append("p%i" % i)
-            dtypes.append("<f8")
+            dtypes.append("<f4")
         pars = np.core.records.fromarrays(
             pars.transpose(), names=columns, formats=dtypes
         )
@@ -413,11 +413,11 @@ def convert_effective_area_file(eaFilePath):
     offset = 1
     for i in range(nBinnedVars):
         columns.extend(["%s%s" % (layout[i + offset], mm) for mm in minMax])
-        dtypes.extend(["<f8", "<f8"])
+        dtypes.extend(["<f4", "<f4"])
     offset += nBinnedVars + 1
     for i in range(nEvalVars):
         columns.append("%s" % (layout[i + offset]))
-        dtypes.append("<f8")
+        dtypes.append("<f4")
 
     pars = np.genfromtxt(
         eaFilePath,

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -7,7 +7,7 @@ from coffea.util import awkward
 from coffea.util import awkward1
 from coffea.util import numpy as np
 
-import pytest, time, pyinstrument
+import pytest, time # , pyinstrument
 
 from dummy_distributions import dummy_jagged_eta_pt, dummy_four_momenta
 
@@ -344,20 +344,15 @@ def test_jet_transformer():
         assert('phi_'+unc+'_up' in met.columns)
 
 
-@pytest.mark.parametrize("awkwardlib", ["ak1"])#, awkwardlibs)
-def test_corrected_jets_factory(awkwardlib):
+def test_corrected_jets_factory():
     import os
-    from coffea.jetmet_tools import CorrectedJetsFactory, JECStack
+    from coffea.jetmet_tools import CorrectedJetsFactory, CorrectedMETFactory, JECStack
 
     events = None
     cache = {}
-    if awkwardlib == "ak0":
-        from coffea.nanoaod import NanoEvents
-        events = NanoEvents.from_file(os.path.abspath('tests/samples/nano_dy.root'))
-    elif awkwardlib == "ak1":
-        from coffea.nanoevents import NanoEventsFactory
-        factory = NanoEventsFactory.from_file(os.path.abspath('tests/samples/nano_dy.root'), runtime_cache=cache)
-        events = factory.events()
+    from coffea.nanoevents import NanoEventsFactory
+    factory = NanoEventsFactory.from_file(os.path.abspath('tests/samples/nano_dy.root'))
+    events = factory.events()
     
     jec_stack_names = ['Summer16_23Sep2016V3_MC_L1FastJet_AK4PFPuppi',
                        'Summer16_23Sep2016V3_MC_L2Relative_AK4PFPuppi',
@@ -382,25 +377,15 @@ def test_corrected_jets_factory(awkwardlib):
     
     jets['pt_raw'] = jets['rawFactor'] * jets['pt']
     jets['mass_raw'] = jets['rawFactor'] * jets['mass']
-    if awkwardlib == "ak0":
-        jets['pt_gen'] = jets.matched_gen.pt.fillna(0.)
-        jets['rho'] = jets.pt.tojagged(events.fixedGridRhoFastjetAll)
-    if awkwardlib == "ak1":
-        jets['pt_gen'] = awkward1.values_astype(awkward1.fill_none(jets.matched_gen.pt, 0), np.float32)
-        print(jets['pt_gen'].layout)
-        jets['rho'] = awkward1.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
+    jets['pt_gen'] = awkward1.values_astype(awkward1.fill_none(jets.matched_gen.pt, 0), np.float32)
+    print(jets['pt_gen'].layout)
+    jets['rho'] = awkward1.broadcast_arrays(events.fixedGridRhoFastjetAll, jets.pt)[0]
     name_map['ptGenJet'] = 'pt_gen'
     name_map['ptRaw'] = 'pt_raw'
     name_map['massRaw'] = 'mass_raw'
     name_map['Rho'] = 'rho'
     
-    events_cache = None
-    if awkwardlib == "ak0":
-        print(jets.columns)
-        events_cache = events._cache
-    if awkwardlib == "ak1":
-        print(awkward1.fields(jets))
-        events_cache = events.caches[0]
+    events_cache = events.caches[0]
     
     print(name_map)
     
@@ -408,16 +393,18 @@ def test_corrected_jets_factory(awkwardlib):
     jet_factory = CorrectedJetsFactory(name_map, jec_stack)
     toc = time.time()
     
-    print('setup time =', toc-tic)
+    print('setup corrected jets time =', toc-tic)
     
     tic = time.time()
-    prof = pyinstrument.Profiler()
-    prof.start()
+    #prof = pyinstrument.Profiler()
+    #prof.start()
     corrected_jets = jet_factory.build(jets, lazy_cache=events_cache)
-    prof.stop()
+    #prof.stop()
     toc = time.time()
 
     print('corrected_jets build time =', toc-tic)
+    
+    #sprint(prof.output_text(unicode=True, color=True, show_all=True))
     
     tic = time.time()
     for unc in jet_factory.uncertainties():
@@ -425,33 +412,44 @@ def test_corrected_jets_factory(awkwardlib):
         print(corrected_jets[unc].up.pt)
         print(corrected_jets[unc].down.pt)
     toc = time.time()
+
+    print('build all jet variations =', toc-tic)
+
+    name_map['METpt'] = 'pt'
+    name_map['METphi'] = 'phi'
+    name_map['METx'] = 'x'
+    name_map['METy'] = 'y'
+    name_map['JETx'] = 'x'
+    name_map['JETy'] = 'y'
+    name_map['xMETRaw'] = 'x_raw'
+    name_map['yMETRaw'] = 'y_raw'
+    name_map['UnClusteredEnergyDeltaX'] = 'MetUnclustEnUpDeltaX'
+    name_map['UnClusteredEnergyDeltaY'] = 'MetUnclustEnUpDeltaY'
+
+    tic = time.time()
+    met_factory = CorrectedMETFactory(name_map)
+    toc = time.time()
     
-    #print(corrected_jets['JER'].down.type)
-    print(prof.output_text(unicode=True, color=True, show_all=True))
-   
-    #print(corrected_jets['JER'].down.pt)
-    #print(corrected_jets.pt)
-    #print(corrected_jets['JER'].up.pt)
-    
-    #tic = time.time()
-    #uncertainty_handler = jet_factory.build_uncertainties(corrected_jets)#, lazy_cache=events_cache)
-    #toc = time.time()
-    
-    #print('uncertainty_handler build time =', toc-tic)
-    
+    print('setup corrected MET time =', toc-tic)
+
+
+    met = events.MET
+    tic = time.time()
     #prof = pyinstrument.Profiler()
     #prof.start()
-
-    #tic = time.time()
-    #for key in uncertainty_handler.keys():
-    #    uncertainty = uncertainty_handler[key]
-    #    up_var = uncertainty.up
-    #    down_var = uncertainty.down
-    #toc = time.time()
-    
+    corrected_met = met_factory.build(met, corrected_jets, lazy_cache=events_cache)
     #prof.stop()
-    #print(prof.output_text(unicode=True, color=True, show_all=True))
-    
-    print('build all variations =', toc-tic)
+    toc = time.time()
 
+    #print(prof.output_text(unicode=True, color=True, show_all=True))
+
+    print('corrected_met build time =', toc-tic)
+
+    tic = time.time()
+    for unc in (jet_factory.uncertainties() + met_factory.uncertainties()):
+        print(unc)
+        print(corrected_met[unc].up.pt)
+        print(corrected_met[unc].down.pt)
+    toc = time.time()
     
+    print('build all met variations =', toc-tic)

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -344,7 +344,7 @@ def test_jet_transformer():
         assert('phi_'+unc+'_up' in met.columns)
 
 
-@pytest.mark.parametrize("awkwardlib", awkwardlibs)
+@pytest.mark.parametrize("awkwardlib", ["ak1"])#, awkwardlibs)
 def test_corrected_jets_factory(awkwardlib):
     import os
     from coffea.jetmet_tools import CorrectedJetsFactory, JECStack

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -7,7 +7,7 @@ from coffea.util import awkward
 from coffea.util import awkward1
 from coffea.util import numpy as np
 
-import pytest
+import pytest, time
 
 from dummy_distributions import dummy_jagged_eta_pt, dummy_four_momenta
 
@@ -173,14 +173,16 @@ def test_jet_correction_uncertainty_sources(awkwardlib):
     juncs = junc.getUncertainty(JetEta=test_eta, JetPt=test_pt)
     
     juncs_jag = list(junc.getUncertainty(JetEta=test_eta_jag, JetPt=test_pt_jag))
-    
+
     for i, (level, corrs) in enumerate(juncs):
         assert(level in levels)
         assert(corrs.shape[0] == test_eta.shape[0])
+        tic = time.time()
         if awkwardlib == "ak1":
             assert(awkward1.all(corrs == awkward1.flatten(juncs_jag[i][1])))
         if awkwardlib == "ak0":
             assert((corrs == juncs_jag[i][1].flatten()).all())
+        toc = time.time()
 
 
 @pytest.mark.parametrize("awkwardlib", awkwardlibs)

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -7,7 +7,7 @@ from coffea.util import awkward
 from coffea.util import awkward1
 from coffea.util import numpy as np
 
-import pytest, time, pyinstrument
+import pytest, time # , pyinstrument
 
 from dummy_distributions import dummy_jagged_eta_pt, dummy_four_momenta
 
@@ -410,14 +410,14 @@ def test_corrected_jets_factory(awkwardlib):
     print('setup time =', toc-tic)
     
     tic = time.time()
-    prof = pyinstrument.Profiler()
-    prof.start()
+    #prof = pyinstrument.Profiler()
+    #prof.start()
     corrected_jets = jet_factory.build(jets)#, lazy_cache=events_cache)
-    prof.stop()
+    #prof.stop()
     toc = time.time()
 
     print('corrected_jets build time =', toc-tic)
-    print(prof.output_text(unicode=True, color=True, show_all=True))
+    #print(prof.output_text(unicode=True, color=True, show_all=True))
    
     print(type(jets))
     print(type(corrected_jets))


### PR DESCRIPTION
This is the first of two PRs.

1 - make it so the current tools are agnostics to underlying awkward version
2 - integrate the JetMET tools with nanoaod/nanoevents in a nice way.

This PR implements:

- [x] Changes to the low level JetMET tools that make them not care about array library type (and also removes all in-place operations)
- [x] Introduces a new tool for managing JECs, leaving the JetTransformer as it is. 
- [x] Ditto for MET
- [x] Allow the stack to work without a FactorizedJetCorrector defined.