### PR TITLE
feat: batching for parsl/futures execs

### DIFF
--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -5,9 +5,6 @@ from collections import defaultdict
 from collections.abc import MutableMapping, MutableSet
 from typing import Iterable, Optional, TypeVar, Union
 
-import pickle
-import warnings
-
 try:
     from typing import Protocol, runtime_checkable  # type: ignore
 except ImportError:
@@ -95,9 +92,6 @@ def accumulate(
         while True:
             # subsequent additions can happen in-place, which may be more performant
             accum = iadd(accum, next(gen))
-            _size = len(pickle.dumps(accum)) / (1024 * 1024)
-            if _size > 4000:  # 2 GB
-                warnings.warn("Accumulator memory size > 4GB. Might cause hangups.")
     except StopIteration:
         pass
     return accum

--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -5,6 +5,9 @@ from collections import defaultdict
 from collections.abc import MutableMapping, MutableSet
 from typing import Iterable, Optional, TypeVar, Union
 
+import pickle
+import warnings
+
 try:
     from typing import Protocol, runtime_checkable  # type: ignore
 except ImportError:
@@ -92,6 +95,9 @@ def accumulate(
         while True:
             # subsequent additions can happen in-place, which may be more performant
             accum = iadd(accum, next(gen))
+            _size = len(pickle.dumps(accum)) / (1024 * 1024)
+            if _size > 4000:  # 2 GB
+                warnings.warn("Accumulator memory size > 4GB. Might cause hangups.")
     except StopIteration:
         pass
     return accum

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -260,7 +260,6 @@ class FuturesHolder:
         self.merges = set()
         self.completed = set()
         self.done = {"futures": 0, "merges": 0}
-        self.total = {"futures": len(futures), "merges": 0}
         self.refresh = refresh
 
     def update(self):
@@ -283,9 +282,9 @@ class FuturesHolder:
             self.done["merges"] += len(completed)
 
     def fetch(self, N):
-        return set(
+        return [
             self.completed.pop().result() for _ in range(N) if len(self.completed) > 0
-        )
+        ]
 
 
 def wqex_create_function_wrapper(tmpdir, x509_proxy=None):
@@ -1439,7 +1438,7 @@ def run_uproot_job(
                 "function_name": "get_metadata",
                 "desc": "Preprocessing",
                 "unit": "file",
-                "compression": 1,
+                "compression": None,
                 "tailtimeout": None,
                 "worker_affinity": False,
             }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,90 +17,95 @@ from functools import reduce
 import inspect
 import subprocess
 import coffea
+
 print("sys.path:", sys.path)
 print("coffea version:", coffea.__version__)
 
 # -- Project information -----------------------------------------------------
 
-project = 'coffea'
-copyright = '2019, Fermi National Accelerator Laboratory'
-author = 'M. Cremonesi, L. Gray, A. Hall, N. Smith, et al. (The Coffea Team)'
+project = "coffea"
+copyright = "2019, Fermi National Accelerator Laboratory"
+author = "M. Cremonesi, L. Gray, A. Hall, N. Smith, et al. (The Coffea Team)"
 
-version = coffea.__version__.rsplit('.', 1)[0]
+version = coffea.__version__.rsplit(".", 1)[0]
 release = coffea.__version__
-githash = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode('ascii')
+githash = subprocess.check_output(["git", "rev-parse", "HEAD"]).strip().decode("ascii")
 
 language = None
 
 # -- General configuration ---------------------------------------------------
 
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'nbsphinx',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.linkcode',
-    'sphinx.ext.napoleon',
-    'sphinx_automodapi.automodapi',
-    'sphinx_automodapi.smart_resolver',
+    "nbsphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.linkcode",
+    "sphinx.ext.napoleon",
+    "sphinx_automodapi.automodapi",
+    "sphinx_automodapi.smart_resolver",
 ]
 
 numpydoc_show_class_members = False
-nbsphinx_execute = 'never'
+nbsphinx_execute = "never"
 autosummary_generate = True
 
+
 def linkcode_resolve(domain, info):
-    if domain != 'py':
+    if domain != "py":
         return None
-    if not info['module']:
+    if not info["module"]:
         return None
-    mod = importlib.import_module(info['module'])
+    mod = importlib.import_module(info["module"])
     modpath = [p for p in sys.path if mod.__file__.startswith(p)]
     if len(modpath) < 1:
-        raise RuntimeException('Cannot deduce module path')
+        raise RuntimeException("Cannot deduce module path")
     modpath = modpath[0]
-    obj = reduce(getattr, [mod] + info['fullname'].split('.'))
+    obj = reduce(getattr, [mod] + info["fullname"].split("."))
     try:
         path = inspect.getsourcefile(obj)
-        relpath = path[len(modpath) + 1:]
+        relpath = path[len(modpath) + 1 :]
         _, lineno = inspect.getsourcelines(obj)
     except TypeError:
         # skip property or other type that inspect doesn't like
         return None
-    return "http://github.com/CoffeaTeam/coffea/blob/{}/{}#L{}".format(githash, relpath, lineno)
+    return "http://github.com/CoffeaTeam/coffea/blob/{}/{}#L{}".format(
+        githash, relpath, lineno
+    )
+
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3', None),
-    'numpy': ('http://docs.scipy.org/doc/numpy', None),
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("http://docs.scipy.org/doc/numpy", None),
 }
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-default_role = 'any'
+default_role = "any"
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
+pygments_style = "sphinx"
+html_theme = "sphinx_rtd_theme"
 todo_include_todos = False
