### PR TITLE
WQEX: Make executor fail on task failure.

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -315,7 +315,7 @@ def wqex_output_task(task, verbose_mode, resource_mode, output_mode):
         print('Task id #{} failed with code: {}'.format(task.id, task.result))
 
 
-# The Work Queue object is global b/c we want to 
+# The Work Queue object is global b/c we want to
 # retain state between runs of the executor, such
 # as connections to workers, cached data, etc.
 _wq_queue = None

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -523,8 +523,9 @@ def work_queue_executor(items, function, accumulator, **kwargs):
                 # Display details of the completed task
                 wqex_output_task(task, verbose_mode, resource_monitor, output)
                 if task.result != 0:
-                    print('Stopping execution')
-                    break
+                    # Note that WQ already retries internal failures.
+                    # If we get to this point, it's a badly formed task.
+                    raise RuntimeError("Task {} item {} failed with output:\n{}".format(task.id, task.tag, task.output))
 
                 # The task tag remembers the itemid for us.
                 itemid = task.tag

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -315,6 +315,9 @@ def wqex_output_task(task, verbose_mode, resource_mode, output_mode):
         print('Task id #{} failed with code: {}'.format(task.id, task.result))
 
 
+# The Work Queue object is global b/c we want to 
+# retain state between runs of the executor, such
+# as connections to workers, cached data, etc.
 _wq_queue = None
 
 
@@ -388,9 +391,6 @@ def work_queue_executor(items, function, accumulator, **kwargs):
             Filename for tasks lifetime reports output
         print-stdout : bool
             If true (default), print the standard output of work queue task on completion.
-        queue-mode : one of 'persistent' or 'one-per-stage'. Default is 'persistent'.
-            'persistent' - One queue is used for all stages of processing.
-            'one-per-stage' - A new queue is used for each of the stages of processing.
     """
     try:
         import work_queue as wq
@@ -438,8 +438,7 @@ def work_queue_executor(items, function, accumulator, **kwargs):
         else:
             port = 9123
 
-    queue_mode = kwargs.pop('queue-mode', 'persistent')
-    if _wq_queue is None or queue_mode == 'one-per-stage':
+    if _wq_queue is None:
         _wq_queue = wq.WorkQueue(port, name=master_name, debug_log=debug_log, stats_log=stats_log, transactions_log=trans_log)
 
     if env_file and not wrapper:


### PR DESCRIPTION
In the work queue executor, force a task failure to result in a RuntimeError() so that the main process exits with failure.   (Otherwise, CI can appear to succeed when it has actually failed.)
