### PR TITLE
Use eventindex instead of global index form for PHYSLITE schema

### DIFF
--- a/coffea/nanoevents/schemas/physlite.py
+++ b/coffea/nanoevents/schemas/physlite.py
@@ -133,6 +133,12 @@ class PHYSLITESchema(BaseSchema):
                             ((key, sub_key + "__G__" + linkto_collection), form)
                         )
 
+            # eventindex forms
+            if sub_key.endswith("pt"):
+                zip_groups[objname].append(
+                    ((key, "_eventindex"), self._create_eventindex_form(ak_form, key))
+                )
+
         contents = {}
         for objname, keys_and_form in zip_groups.items():
             try:
@@ -173,6 +179,15 @@ class PHYSLITESchema(BaseSchema):
         )
         form["content"]["content"]["itemsize"] = 8
         form["content"]["content"]["primitive"] = "int64"
+        return form
+
+    @staticmethod
+    def _create_eventindex_form(base_form, key):
+        form = copy.deepcopy(base_form)
+        form["content"]["parameters"] = {}
+        form["content"]["form_key"] = quote(f"{key},!load,!eventindex,!content")
+        form["content"]["itemsize"] = 8
+        form["content"]["primitive"] = "int64"
         return form
 
     @property

--- a/coffea/nanoevents/schemas/physlite.py
+++ b/coffea/nanoevents/schemas/physlite.py
@@ -19,9 +19,9 @@ class PHYSLITESchema(BaseSchema):
     Collections are assigned mixin types according to the `mixins` mapping.
     All collections are then zipped into one `base.NanoEvents` record and returned.
 