-htmlhelp_basename = 'coffeadoc'
+htmlhelp_basename = "coffeadoc"
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -111,30 +116,26 @@ htmlhelp_basename = 'coffeadoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#
-# 'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#
-# 'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#
-# 'preamble': '',
-
-# Latex figure (float) alignment
-#
-# 'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #
+    # 'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #
+    # 'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #
+    # 'preamble': '',
+    # Latex figure (float) alignment
+    #
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-                   (master_doc, 'coffea.tex', 'Coffea Documentation',
-                    'The Coffea Team', 'manual'),
-                   ]
+    (master_doc, "coffea.tex", "Coffea Documentation", "The Coffea Team", "manual"),
+]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -173,10 +174,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-             (master_doc, 'coffea', 'Coffea Documentation',
-              [author], 1)
-             ]
+man_pages = [(master_doc, "coffea", "Coffea Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 #
@@ -189,10 +187,16 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-                     (master_doc, 'Coffea', 'Coffea Documentation',
-                      author, 'Coffea', 'Efficient columnar HEP analysis in python.',
-                      'Miscellaneous'),
-                     ]
+    (
+        master_doc,
+        "Coffea",
+        "Coffea Documentation",
+        author,
+        "Coffea",
+        "Efficient columnar HEP analysis in python.",
+        "Miscellaneous",
+    ),
+]
 
 # Documents to append as an appendix to all manuals.
 #

--- a/docs/source/wq-example.py
+++ b/docs/source/wq-example.py
@@ -31,18 +31,22 @@ from coffea import hist, processor
 
 # register our candidate behaviors
 from coffea.nanoevents.methods import candidate
+
 ak.behavior.update(candidate.behavior)
+
 
 class MyProcessor(processor.ProcessorABC):
     def __init__(self):
-        self._accumulator = processor.dict_accumulator({
-            "sumw": processor.defaultdict_accumulator(float),
-            "mass": hist.Hist(
-                "Events",
-                hist.Cat("dataset", "Dataset"),
-                hist.Bin("mass", "$m_{\mu\mu}$ [GeV]", 60, 60, 120),
-            ),
-        })
+        self._accumulator = processor.dict_accumulator(
+            {
+                "sumw": processor.defaultdict_accumulator(float),
+                "mass": hist.Hist(
+                    "Events",
+                    hist.Cat("dataset", "Dataset"),
+                    hist.Bin("mass", "$m_{\mu\mu}$ [GeV]", 60, 60, 120),
+                ),
+            }
+        )
 
     @property
     def accumulator(self):
