### PR TITLE
WQ Executor Fixups

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -482,7 +482,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
                             t.resources_measured.wall_time / 1000000))
 
                 if output and t.output:
-                    print('Task id #{} output:\n{}', format(t.id, t.output))
+                    print('Task id #{} output:\n{}'.format(t.id, t.output))
 
                 if t.result != 0:
                     print('Task id #{} failed with code: {}'.format(t.id, t.result))

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -267,20 +267,36 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             Set to ``None`` for no compression.
 
         # work queue specific options:
-        environment-file : str
-            Python environment to use. Required.
         cores : int
             Number of cores for work queue task. If unset, use a whole worker.
         memory : int
             Amount of memory (in MB) for work queue task. If unset, use a whole worker.
         disk : int
             Amount of disk space (in MB) for work queue task. If unset, use a whole worker.
+
         resources-mode : one of 'fixed', or 'auto'. Default is 'fixed'.
             - 'fixed': allocate cores, memory, and disk specified for each task.
             - 'auto': use cores, memory, and disk as maximum values to allocate.
                       Useful when the resources used by a task are not known, as
                       it lets work queue find an efficient value for maximum
                       throughput.
+        resource-monitor : bool
+            If true, (false is the default) turns on resource monitoring for Work Queue.
+
+        master-name : str
+            Name to refer to this work queue master.
+            Sets port to 0 (any available port) if port not given.
+        port : int
+            Port number for work queue master program. Defaults to 9123 if
+            master-name not given.
+        password-file: str
+            Location of a file containing a password used to authenticate workers.
+
+        environment-file : str
+            Python environment to use. Required.
+        wrapper : str
+            Wrapper script to run/open python environment tarball. Defaults to python_package_run found in PATH.
+
         verbose : bool
             If true, emit a message on each task submission and completion.
             Default is false.
@@ -290,23 +306,11 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             Filename for tasks statistics output
         transactions-log : str
             Filename for tasks lifetime reports output
-        master-name : str
-            Name to refer to this work queue master.
-            Sets port to 0 (any available port) if port not given.
-        port : int
-            Port number for work queue master program. Defaults to 9123 if
-            master-name not given.
-        wrapper : str
-            Wrapper script to run/open python environment tarball. Defaults to python_package_run found in PATH.
         print-stdout : bool
             If true (default), print the standard output of work queue task on completion.
         queue-mode : one of 'persistent' or 'one-per-stage'. Default is 'persistent'.
             'persistent' - One queue is used for all stages of processing.
             'one-per-stage' - A new queue is used for each of the stages of processing.
-        resource-monitor : bool
-            If true, (false is the default) turns on resource monitoring for Work Queue.
-        password-file: str
-            Location of a file containing a password used to authenticate workers.
     """
     try:
         import work_queue as wq

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -305,6 +305,8 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             'one-per-stage' - A new queue is used for each of the stages of processing.
         resource-monitor : bool
             If true, (false is the default) turns on resource monitoring for Work Queue.
+        password-file: str
+            Location of a file containing a password used to authenticate workers.
     """
     try:
         import work_queue as wq
@@ -344,6 +346,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
     clevel = kwargs.pop('compression', 1)
     filepath = kwargs.pop('filepath', '.')
     output = kwargs.pop('print-stdout', False)
+    password_file = kwargs.pop('password-file',None)
 
     if clevel is not None:
         function = _compression_wrapper(clevel, function)
@@ -391,6 +394,9 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             _wq_queue.tune('category-steady-n-tasks', 3)
             _wq_queue.specify_category_max_resources('default', {})
             _wq_queue.specify_category_mode('default', wq.WORK_QUEUE_ALLOCATION_MODE_MAX_THROUGHPUT)
+
+        if password_file is not None:
+            _wq_queue.specify_password_file(password_file)
 
         # Define function input here
         infile_function = os.path.join(tmpdir, 'function.p')

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -324,7 +324,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
     global _wq_queue
 
-    verbose_mode = kwargs.pop('verbose',False)
+    verbose_mode = kwargs.pop('verbose', False)
     debug_log = kwargs.pop('debug-log', None)
     stats_log = kwargs.pop('stats-log', None)
     trans_log = kwargs.pop('transactions-log', None)
@@ -350,7 +350,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
     clevel = kwargs.pop('compression', 1)
     filepath = kwargs.pop('filepath', '.')
     output = kwargs.pop('print-stdout', False)
-    password_file = kwargs.pop('password-file',None)
+    password_file = kwargs.pop('password-file', None)
 
     if clevel is not None:
         function = _compression_wrapper(clevel, function)
@@ -414,7 +414,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
         add_fn = _iadd
 
-	# First generate all of the tasks and submit to WQ.
+        # First generate all of the tasks and submit to WQ.
 
         for i, item in tqdm(enumerate(items), disable=not status, unit=unit, total=len(items), desc="Creating Tasks"):
             with open(os.path.join(tmpdir, 'item_{}.p'.format(i)), 'wb') as wf:
@@ -456,16 +456,16 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
         # Then wait for the same number of tasks to complete.
 
-        for i in tqdm(range(len(items)), disable=not status, unit=unit, desc="Processing"):
+        for i in tqdm(range(len(items)), disable=not status, unit=unit, desc=desc):
 
             # This awkward bit of logic is used so that we iterate
             # the tqdm progress bar the correct number of times.
- 
+
             while True:
-                    t = _wq_queue.wait(5)
-                    if t:
-                        break
-          
+                t = _wq_queue.wait(5)
+                if t:
+                    break
+
             if t:
                 if verbose_mode:
                     print('Task (id #{}) complete: {} (return code {})'.format(t.id, t.command, t.return_status))
@@ -482,7 +482,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
                             t.resources_measured.wall_time / 1000000))
 
                 if output and t.output:
-                    print('Task id #{} output:\n{}',format(t.id,t.output))
+                    print('Task id #{} output:\n{}', format(t.id, t.output))
 
                 if t.result != 0:
                     print('Task id #{} failed with code: {}'.format(t.id, t.result))


### PR DESCRIPTION
Several updates to improve the ergonomics of the Work Queue executor:
- The progress bar display was broken and only showed the creation of tasks.  It now shows one bar for creation, then a second bar for actual execution.
- Added options to control verbose mode, output mode, and worker password, so they don't clobber the actual output.  By default, you only get excess output when a task fails in some way.

(Some further PRs incoming to update the WQ installation and examples.)