### PR TITLE
Fix in Rochester lookup (follow-up on #503)

### DIFF
--- a/coffea/lookup_tools/rochester_lookup.py
+++ b/coffea/lookup_tools/rochester_lookup.py
@@ -235,11 +235,7 @@ class rochester_lookup:
 
         x = awkward.where(
             mask,
-            (
-                numpy.sqrt(kData * kData - kMC * kMC)
-                * sigma
-                * invcdf
-            ),
+            (numpy.sqrt(kData * kData - kMC * kMC) * sigma * invcdf),
             x,
         )
         result = awkward.where(x > -1, 1.0 / (1.0 + x), awkward.ones_like(kpt))

--- a/coffea/lookup_tools/rochester_lookup.py
+++ b/coffea/lookup_tools/rochester_lookup.py
@@ -236,9 +236,9 @@ class rochester_lookup:
         x = awkward.where(
             mask,
             (
-                numpy.sqrt(kData[mask] * kData[mask] - kMC[mask] * kMC[mask])
-                * sigma[mask]
-                * invcdf[mask]
+                numpy.sqrt(kData * kData - kMC * kMC)
+                * sigma
+                * invcdf
             ),
             x,
         )


### PR DESCRIPTION
Fixes remaining bug with argument shapes in `ak.where()`, see https://github.com/CoffeaTeam/coffea/pull/503