### PR TITLE
fix: protect for "compound" name aka Jet and JetPF

### DIFF
--- a/coffea/nanoevents/schemas.py
+++ b/coffea/nanoevents/schemas.py
@@ -217,7 +217,7 @@ class NanoAODSchema(BaseSchema):
         # Create global index virtual arrays for indirection
         idxbranches = [k for k in branch_forms if "Idx" in k]
         for name in collections:
-            indexers = [k for k in idxbranches if k.startswith(name)]
+            indexers = [k for k in idxbranches if k.startswith(name + "_")]
             for k in indexers:
                 target = k[len(name) + 1 : k.find("Idx")]
                 target = target[0].upper() + target[1:]


### PR DESCRIPTION
Minor bugfix
- NanoAODSchema indexing will crash if any collection names are a subset of others like `Jet` and `JetPFCands` 