### PR TITLE
wq executor: do not transfer root files with absolute paths

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -310,8 +310,9 @@ def wqex_create_task(
         task.specify_input_file(env_file, cache=True)
         task.specify_input_file(wrapper, cache=True)
 
-    if re.search("://", item.filename):
-        # This looks like an URL. Not transfering file.
+    if re.search("://", item.filename) or os.path.isabs(item.filename):
+        # This looks like an URL or an absolute path (assuming shared
+        # filesystem). Not transfering file.
         pass
     else:
         task.specify_input_file(item.filename, remote_name=item.filename, cache=True)


### PR DESCRIPTION
Such paths are assumed to be on a shared filesystem, thus they do not
need to be transfered to the execution site.