### PR TITLE
Add entrystart and entrystop to events metadata

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -14,6 +14,7 @@ import uproot4
 import subprocess
 import re
 import os
+import uuid
 from tqdm.auto import tqdm
 from collections import defaultdict
 from cachetools import LRUCache
@@ -797,7 +798,7 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                 'treename': item.treename,
                 'entrystart': item.entrystart,
                 'entrystop': item.entrystop,
-                'fileuuid': list(item.fileuuid)  # list to be JSON serializable
+                'fileuuid': str(uuid.UUID(bytes=item.fileuuid))
             }
             with filecontext as file:
                 if schema is None:

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -798,6 +798,8 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                     events = LazyDataFrame(tree, item.entrystart, item.entrystop, flatten=flatten)
                     events['dataset'] = item.dataset
                     events['filename'] = item.filename
+                    events['entrystart'] = item.entrystart
+                    events['entrystop'] = item.entrystop,
                 elif schema is NanoEvents:
                     # To deprecate
                     events = NanoEvents.from_file(
@@ -808,6 +810,8 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                         metadata={
                             'dataset': item.dataset,
                             'filename': item.filename,
+                            'entrystart': item.entrystart,
+                            'entrystop': item.entrystop,
                         },
                         cache=_get_cache(cachestrategy),
                     )
@@ -823,6 +827,8 @@ def _work_function(item, processor_instance, flatten=False, savemetrics=False,
                         metadata={
                             'dataset': item.dataset,
                             'filename': item.filename,
+                            'entrystart': item.entrystart,
+                            'entrystop': item.entrystop,
                         },
                         access_log=materialized,
                     )


### PR DESCRIPTION
As discussed on the mailing list, here are my suggested additions.
This just adds the `entrystart` and `entrystop` numbers to the events metadata, which can be very useful for debugging.
I noticed at this point one might also add `treename` and `fileuuid`, as these are the only fields of `WorkItem` that would still be missing from the metadata. Do you think these should be added?
Jim Pivarski suggested using uproot4 Report object. I think it would be nice to have, however the scope is missing a reference to the tree and it doesn't know the global offset. Plus a tree object isn't picklable, which I could imagine to produce problems here.