### PR TITLE
WQ Executor: Pipelining and Garbage Collection

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -260,7 +260,7 @@ def wqex_create_task(itemid, item, wrapper, env_file, command_path, infile_funct
 
     # If wrapper and env provided, add that.
     if wrapper and env_file:
-        command = './{} --environment {} --unpack-to "$WORK_QUEUE_SANDBOX"/{}-env {}'.format(basename(wrapper),basename(env_file),basename(env_file),command)
+        command = './{} --environment {} --unpack-to "$WORK_QUEUE_SANDBOX"/{}-env {}'.format(basename(wrapper), basename(env_file), basename(env_file), command)
 
     task = wq.Task(command)
     task.specify_category('default')

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -503,11 +503,8 @@ def work_queue_executor(items, function, accumulator, **kwargs):
         # Main loop of executor
         while tasks_done < tasks_total:
 
-            tasks_waiting = tasks_done-tasks_submitted  # get something from the queue
-
-            # Submit tasks into the queue, until at least 100 are idle.
-
-            while tasks_submitted < tasks_total and tasks_waiting < 100:
+            # Submit tasks into the queue, but no more than 100 idle tasks
+            while tasks_submitted < tasks_total and _wq_queue.stats.tasks_waiting < 100:
                task = wqex_create_task(tasks_submitted,items[tasks_submitted],wrapper,env_file,command_path,infile_function,tmpdir)
                task_id = _wq_queue.submit(task)
                tasks_submitted += 1

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -496,8 +496,9 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
         print('Listening for work queue workers on port {}...'.format(_wq_queue.port))
 
-        # Create a progress bar that will be advanced manually.
-        progress_bar = tqdm(total=tasks_total,position=1,disable=not status,desc="Processing")
+        # Create a dual progress bar to show submission and completion.
+        submit_bar = tqdm(total=tasks_total,position=0,disable=not status,desc="Submitted")
+        complete_bar = tqdm(total=tasks_total,position=1,disable=not status,desc="Completed")
 
         # Main loop of executor
         while tasks_done < tasks_total:
@@ -513,6 +514,9 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
                if(verbose_mode):
                    print('Submitted task (id #{}): {}'.format(task_id,task.command))
+               else:
+                   submit_bar.update(1)
+                   complete_bar.update(0)
 
             # When done submitting, look for completed tasks.
 
@@ -532,7 +536,11 @@ def work_queue_executor(items, function, accumulator, **kwargs):
                 tasks_done += 1
 
                 if(not verbose_mode):
-                    progress_bar.update(1)
+                    submit_bar.update(0)
+                    complete_bar.update(1)
+
+        submit_bar.close()
+        complete_bar.close()
 
         if os.path.exists(command_path):
             os.remove(command_path)

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -235,7 +235,11 @@ with open(arg, "rb") as f:
 
 pickle_out = exec_function(exec_item)
 with open(out, "wb") as f:
-    dill.dump(pickle_out, f) """)
+    dill.dump(pickle_out, f)
+
+# Force an OS exit here to avoid a bug in xrootd finalization
+os._exit(0)
+""")
 
     return name
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -245,7 +245,6 @@ with open(out, "wb") as f:
 #
 
 def wqex_create_task( itemid, item, wrapper, env_file, command_path, infile_function, tmpdir ):
-
     import dill
     from os.path import basename
     import work_queue as wq
