### PR TITLE
Fix reading from CSV for numpy 1.20.0

### DIFF
--- a/coffea/lookup_tools/csv_converters.py
+++ b/coffea/lookup_tools/csv_converters.py
@@ -50,7 +50,6 @@ def convert_btag_csv_file(csvFilePath):
         },
         delimiter=",",
         skip_header=1,
-        unpack=True,
         encoding="ascii",
     )
 

--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -105,7 +105,6 @@ def _parse_jme_formatted_file(
             jme_f,
             dtype=tuple(dtypes),
             names=tuple(columns),
-            unpack=True,
             encoding="ascii",
         )
         if len(pars.shape) == 0:
@@ -424,7 +423,6 @@ def convert_effective_area_file(eaFilePath):
         dtype=tuple(dtypes),
         names=tuple(columns),
         skip_header=1,
-        unpack=True,
         encoding="ascii",
     )
 


### PR DESCRIPTION
In version 1.20.0 of numpy a fix to np.genfromtxt was introduced that makes it return a list if the result is not transposable and unpack is True.
See https://github.com/numpy/numpy/commit/3329d26c5d1d53f7fca1dfe253fdc43e93f0f6aa