### PR TITLE
catch missing return in process() w/ better error message

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -883,6 +883,8 @@ def _work_function(item, processor_instance, savemetrics=False,
                     out = processor_instance.process(events)
                 except Exception as e:
                     raise Exception(f"Failed processing file: {item.filename} ({item.entrystart}-{item.entrystop})") from e
+                if out is None:
+                    raise ValueError("Output of process() should not be None. Make sure your processor's process() function returns an accumulator.")
                 toc = time.time()
                 if use_dataframes:
                     return out


### PR DESCRIPTION
Currently, if a user forgets to put a return statement in their processor's `process()` function, the following kind of error message will occur:
```
Traceback (most recent call last):
  File "simple_local.py", line 77, in <module>
    main()
  File "simple_local.py", line 61, in main
    maxchunks=maxchunks,
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/executor.py", line 1177, in run_uproot_job
    executor(chunks, closure, wrapped_out, **exe_args)
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/executor.py", line 508, in iterative_executor
    add_fn(accumulator, function(item))
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/executor.py", line 147, in _iadd
    output += _maybe_decompress(result)
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/accumulator.py", line 84, in __iadd__
    self.add(other)
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/accumulator.py", line 177, in add
    self[key] += value
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/accumulator.py", line 84, in __iadd__
    self.add(other)
  File "/uscms_data/d3/pedrok/semivisible/analysis/t-channel_Analysis/coffeaenv/lib/python3.6/site-packages/coffea/processor/accumulator.py", line 179, in add
    raise ValueError
ValueError
```

This is not very informative. This PR catches the issue earlier and issues a more helpful error message.