@@ -51,19 +55,22 @@ class MyProcessor(processor.ProcessorABC):
     def process(self, events):
 
         # Note: This is required to ensure that behaviors are registered
-        # when running this code in a remote task.        
+        # when running this code in a remote task.
         ak.behavior.update(candidate.behavior)
 
         output = self.accumulator.identity()
 
-        dataset = events.metadata['dataset']
-        muons = ak.zip({
-            "pt": events.Muon_pt,
-            "eta": events.Muon_eta,
-            "phi": events.Muon_phi,
-            "mass": events.Muon_mass,
-            "charge": events.Muon_charge,
-        }, with_name="PtEtaPhiMCandidate")
+        dataset = events.metadata["dataset"]
+        muons = ak.zip(
+            {
+                "pt": events.Muon_pt,
+                "eta": events.Muon_eta,
+                "phi": events.Muon_phi,
+                "mass": events.Muon_mass,
+                "charge": events.Muon_charge,
+            },
+            with_name="PtEtaPhiMCandidate",
+        )
 
         cut = (ak.num(muons) == 2) & (ak.sum(muons.charge) == 0)
         # add first and second muon in every event together
@@ -93,13 +100,13 @@ import shutil
 import getpass
 import os.path
 
-wq_env_tarball="coffea-env.tar.gz"
-wq_wrapper_path=shutil.which('python_package_run')
-wq_master_name="coffea-wq-{}".format(getpass.getuser())
+wq_env_tarball = "coffea-env.tar.gz"
+wq_wrapper_path = shutil.which("python_package_run")
+wq_master_name = "coffea-wq-{}".format(getpass.getuser())
 
-print("Master Name: -N "+wq_master_name)
-print("Environment: "+wq_env_tarball)
-print("Wrapper Path: "+wq_wrapper_path)
+print("Master Name: -N " + wq_master_name)
+print("Environment: " + wq_env_tarball)
+print("Wrapper Path: " + wq_wrapper_path)
 
 print("------------------------------------------------")
 
