### PR TITLE
Back off to parsl >= 1.0, see if tests hang or not.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ INSTALL_REQUIRES = [
 ]
 EXTRAS_REQUIRE = {}
 EXTRAS_REQUIRE["spark"] = ["pyspark>=2.4.1,<3.0.0", "jinja2"]
-EXTRAS_REQUIRE["parsl"] = ["parsl>=1.1.0a0"]
+EXTRAS_REQUIRE["parsl"] = ["parsl>=1.0"]
 EXTRAS_REQUIRE["dask"] = [
     "dask[dataframe]>=2.6.0",
     "distributed>=2.6.0",


### PR DESCRIPTION
As in title, revert to non-alpha release of parsl.