### PR TITLE
fix wq debug output typo

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -347,7 +347,7 @@ def wqex_output_task(task, verbose_mode, resource_mode, output_mode):
                     task.resources_measured.cores,
                     task.resources_measured.memory,
                     task.resources_measured.disk,
-                    task.resources_measures.gpus,
+                    task.resources_measured.gpus,
                     task.resources_measured.wall_time / 1000000,
                 )
             )


### PR DESCRIPTION
changes `task.resources_measures.gpu`  to `task.resourced_measures.gpu`