### PR TITLE
Gzip fixes

### DIFF
--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -12,9 +12,11 @@ except ImportError:
 # for later
 # func = numbaize(formula,['p%i'%i for i in range(nParms)]+[varnames[i] for i in range(nEvalVars)])
 
+
 def is_gz_file(filename):
-    with open(filename, 'rb') as f:
-        return f.read(2) == b'\x1f\x8b'
+    with open(filename, "rb") as f:
+        return f.read(2) == b"\x1f\x8b"
+
 
 def _parse_jme_formatted_file(
     jmeFilePath, interpolatedFunc=False, parmsFromColumns=False, jme_f=None

--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -12,6 +12,9 @@ except ImportError:
 # for later
 # func = numbaize(formula,['p%i'%i for i in range(nParms)]+[varnames[i] for i in range(nEvalVars)])
 
+def is_gz_file(filename):
+    with open(filename, 'rb') as f:
+        return f.read(2) == b'\x1f\x8b'
 
 def _parse_jme_formatted_file(
     jmeFilePath, interpolatedFunc=False, parmsFromColumns=False, jme_f=None
@@ -19,7 +22,7 @@ def _parse_jme_formatted_file(
     if jme_f is None:
         fopen = open
         fmode = "rt"
-        if ".gz" in jmeFilePath:
+        if is_gz_file(jmeFilePath):
             import gzip
 
             fopen = gzip.open
@@ -293,7 +296,7 @@ def convert_junc_txt_file(juncFilePath):
     basename = os.path.basename(juncFilePath).split(".")[0]
     fopen = open
     fmode = "rt"
-    if ".gz" in juncFilePath:
+    if is_gz_file(juncFilePath):
         import gzip
 
         fopen = gzip.open
@@ -383,7 +386,7 @@ def convert_junc_txt_component(juncFilePath, uncFile):
 def convert_effective_area_file(eaFilePath):
     fopen = open
     fmode = "rt"
-    if ".gz" in eaFilePath:
+    if is_gz_file(eaFilePath):
         import gzip
 
         fopen = gzip.open
@@ -477,7 +480,7 @@ def convert_rochester_file(path, loaduncs=True):
 
     fopen = open
     fmode = "rt"
-    if ".gz" in path:
+    if is_gz_file(path):
         import gzip
 
         fopen = gzip.open


### PR DESCRIPTION
These updates would resolve [Issue #534](https://github.com/CoffeaTeam/coffea/issues/534) by checking whether or not a file is a gz file before attempting to open it as a gz file. The recent [PR](https://github.com/CoffeaTeam/coffea/pull/536/commits/82099e92d70b3e9fb188c7b79e8d802893056033) by @lgray already resolves the issue with an adjustment of the filename-based approach, but I wanted to provide this PR as well because it checks the file content instead of relying on the file name.