### PR TITLE
Restrict pyarrow version in rados build job.

### DIFF
--- a/docker/coffea_rados_parquet/script.sh
+++ b/docker/coffea_rados_parquet/script.sh
@@ -102,7 +102,7 @@ popd
 
 pip3 install dask[distributed] nbconvert
 pip3 install 'fsspec>=0.3.3'
-pip3 install --upgrade . # install coffea
+pip3 install --upgrade . pyarrow<4# install coffea
 pip3 install --upgrade /pyarrow-*.whl # update the PyArrow with Rados parquet extensions
 
 if [ ! -z "$IS_CI" ]; then


### PR DESCRIPTION
pyarrow 4 doesn't seem to have an appropriate wheel yet.
