### PR TITLE
Update to reflect awkward1 0.4.3 breaking changes

### DIFF
--- a/coffea/lookup_tools/lookup_base.py
+++ b/coffea/lookup_tools/lookup_base.py
@@ -42,7 +42,7 @@ class lookup_base(object):
         ]
         out = awkward1._util.broadcast_and_apply(args, getfunction, behavior)
         assert isinstance(out, tuple) and len(out) == 1
-        return awkward1._util.wrap(out[0], behavior)
+        return awkward1._util.wrap(out[0], behavior=behavior)
 
     def _call_ak0(self, inputs, **kwargs):
         offsets = None

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -165,7 +165,7 @@ class NanoEventsFactory:
                 sep="/",
                 lazy=True,
                 lazy_lengths=len(self),
-                lazy_cache="attach" if self._cache is None else self._cache,
+                lazy_cache="new" if self._cache is None else self._cache,
                 behavior=behavior,
             )
             self._events = weakref.ref(events)

--- a/coffea/nanoevents/methods/base.py
+++ b/coffea/nanoevents/methods/base.py
@@ -60,19 +60,19 @@ class NanoCollection:
         """
         if isinstance(index, int):
             out = self._content()[index]
-        else:
+            return awkward1.Record(out, behavior=self.behavior)
 
-            def flat_take(layout):
-                idx = awkward1.Array(layout)
-                return self._content()[idx.mask[idx >= 0]]
+        def flat_take(layout):
+            idx = awkward1.Array(layout)
+            return self._content()[idx.mask[idx >= 0]]
 
-            def descend(layout, depth):
-                if layout.purelist_depth == 1:
-                    return lambda: flat_take(layout)
+        def descend(layout, depth):
+            if layout.purelist_depth == 1:
+                return lambda: flat_take(layout)
 
-            (index,) = awkward1.broadcast_arrays(index)
-            out = awkward1._util.recursively_apply(index.layout, descend)
-        return awkward1._util.wrap(out, self.behavior, cache=self.cache)
+        (index,) = awkward1.broadcast_arrays(index)
+        out = awkward1._util.recursively_apply(index.layout, descend)
+        return awkward1.Array(out, behavior=self.behavior)
 
     def _events(self):
         """Internal method to get the originally-constructed NanoEvents

--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -126,7 +126,7 @@ class TwoVector:
             with_name="TwoVector",
             highlevel=False,
         )
-        return awkward1._util.wrap(out, cache=self.cache, behavior=self.behavior)
+        return awkward1.Array(out, behavior=self.behavior)
 
     @awkward1.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):
@@ -261,7 +261,7 @@ class ThreeVector(TwoVector):
             with_name="ThreeVector",
             highlevel=False,
         )
-        return awkward1._util.wrap(out, cache=self.cache, behavior=self.behavior)
+        return awkward1.Array(out, behavior=self.behavior)
 
     @awkward1.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):
@@ -391,7 +391,7 @@ class LorentzVector(ThreeVector):
             with_name="LorentzVector",
             highlevel=False,
         )
-        return awkward1._util.wrap(out, cache=self.cache, behavior=self.behavior)
+        return awkward1.Array(out, behavior=self.behavior)
 
     @awkward1.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def get_description():
 INSTALL_REQUIRES = ['awkward>=0.12.20',
                     'uproot-methods>=0.7.3',
                     'uproot>=3.11.0',
-                    'awkward1>=0.3.0',
+                    'awkward1>=0.4.3',
                     'uproot4>=0.0.17',
                     'matplotlib>=3',
                     'numba>=0.50.0',


### PR DESCRIPTION
In longer term, we should figure out how to remove remaining uses of private awkward1 functions:
```
coffea/nanoevents/methods/base.py:        return awkward1._util.recursively_apply(self.layout, descend)
coffea/nanoevents/methods/base.py:        out = awkward1._util.recursively_apply(index.layout, descend)
coffea/lookup_tools/lookup_base.py:        behavior = awkward1._util.behaviorof(*args)
coffea/lookup_tools/lookup_base.py:        out = awkward1._util.broadcast_and_apply(args, getfunction, behavior)
coffea/lookup_tools/lookup_base.py:        return awkward1._util.wrap(out[0], behavior=behavior)
```
The bottom three are due to https://github.com/CoffeaTeam/coffea/pull/344#discussion_r483833514 and the remaining ones need a feature request for public `recursively_apply`. FYI @jpivarski 