### PR TITLE
Fix JER smearing hybrid method deltaPtRel threshold

### DIFF
--- a/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -71,7 +71,7 @@ def jer_smear(
     jersmear = jet_energy_resolution * jet_resolution_rand_gauss
     jersf = jet_energy_resolution_scale_factor[:, variation]
     deltaPtRel = (jetPt - pt_gen) / jetPt
-    doHybrid = (pt_gen > 0) & (numpy.abs(deltaPtRel) < 3)
+    doHybrid = (pt_gen > 0) & (numpy.abs(deltaPtRel) < 3 * jet_energy_resolution)
 
     detSmear = 1 + (jersf - 1) * deltaPtRel
     stochSmear = 1 + numpy.sqrt(numpy.maximum(jersf ** 2 - 1, 0)) * jersmear


### PR DESCRIPTION
According to the [twiki](https://twiki.cern.ch/twiki/bin/view/CMS/JetResolution), `deltaPtRel` should be smaller than 3 times the resolution, for the hybrid JER smearing method to be applicable.
This is corroborated by the [implementation of the `SmearedJetProducerT`](https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h), see [L76](https://github.com/cms-sw/cmssw/blob/a59283f45c8b5becca6cff5e643687c6241343a3/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L76) and [L243](https://github.com/cms-sw/cmssw/blob/a59283f45c8b5becca6cff5e643687c6241343a3/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h#L243) and [typical values for `dPtMaxFactor`](https://github.com/cms-sw/cmssw/search?q=dPtMaxFactor).