@@ -289,7 +288,6 @@ def wqex_create_task( itemid, item, wrapper, env_file, command_path, infile_func
 #
 
 def wqex_output_task( task, verbose_mode, resource_mode, output_mode ):
-
     if verbose_mode:
         print('Task (id #{}) complete: {} (return code {})'.format(task.id, task.command, task.return_status))
 
@@ -497,8 +495,8 @@ def work_queue_executor(items, function, accumulator, **kwargs):
         print('Listening for work queue workers on port {}...'.format(_wq_queue.port))
 
         # Create a dual progress bar to show submission and completion.
-        submit_bar = tqdm(total=tasks_total,position=0,disable=not status,desc="Submitted")
-        complete_bar = tqdm(total=tasks_total,position=1,disable=not status,desc="Completed")
+        submit_bar = tqdm(total=tasks_total, position=0, disable=not status, unit=unit, desc="Submitted")
+        complete_bar = tqdm(total=tasks_total, position=1, disable=not status, unit=unit, desc=desc)
 
         itemiter = iter(items)
 
@@ -507,23 +505,23 @@ def work_queue_executor(items, function, accumulator, **kwargs):
 
             # Submit tasks into the queue, but no more than 100 idle tasks
             while tasks_submitted < tasks_total and _wq_queue.stats.tasks_waiting < 100:
-               item = next(itemiter)
-               task = wqex_create_task(tasks_submitted,item,wrapper,env_file,command_path,infile_function,tmpdir)
-               task_id = _wq_queue.submit(task)
-               tasks_submitted += 1
+                item = next(itemiter)
+                task = wqex_create_task(tasks_submitted, item, wrapper, env_file, command_path, infile_function, tmpdir)
+                task_id = _wq_queue.submit(task)
+                tasks_submitted += 1
 
-               if(verbose_mode):
-                   print('Submitted task (id #{}): {}'.format(task_id,task.command))
-               else:
-                   submit_bar.update(1)
-                   complete_bar.update(0)
+                if(verbose_mode):
+                    print('Submitted task (id #{}): {}'.format(task_id, task.command))
+                else:
+                    submit_bar.update(1)
+                    complete_bar.update(0)
 
             # When done submitting, look for completed tasks.
 
             task = _wq_queue.wait(5)
             if task:
                 # Display details of the completed task
-                wqex_output_task(task,verbose_mode,resource_monitor,output)
+                wqex_output_task(task, verbose_mode, resource_monitor, output)
                 if task.result != 0:
                     print('Stopping execution')
                     break

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -240,6 +240,7 @@ with open(out, "wb") as f:
     return name
 
 #
+# Work Queue Executor:
 # Global Work Queue object to allow queue to be used
 # across executor invocations.
 #
@@ -247,6 +248,7 @@ with open(out, "wb") as f:
 _wq_queue = None
 
 #
+# Work Queue Executor:
 # Generate a WQ task from a Coffea item.
 #
 
@@ -290,6 +292,7 @@ def wqex_create_task( i, item, wrapper, env_file, command_path, infile_function,
     return task
 
 #
+# Work Queue Executor:
 # Display output of a task depending on various modes
 #
 
@@ -315,6 +318,10 @@ def wqex_output_task( task, verbose_mode, resource_mode, output_mode ):
 
     if task.result != 0:
         print('Task id #{} failed with code: {}'.format(task.id, task.result))
+
+#
+# Work Queue Executor: Main Loop
+#
 
 def work_queue_executor(items, function, accumulator, **kwargs):
     """Execute using Work Queue

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -239,12 +239,8 @@ with open(out, "wb") as f:
 
     return name
 
-#
-# Work Queue Executor:
-# Generate a WQ task from a Coffea item.
-#
 
-def wqex_create_task( itemid, item, wrapper, env_file, command_path, infile_function, tmpdir ):
+def wqex_create_task(itemid, item, wrapper, env_file, command_path, infile_function, tmpdir):
     import dill
     from os.path import basename
     import work_queue as wq
@@ -282,12 +278,8 @@ def wqex_create_task( itemid, item, wrapper, env_file, command_path, infile_func
 
     return task
 
-#
-# Work Queue Executor:
-# Display output of a task depending on various modes
-#
 
-def wqex_output_task( task, verbose_mode, resource_mode, output_mode ):
+def wqex_output_task(task, verbose_mode, resource_mode, output_mode):
     if verbose_mode:
         print('Task (id #{}) complete: {} (return code {})'.format(task.id, task.command, task.return_status))
 
@@ -309,17 +301,9 @@ def wqex_output_task( task, verbose_mode, resource_mode, output_mode ):
     if task.result != 0:
         print('Task id #{} failed with code: {}'.format(task.id, task.result))
 
-#
-# Work Queue Executor:
-# Global Work Queue object to allow queue to be used
-# across executor invocations.
-#
 
 _wq_queue = None
 
-#
-# Work Queue Executor: Main Loop
-#
 
 def work_queue_executor(items, function, accumulator, **kwargs):
     """Execute using Work Queue


### PR DESCRIPTION
The existing WQ executor first materializes all tasks and then waits for them all to complete.  This works, but causes trouble if you have a very large number of tasks such that the filesystem becomes a bottleneck with all of the temp files generated.

This PR pipelines execution so that submission and execution are interleaved.  If more than 100 tasks are idle in the queue, the executor starts waiting for some to execute or complete before generating more.  Temporary files are deleted as we go along.
