### PR TITLE
Testing and Updates to Auto Schema

### DIFF
--- a/coffea/nanoevents/schemas/schema.py
+++ b/coffea/nanoevents/schemas/schema.py
@@ -9,7 +9,7 @@ def _build_record_array(
     """Build a record array using the mapping we've got from the contents.
 
     Args:
-        nam_mapping (Dict[str, str]): The mapping of user variable to column in the contents
+        name_mapping (Dict[str, str]): The mapping of user variable to column in the contents
         contents (Dict[str, Any]): The contents of the array we are building into
     """
     items = {
@@ -33,7 +33,7 @@ def _build_record_array(
 
 
 class auto_schema(BaseSchema):
-    """Build a schema"""
+    """Build a schema using heuristics to imply a structure"""
 
     def __init__(self, base_form: Dict[str, Any]):
         """Create an auto schema by parsing the names of the incoming columns
@@ -42,6 +42,7 @@ class auto_schema(BaseSchema):
             - There is a recursiveness to this defintion, as there is to any data structure,
               that is not matched with this. This should be made much more flexible. Perhaps
               with something like python type-hints so editors can also take advantage of this.
+            - Any `_` is inerpreted as going down a level in the structure.
 
         Args:
             base_form (Dict[str, Any]): The base form of what we are going to generate a new schema (form) for.
@@ -50,7 +51,7 @@ class auto_schema(BaseSchema):
 
         # Get the collection names - anything with a common name before the "_".
         contents = self._form["contents"]
-        collections = set(k.split("_")[0] for k in contents)
+        collections = set(k.split("_")[0] for k in contents if '_' in k)
 
         output = {}
         for c_name in collections:
@@ -60,20 +61,38 @@ class auto_schema(BaseSchema):
 
             # Build the new data model from this guy. Look at what is available to see if
             # we can build a 4-vector collection or just a "normal" collection.
-            is_4vector = (
+            is_4vector_mass = (
                 "pt" in mapping
                 and "eta" in mapping
                 and "phi" in mapping
                 and "mass" in mapping
+                and "charge" in mapping
             )
+            is_4vector_E = (
+                "pt" in mapping
+                and "eta" in mapping
+                and "phi" in mapping
+                and "energy" in mapping
+                and "charge" in mapping
+            )
+            record_name = "PtEtaPhiMCandidate" if is_4vector_mass \
+                else "PtEtaPhiECandidate" if is_4vector_E \
+                else "NanoCollection"
+
             record = _build_record_array(
                 c_name,
                 mapping,
                 contents,
-                "PtEtaPhiMCandidate" if is_4vector else "NanoCollection",
+                record_name,
             )
+
             record["parameters"].update({"collection_name": c_name})
             output[c_name] = record
+
+        # Single items in the collection
+        single_items = [k for k in contents if '_' not in k]
+        for item_name in single_items:
+            output[item_name] = contents[item_name]
 
         self._form["contents"] = output
 

--- a/coffea/nanoevents/schemas/schema.py
+++ b/coffea/nanoevents/schemas/schema.py
@@ -51,7 +51,7 @@ class auto_schema(BaseSchema):
 
         # Get the collection names - anything with a common name before the "_".
         contents = self._form["contents"]
-        collections = set(k.split("_")[0] for k in contents if '_' in k)
+        collections = set(k.split("_")[0] for k in contents if "_" in k)
 
         output = {}
         for c_name in collections:
@@ -75,9 +75,13 @@ class auto_schema(BaseSchema):
                 and "energy" in mapping
                 and "charge" in mapping
             )
-            record_name = "PtEtaPhiMCandidate" if is_4vector_mass \
-                else "PtEtaPhiECandidate" if is_4vector_E \
+            record_name = (
+                "PtEtaPhiMCandidate"
+                if is_4vector_mass
+                else "PtEtaPhiECandidate"
+                if is_4vector_E
                 else "NanoCollection"
+            )
 
             record = _build_record_array(
                 c_name,
@@ -90,7 +94,7 @@ class auto_schema(BaseSchema):
             output[c_name] = record
 
         # Single items in the collection
-        single_items = [k for k in contents if '_' not in k]
+        single_items = [k for k in contents if "_" not in k]
         for item_name in single_items:
             output[item_name] = contents[item_name]
 

--- a/tests/test_nanoevents_schema.py
+++ b/tests/test_nanoevents_schema.py
@@ -1,0 +1,248 @@
+from coffea.nanoevents.schemas.schema import auto_schema
+
+
+def test_auto_empty():
+    'Test an empy incoming form'
+
+    b = auto_schema({'contents': {}})
+
+    assert len(b.form["contents"]) == 0
+
+
+def test_auto_single_no_structure():
+    'Test a single item with no underscore'
+
+    b = auto_schema({
+        'contents': {
+            'pt': {}
+        }
+    })
+
+    assert len(b.form['contents']) == 1
+
+
+def test_auto_single_with_structure():
+    'Test a single item, that does have an underscore'
+
+    b = auto_schema({
+        'contents': {
+            'lep_pt': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+        },
+    })
+
+    assert 'lep' in b.form['contents']
+    assert 'pt' in b.form['contents']['lep']['content']['contents']
+
+
+def test_auto_multi_with_structure():
+    'Test a multiple items, that does have an underscore'
+
+    b = auto_schema({
+        'contents': {
+            'lep_pt': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_eta': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_phi': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+        },
+    })
+
+    assert 'lep' in b.form['contents']
+    assert 'pt' in b.form['contents']['lep']['content']['contents']
+    assert 'phi' in b.form['contents']['lep']['content']['contents']
+    assert 'eta' in b.form['contents']['lep']['content']['contents']
+
+
+def test_auto_multi_and_single_with_structure():
+    'Test a multiple items along with a non-structure item, that does have an underscore'
+
+    b = auto_schema({
+        'contents': {
+            'lep_pt': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_eta': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_phi': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'fork': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+        },
+    })
+
+    assert 'lep' in b.form['contents']
+    assert 'fork' in b.form['contents']
+    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'NanoCollection'
+
+
+def test_auto_4vector_mass():
+    'Test a multiple items, that does have an underscore'
+
+    b = auto_schema({
+        'contents': {
+            'lep_pt': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_eta': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_phi': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_mass': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_charge': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            # Make sure we can handle an extra item besides!
+            'lep_extra': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+        },
+    })
+
+    assert 'lep' in b.form['contents']
+    assert 'extra' in b.form['contents']['lep']['content']['contents']
+    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'PtEtaPhiMCandidate'
+
+
+def test_auto_4vector_e():
+    'Test a multiple items, that does have an underscore'
+
+    b = auto_schema({
+        'contents': {
+            'lep_pt': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_eta': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_phi': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_energy': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            'lep_charge': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+            # Make sure we can handle an extra item besides!
+            'lep_extra': {
+                'content': {
+                    'class': 'RecordArray'
+                },
+                'class': 'RecordArray',
+                'offsets': None,
+                'form_key': None,
+            },
+        },
+    })
+
+    assert 'lep' in b.form['contents']
+    assert 'extra' in b.form['contents']['lep']['content']['contents']
+    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'PtEtaPhiECandidate'

--- a/tests/test_nanoevents_schema.py
+++ b/tests/test_nanoevents_schema.py
@@ -2,247 +2,222 @@ from coffea.nanoevents.schemas.schema import auto_schema
 
 
 def test_auto_empty():
-    'Test an empy incoming form'
+    "Test an empy incoming form"
 
-    b = auto_schema({'contents': {}})
+    b = auto_schema({"contents": {}})
 
     assert len(b.form["contents"]) == 0
 
 
 def test_auto_single_no_structure():
-    'Test a single item with no underscore'
+    "Test a single item with no underscore"
 
-    b = auto_schema({
-        'contents': {
-            'pt': {}
-        }
-    })
+    b = auto_schema({"contents": {"pt": {}}})
 
-    assert len(b.form['contents']) == 1
+    assert len(b.form["contents"]) == 1
 
 
 def test_auto_single_with_structure():
-    'Test a single item, that does have an underscore'
+    "Test a single item, that does have an underscore"
 
-    b = auto_schema({
-        'contents': {
-            'lep_pt': {
-                'content': {
-                    'class': 'RecordArray'
+    b = auto_schema(
+        {
+            "contents": {
+                "lep_pt": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
             },
-        },
-    })
+        }
+    )
 
-    assert 'lep' in b.form['contents']
-    assert 'pt' in b.form['contents']['lep']['content']['contents']
+    assert "lep" in b.form["contents"]
+    assert "pt" in b.form["contents"]["lep"]["content"]["contents"]
 
 
 def test_auto_multi_with_structure():
-    'Test a multiple items, that does have an underscore'
+    "Test a multiple items, that does have an underscore"
 
-    b = auto_schema({
-        'contents': {
-            'lep_pt': {
-                'content': {
-                    'class': 'RecordArray'
+    b = auto_schema(
+        {
+            "contents": {
+                "lep_pt": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_eta': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_eta": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_phi': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_phi": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
             },
-        },
-    })
+        }
+    )
 
-    assert 'lep' in b.form['contents']
-    assert 'pt' in b.form['contents']['lep']['content']['contents']
-    assert 'phi' in b.form['contents']['lep']['content']['contents']
-    assert 'eta' in b.form['contents']['lep']['content']['contents']
+    assert "lep" in b.form["contents"]
+    assert "pt" in b.form["contents"]["lep"]["content"]["contents"]
+    assert "phi" in b.form["contents"]["lep"]["content"]["contents"]
+    assert "eta" in b.form["contents"]["lep"]["content"]["contents"]
 
 
 def test_auto_multi_and_single_with_structure():
-    'Test a multiple items along with a non-structure item, that does have an underscore'
+    "Test a multiple items along with a non-structure item, that does have an underscore"
 
-    b = auto_schema({
-        'contents': {
-            'lep_pt': {
-                'content': {
-                    'class': 'RecordArray'
+    b = auto_schema(
+        {
+            "contents": {
+                "lep_pt": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_eta': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_eta": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_phi': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_phi": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'fork': {
-                'content': {
-                    'class': 'RecordArray'
+                "fork": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
             },
-        },
-    })
+        }
+    )
 
-    assert 'lep' in b.form['contents']
-    assert 'fork' in b.form['contents']
-    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'NanoCollection'
+    assert "lep" in b.form["contents"]
+    assert "fork" in b.form["contents"]
+    assert (
+        b.form["contents"]["lep"]["content"]["parameters"]["__record__"]
+        == "NanoCollection"
+    )
 
 
 def test_auto_4vector_mass():
-    'Test a multiple items, that does have an underscore'
+    "Test a multiple items, that does have an underscore"
 
-    b = auto_schema({
-        'contents': {
-            'lep_pt': {
-                'content': {
-                    'class': 'RecordArray'
+    b = auto_schema(
+        {
+            "contents": {
+                "lep_pt": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_eta': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_eta": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_phi': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_phi": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_mass': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_mass": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_charge': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_charge": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            # Make sure we can handle an extra item besides!
-            'lep_extra': {
-                'content': {
-                    'class': 'RecordArray'
+                # Make sure we can handle an extra item besides!
+                "lep_extra": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
             },
-        },
-    })
+        }
+    )
 
-    assert 'lep' in b.form['contents']
-    assert 'extra' in b.form['contents']['lep']['content']['contents']
-    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'PtEtaPhiMCandidate'
+    assert "lep" in b.form["contents"]
+    assert "extra" in b.form["contents"]["lep"]["content"]["contents"]
+    assert (
+        b.form["contents"]["lep"]["content"]["parameters"]["__record__"]
+        == "PtEtaPhiMCandidate"
+    )
 
 
 def test_auto_4vector_e():
-    'Test a multiple items, that does have an underscore'
+    "Test a multiple items, that does have an underscore"
 
-    b = auto_schema({
-        'contents': {
-            'lep_pt': {
-                'content': {
-                    'class': 'RecordArray'
+    b = auto_schema(
+        {
+            "contents": {
+                "lep_pt": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_eta': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_eta": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_phi': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_phi": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_energy': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_energy": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            'lep_charge': {
-                'content': {
-                    'class': 'RecordArray'
+                "lep_charge": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
-            },
-            # Make sure we can handle an extra item besides!
-            'lep_extra': {
-                'content': {
-                    'class': 'RecordArray'
+                # Make sure we can handle an extra item besides!
+                "lep_extra": {
+                    "content": {"class": "RecordArray"},
+                    "class": "RecordArray",
+                    "offsets": None,
+                    "form_key": None,
                 },
-                'class': 'RecordArray',
-                'offsets': None,
-                'form_key': None,
             },
-        },
-    })
+        }
+    )
 
-    assert 'lep' in b.form['contents']
-    assert 'extra' in b.form['contents']['lep']['content']['contents']
-    assert b.form['contents']['lep']['content']['parameters']['__record__'] == 'PtEtaPhiECandidate'
+    assert "lep" in b.form["contents"]
+    assert "extra" in b.form["contents"]["lep"]["content"]["contents"]
+    assert (
+        b.form["contents"]["lep"]["content"]["parameters"]["__record__"]
+        == "PtEtaPhiECandidate"
+    )


### PR DESCRIPTION
Add Features:

* Correctly look for all required items for Pt, Eta, phi, mass, charge (!), candidates
* Add a pT, Eta, Phi, E, charge candidate
* More careful testing of the auto_schema code.

Bug fixes:
* Correctly deal with a single item that has an underscore
* Correctly deal with a single item