### PR TITLE
Remove nested virtual from CorrectedJetsFactory due to cycles

### DIFF
--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -727,10 +727,8 @@ def test_factory_lifecycle():
         "Summer16_23Sep2016V3_MC_L3Absolute_AK4PFPuppi",
         "Spring16_25nsV10_MC_PtResolution_AK4PFPuppi",
         "Spring16_25nsV10_MC_SF_AK4PFPuppi",
+        "Summer16_23Sep2016V3_MC_UncertaintySources_AK4PFPuppi_AbsoluteStat",
     ]
-    # for key in evaluator.keys():
-    #     if 'Summer16_23Sep2016V3_MC_UncertaintySources_AK4PFPuppi' in key:
-    #         jec_stack_names.append(key)
 
     jec_stack = JECStack({name: evaluator[name] for name in jec_stack_names})
     name_map = jec_stack.blank_name_map

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -749,7 +749,8 @@ def test_factory_lifecycle():
     met_factory = CorrectedMETFactory(name_map)
 
     from coffea.nanoevents.mapping import ArrayLifecycleMapping
-    import weakref, threading
+    import weakref
+    import threading
 
     array_log = ArrayLifecycleMapping()
     jec_finalized = threading.Event()  # just using this as a flag object


### PR DESCRIPTION
Tried to keep the performance up by doing the same dictionary trick for the variations as for the main corrected jets object.