-    Cross references are build from ElementLink columns where the possible
-    index -> target collection relations are currently hard coded in the
-    `cross_reference_indices` and `cross_reference_elementlinks` mappings.
+    Cross references are build from ElementLink columns. Global indices are
+    created dynamically, using an ``_eventindex`` field that is attached to
+    each collection.
     """
 
     _hack_for_elementlink_int64 = True
@@ -61,38 +61,13 @@ class PHYSLITESchema(BaseSchema):
     for _k in truth_collections:
         mixins[_k] = "TruthParticle"
 
-    cross_reference_indices = {
-        ("Muons", "combinedTrackParticleLink.m_persIndex"): [
-            "CombinedMuonTrackParticles"
-        ]
-    }
-    """Possible relations for single-jagged ElementLinks"""
-
-    cross_reference_elementlinks = {
-        ("Electrons", "trackParticleLinks"): ["GSFTrackParticles"],
-        ("HLT_e7_lhmedium_nod0_mu24", "TrigMatchedObjects"): ["Electrons", "Muons"],
-    }
-    """Possible relations for double-jagged ElementLinks"""
-    for _k in truth_collections:
-        cross_reference_elementlinks[(_k, "childLinks")] = truth_collections
-        cross_reference_elementlinks[(_k, "parentLinks")] = truth_collections
-
-    link_load_columns = {
-        "CombinedMuonTrackParticles": "CombinedMuonTrackParticlesAuxDyn.z0",
-        "GSFTrackParticles": "GSFTrackParticlesAuxDyn.z0",
-        "Electrons": "AnalysisElectronsAuxDyn.pt",
-        "Muons": "AnalysisMuonsAuxDyn.pt",
-    }
-    """Columns to load for extracting offsets when creating global indices"""
-    for _k in truth_collections:
-        link_load_columns[_k] = f"{_k}AuxDyn.px"
-
     def __init__(self, base_form):
         super().__init__(base_form)
         self._form["contents"] = self._build_collections(self._form["contents"])
 
     def _build_collections(self, branch_forms):
         zip_groups = defaultdict(list)
+        has_eventindex = defaultdict(bool)
         for key, ak_form in branch_forms.items():
             # Normal fields
             key_fields = key.split("/")[-1].split(".")
@@ -113,32 +88,18 @@ class PHYSLITESchema(BaseSchema):
 
             zip_groups[objname].append(((key, sub_key), ak_form))
 
-            # Global indices
-            for cross_references in [
-                self.cross_reference_indices,
-                self.cross_reference_elementlinks,
-            ]:
-                if (objname, sub_key) in cross_references:
-                    for linkto_collection in cross_references[(objname, sub_key)]:
-                        linkto_key = self.link_load_columns[linkto_collection]
-                        if cross_references is self.cross_reference_indices:
-                            form = self._create_global_index_form(
-                                ak_form, key, linkto_key
-                            )
-                        elif cross_references is self.cross_reference_elementlinks:
-                            form = self._create_global_index_form_elementlink(
-                                ak_form, key, linkto_key
-                            )
-                        zip_groups[objname].append(
-                            ((key, sub_key + "__G__" + linkto_collection), form)
-                        )
-
-            # eventindex forms
-            if sub_key.endswith("pt"):
+            # add eventindex form, based on the first single-jagged list column
+            if (
+                not has_eventindex[objname]
+                and "List" in ak_form["class"]
+                and "List" not in ak_form["content"]["class"]
+            ):
                 zip_groups[objname].append(
                     ((key, "_eventindex"), self._create_eventindex_form(ak_form, key))
                 )
+                has_eventindex[objname] = True
 
+        # zip the forms
         contents = {}
         for objname, keys_and_form in zip_groups.items():
             try:
@@ -156,38 +117,15 @@ class PHYSLITESchema(BaseSchema):
         return contents
 
     @staticmethod
-    def _create_global_index_form(base_form, key, linkto_key):
-        form = copy.deepcopy(base_form)
-        form["content"]["form_key"] = quote(
-            f"{key},!load,{linkto_key},!load,!offsets,!local2global"
-        )
-        form["content"]["itemsize"] = 8
-        form["content"]["primitive"] = "int64"
-        return form
-
-    @staticmethod
-    def _create_global_index_form_elementlink(base_form, key, linkto_key):
-        form = copy.deepcopy(base_form)
-        record = form["content"]["content"]["contents"]
-        form["content"]["content"] = record["m_persIndex"]
-        form["content"]["content"]["form_key"] = quote(
-            f"{key},!load,m_persIndex,!item,{linkto_key},!load,!offsets,!local2global"
-        )
-        form["content"]["form_key"] = quote(
-            # the !skip,{linkto_key} is a hack to avoid having the same key as the actual elementlink
-            f"{key},!load,!content,!skip,{linkto_key}"
-        )
-        form["content"]["content"]["itemsize"] = 8
-        form["content"]["content"]["primitive"] = "int64"
-        return form
-
-    @staticmethod
     def _create_eventindex_form(base_form, key):
         form = copy.deepcopy(base_form)
-        form["content"]["parameters"] = {}
-        form["content"]["form_key"] = quote(f"{key},!load,!eventindex,!content")
-        form["content"]["itemsize"] = 8
-        form["content"]["primitive"] = "int64"
+        form["content"] = {
+            "class": "NumpyArray",
+            "parameters": {},
+            "form_key": quote(f"{key},!load,!eventindex,!content"),
+            "itemsize": 8,
+            "primitive": "int64",
+        }
         return form
 
     @property

--- a/coffea/nanoevents/transforms.py
+++ b/coffea/nanoevents/transforms.py
@@ -335,3 +335,9 @@ def nestedindex(stack):
 def item(stack):
     field = stack.pop()
     stack.append(stack.pop()[field])
+
+
+def eventindex(stack):
+    out = stack.pop()
+    out, _ = awkward.broadcast_arrays(numpy.arange(len(out)), out)
+    stack.append(out)

--- a/coffea/nanoevents/transforms.py
+++ b/coffea/nanoevents/transforms.py
@@ -339,5 +339,5 @@ def item(stack):
 
 def eventindex(stack):
     out = stack.pop()
-    out, _ = awkward.broadcast_arrays(numpy.arange(len(out)), out)
+    out, _ = awkward.broadcast_arrays(numpy.arange(len(out), dtype=numpy.int64), out)
     stack.append(out)


### PR DESCRIPTION
This might be a way to avoid hardcoding all possible relations between collections that can link into each other: Instead of a global index i attach an event index to all collections (also via a lazy form). This eventindex can then be used to index into the offset array of an arbitrary target collection (even after the object has been sliced) which then can be used to create the global indices.

Then i only have to specify the targets for links into fixed collections in the corresponding mixin methods and for the links into arbitrary/multiple collections i can do it dynamically.

I think i would prefer that approach. What do @nsmith- , @lgray  think? Am i missing something obvious?