@@ -109,9 +116,9 @@ print("------------------------------------------------")
 ###############################################################
 
 fileset = {
-    'DoubleMuon': [
-        'root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root',
-        'root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root',
+    "DoubleMuon": [
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012B_DoubleMuParked.root",
+        "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/Run2012C_DoubleMuParked.root",
     ],
 }
 
@@ -120,45 +127,35 @@ fileset = {
 ###############################################################
 
 work_queue_executor_args = {
-
     # Options are common to all executors:
-    'compression': 1,
-    'schema' : BaseSchema,
-    'skipbadfiles': False,      # Note that maxchunks only works if this is false.
- 
+    "compression": 1,
+    "schema": BaseSchema,
+    "skipbadfiles": False,  # Note that maxchunks only works if this is false.
     # Options specific to Work Queue:
-
     # Additional files needed by the processor, such as local code libraries.
     # 'extra-input-files' : [ 'myproc.py', 'config.dat' ],
-
     # Resources to allocate per task.
-    'resources-mode' : 'auto',  # Adapt task resources to what's observed.
-    'resource-monitor': True,   # Measure actual resource consumption
-
+    "resources-mode": "auto",  # Adapt task resources to what's observed.
+    "resource-monitor": True,  # Measure actual resource consumption
     # With resources set to auto, these are the max values for any task.
-    'cores': 2,                  # Cores needed per task.
-    'disk': 2000,                # Disk needed per task (MB)
-    'memory': 2000,              # Memory needed per task (MB)
-    'gpus' : 0,                  # GPUs needed per task.
-
+    "cores": 2,  # Cores needed per task.
+    "disk": 2000,  # Disk needed per task (MB)
+    "memory": 2000,  # Memory needed per task (MB)
+    "gpus": 0,  # GPUs needed per task.
     # Options to control how workers find this master.
-    'master-name': wq_master_name,
-    'port': 9123,     # Port for manager to listen on: if zero, will choose automatically.
-
+    "master-name": wq_master_name,
+    "port": 9123,  # Port for manager to listen on: if zero, will choose automatically.
     # Options to control how the environment is constructed.
     # The named tarball will be transferred to each worker
     # and activated using the wrapper script.
-    'environment-file': wq_env_tarball,
-    'wrapper' : wq_wrapper_path,
-
+    "environment-file": wq_env_tarball,
+    "wrapper": wq_wrapper_path,
     # Debugging: Display output of task if not empty.
-    'print-stdout': True,
-
+    "print-stdout": True,
     # Debugging: Display notes about each task submitted/complete.
-    'verbose': False,
-
+    "verbose": False,
     # Debugging: Produce a lot at the master side of things.
-    'debug-log' : 'coffea-wq.log',
+    "debug-log": "coffea-wq.log",
 }
 
 ###############################################################
@@ -166,16 +163,16 @@ work_queue_executor_args = {
 ###############################################################
 
 import time
+
 tstart = time.time()
 
 output = processor.run_uproot_job(
     fileset,
-    treename='Events',
+    treename="Events",
     processor_instance=MyProcessor(),
     executor=processor.work_queue_executor,
     executor_args=work_queue_executor_args,
     chunksize=100000,
-
     # Change this to None for a large run:
     maxchunks=4,
 )
@@ -183,4 +180,3 @@ output = processor.run_uproot_job(
 elapsed = time.time() - tstart
 
 print(output)
-

--- a/validation/btag/validate.py
+++ b/validation/btag/validate.py
@@ -1,7 +1,8 @@
 import ROOT
+
 ROOT.gROOT.SetBatch(True)
 ROOT.PyConfig.IgnoreCommandLineOptions = True
-ROOT.gInterpreter.LoadFile('BTagCalibrationStandalone.cpp')
+ROOT.gInterpreter.LoadFile("BTagCalibrationStandalone.cpp")
 
 from functools import partial
 import numpy
@@ -9,7 +10,7 @@ from coffea.btag_tools import BTagScaleFactor
 
 
 def stdvec(l):
-    out = ROOT.std.vector('string')()
+    out = ROOT.std.vector("string")()
     for item in l:
         out.push_back(item)
     return out
@@ -29,7 +30,9 @@ def makesf(btagReader):
             if discr is None:
                 return btagReader.eval_auto_bounds(syst, btvflavor, abseta, pt)
             return btagReader.eval_auto_bounds(syst, btvflavor, abseta, pt, discr)
-        return numpy.vectorize(wrap, otypes='d')(flavor, abseta, pt, discr)
+
+        return numpy.vectorize(wrap, otypes="d")(flavor, abseta, pt, discr)
+
     return btv_sf
 
 
@@ -38,41 +41,51 @@ def validate_btag(filename, btagtype, etamax):
     npts = 10000
     flavor = numpy.full(npts, 5)
     abseta = numpy.random.uniform(0, etamax, size=npts)
-    pt = numpy.random.exponential(50, size=npts) + numpy.random.exponential(20, size=npts)
+    pt = numpy.random.exponential(50, size=npts) + numpy.random.exponential(
+        20, size=npts
+    )
     pt = numpy.maximum(20.1, pt)
     discr = numpy.random.rand(npts)
 
-    coffea_sf = BTagScaleFactor(filename, BTagScaleFactor.RESHAPE, 'iterativefit', keep_df=True)
-    btagReader = ROOT.BTagCalibrationReader(ROOT.BTagEntry.OP_RESHAPING, 'central', stdvec(['up_jes', 'down_jes']))
-    btagReader.load(btagData, ROOT.BTagEntry.FLAV_B, 'iterativefit')
+    coffea_sf = BTagScaleFactor(
+        filename, BTagScaleFactor.RESHAPE, "iterativefit", keep_df=True
+    )
+    btagReader = ROOT.BTagCalibrationReader(
+        ROOT.BTagEntry.OP_RESHAPING, "central", stdvec(["up_jes", "down_jes"])
+    )
+    btagReader.load(btagData, ROOT.BTagEntry.FLAV_B, "iterativefit")
     btv_sf = makesf(btagReader)
 
-    for syst in ['central', 'up_jes', 'down_jes']:
+    for syst in ["central", "up_jes", "down_jes"]:
         csf = coffea_sf.eval(syst, flavor, abseta, pt, discr)
         bsf = btv_sf(syst, flavor, abseta, pt, discr)
         print(abs(csf - bsf).max())
 
     flavor = numpy.random.choice([0, 4, 5], size=npts)
-    coffea_sf = BTagScaleFactor(filename, BTagScaleFactor.TIGHT, 'comb,mujets,incl', keep_df=True)
-    btagReader = ROOT.BTagCalibrationReader(ROOT.BTagEntry.OP_TIGHT, 'central', stdvec(['up', 'down']))
-    btagReader.load(btagData, ROOT.BTagEntry.FLAV_B, 'comb')
-    btagReader.load(btagData, ROOT.BTagEntry.FLAV_C, 'mujets')
-    btagReader.load(btagData, ROOT.BTagEntry.FLAV_UDSG, 'incl')
+    coffea_sf = BTagScaleFactor(
+        filename, BTagScaleFactor.TIGHT, "comb,mujets,incl", keep_df=True
+    )
+    btagReader = ROOT.BTagCalibrationReader(
+        ROOT.BTagEntry.OP_TIGHT, "central", stdvec(["up", "down"])
+    )
+    btagReader.load(btagData, ROOT.BTagEntry.FLAV_B, "comb")
+    btagReader.load(btagData, ROOT.BTagEntry.FLAV_C, "mujets")
+    btagReader.load(btagData, ROOT.BTagEntry.FLAV_UDSG, "incl")
     btv_sf = makesf(btagReader)
 
-    for syst in ['central', 'up', 'down']:
+    for syst in ["central", "up", "down"]:
         csf = coffea_sf.eval(syst, flavor, abseta, pt, discr)
         bsf = btv_sf(syst, flavor, abseta, pt, discr)
         print(abs(csf - bsf).max())
 
 
 validate_btag(
-    filename='DeepCSV_102XSF_V1.btag.csv',
-    btagtype='DeepCSV',
+    filename="DeepCSV_102XSF_V1.btag.csv",
+    btagtype="DeepCSV",
     etamax=2.5,
 )
 validate_btag(
-    filename='testBTagSF.btag.csv',
-    btagtype='CSVv2',
+    filename="testBTagSF.btag.csv",
+    btagtype="CSVv2",
     etamax=2.4,
 )


### PR DESCRIPTION
- As mentioned #515 doing only one reduce on submit node is a massive bottleneck for large (full analysis) runs, or in general when enough nodes are available to process worker functions faster than merging the outputs.
-  This implementation fixes that for `futures`/`parsl` by submitting batches of reduce jobs as the results become available
- Separate tracking (tqdm) for map/reduce jobs
- chunking is currently adaptive with `minsize`, `maxsize`, `nsplits` of finished jobs, this could/should be made an executor arg
- this implementation replaces the single node generator based merge from `_futures_handler` rendering the intermediate results on the submit node, this should however be in principle fine as the intermediate should be relatively small and not stay in mem on the submit node. Finally, the mem cost of rendering each batch should be tweakable by adjusting `maxsize`

