### PR TITLE
Deprecation warnings for awkward 0

### DIFF
--- a/coffea/analysis_objects/JaggedCandidateMethods.py
+++ b/coffea/analysis_objects/JaggedCandidateMethods.py
@@ -1,8 +1,8 @@
 import uproot_methods
 
 import math
-from ..util import awkward
-from ..util import numpy as np
+from coffea.util import awkward, deprecate_awkward0_util
+from coffea.util import numpy as np
 
 
 # functions to quickly cash useful quantities
@@ -153,6 +153,8 @@ class JaggedCandidateMethods(awkward.Methods):
                                                                ...)
 
         """
+        deprecate_awkward0_util(cls)
+
         items = kwargs
         argkeys = items.keys()
         p4 = None

--- a/coffea/arrays/Builder.py
+++ b/coffea/arrays/Builder.py
@@ -1,6 +1,7 @@
 import awkward
 
-from ..util import awkward as util_awkward
+from coffea.util import awkward as util_awkward
+from coffea.util import deprecate_awkward0_util
 import uproot_methods
 from uproot_methods.classes.TLorentzVector import ArrayMethods, TLorentzVectorArray, TLorentzVector
 
@@ -60,6 +61,8 @@ class SaiyanArray(SaiyanCommonMethods, TLorentzVectorArray):
 
 
 def Initialize(items):
+    deprecate_awkward0_util('Saiyan array initializer and classes')
+
     argkeys = items.keys()
     p4 = None
 

--- a/coffea/jetmet_tools/JetTransformer.py
+++ b/coffea/jetmet_tools/JetTransformer.py
@@ -3,7 +3,8 @@ from .JetResolution import JetResolution
 from .JetResolutionScaleFactor import JetResolutionScaleFactor
 from .JetCorrectionUncertainty import JetCorrectionUncertainty
 
-from ..analysis_objects.JaggedCandidateArray import JaggedCandidateArray
+from coffea.analysis_objects.JaggedCandidateArray import JaggedCandidateArray
+from coffea.util import deprecate_awkward0_util
 
 import numpy as np
 from uproot_methods.classes.TLorentzVector import (
@@ -76,6 +77,7 @@ class JetTransformer(object):
 
     """
     def __init__(self, jec=None, junc=None, jer=None, jersf=None):
+        deprecate_awkward0_util(type(self))
         if jec is None:
             raise Exception('JetTransformer must have "jec" specified as an argument!')
         if not isinstance(jec, FactorizedJetCorrector):

--- a/coffea/lookup_tools/lookup_base.py
+++ b/coffea/lookup_tools/lookup_base.py
@@ -3,6 +3,8 @@ import awkward
 import awkward1
 import numbers
 
+from coffea.util import deprecate_detected_awkward0
+
 
 class lookup_base(object):
     """Base class for all objects that do some sort of value or function lookup"""
@@ -11,6 +13,7 @@ class lookup_base(object):
         pass
 
     def __call__(self, *args, **kwargs):
+        deprecate_detected_awkward0(*args, **kwargs)
         if all(isinstance(x, (numpy.ndarray, numbers.Number)) for x in args):
             return self._evaluate(*args, **kwargs)
         elif any(isinstance(x, awkward.JaggedArray) for x in args):

--- a/coffea/nanoaod/nanoevents.py
+++ b/coffea/nanoaod/nanoevents.py
@@ -3,7 +3,7 @@ import uproot
 import awkward
 from .methods import collection_methods
 from .util import _mixin
-from ..util import _hex, _ascii
+from ..util import _hex, _ascii, deprecate_awkward0_util
 
 
 class NanoCollection(awkward.VirtualArray):
@@ -55,6 +55,7 @@ class NanoCollection(awkward.VirtualArray):
 
         Returns a NanoCollection object, possibly mixed in with methods.
         '''
+        deprecate_awkward0_util(cls)
         outtype = cls._get_mixin(methods)
         jagged = 'n' + name in arrays.keys()
         columns = {k[len(name) + 1:]: arrays[k] for k in arrays.keys() if k.startswith(name + '_')}
@@ -241,6 +242,7 @@ class NanoEvents(awkward.Table):
 
         Returns a NanoEvents object
         '''
+        deprecate_awkward0_util(cls)
         arrays = dict(arrays)
         for k in arrays:
             if isinstance(arrays[k], awkward.VirtualArray):

--- a/coffea/processor/dataframe.py
+++ b/coffea/processor/dataframe.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableMapping
 import awkward1
 import uproot4
+from coffea.util import deprecate_detected_awkward0
 
 
 class LazyDataFrame(MutableMapping):
@@ -57,6 +58,7 @@ class LazyDataFrame(MutableMapping):
             if self._flatten and isinstance(awkward1.type(array).type, awkward1.types.ListType):
                 array = awkward1.flatten(array)
             array = awkward1.to_awkward0(array)
+            deprecate_detected_awkward0(array)
             self._dict[key] = array
             return self._dict[key]
         else:
@@ -140,7 +142,9 @@ class PreloadedDataFrame(MutableMapping):
 
     def __getitem__(self, key):
         self._accessed.add(key)
-        return self._dict[key]
+        out = self._dict[key]
+        deprecate_detected_awkward0(out)
+        return out
 
     def __getattr__(self, key):
         if key.startswith("_"):

--- a/coffea/util.py
+++ b/coffea/util.py
@@ -91,7 +91,7 @@ def deprecate(exception, version, date=None):
         else:
             date = " (target date: " + date + ")"
         message = """In coffea version {0}{1}, this will be an error.
-(Set ak.deprecations_as_errors = True to get a stack trace now.)
+(Set awkward1.deprecations_as_errors = True to get a stack trace now.)
 {2}: {3}""".format(
             version, date, type(exception).__name__, str(exception)
         )

--- a/coffea/util.py
+++ b/coffea/util.py
@@ -13,8 +13,7 @@ nb = numba
 
 import lz4.frame
 import cloudpickle
-
-supported_column_file_types = {b'root': 'root', b'PAR1': 'parquet'}
+import warnings
 
 
 def load(filename):
@@ -74,3 +73,48 @@ def _ensure_flat(array, allow_missing=False):
     if isinstance(array, awkward1.Array):
         array = awkward1.to_numpy(array, allow_missing=allow_missing)
     return array
+
+
+# lifted from awkward1 - https://github.com/scikit-hep/awkward-1.0/blob/5fe31a916bf30df6c2ea10d4094f6f1aefcf3d0c/src/awkward/_util.py#L47-L61 # noqa
+# we will drive the deprecations as errors using the awkward1 flag for it
+# since this is largely an awkward1 related campaign
+class Awkward0Warning(FutureWarning):
+    pass
+
+
+def deprecate(exception, version, date=None):
+    if awkward1.deprecations_as_errors:
+        raise exception
+    else:
+        if date is None:
+            date = ""
+        else:
+            date = " (target date: " + date + ")"
+        message = """In coffea version {0}{1}, this will be an error.
+(Set ak.deprecations_as_errors = True to get a stack trace now.)
+{2}: {3}""".format(
+            version, date, type(exception).__name__, str(exception)
+        )
+        warnings.warn(message, Awkward0Warning)
+
+
+# if we have found awkward0 being passed to coffea, complain
+def deprecate_detected_awkward0(*args, **kwargs):
+    has_ak0 = any([isinstance(arg, awkward.array.base.AwkwardArray) for arg in args])
+    has_ak0 |= any([isinstance(arg, awkward.array.base.AwkwardArray) for arg in kwargs.values()])
+
+    # special case, if no args or kwargs given just emit!
+    if len(args) == len(kwargs) == 0:
+        has_ak0 = True
+
+    if has_ak0:
+        e = TypeError('Use of awkward 0.x arrays in coffea is deprecated!\nIn coming releases'
+                      ' coffea will only accept awkward > 1.0 arrays and awkward0-only classes'
+                      ' will be removed.')
+        deprecate(e, '0.7', date='January 2021')
+
+
+def deprecate_awkward0_util(item):
+    e = TypeError('{0} relies exclusively on awkward 0.x and will be removed in upcoming'
+                  ' versions of coffea!'.format(item))
+    deprecate(e, '0.7', date='January 2021')


### PR DESCRIPTION
With a target date for changing to errors ~January 2021
The warnings can be flipped to errors with the `awkward1.deprecations_as_errors` flag.