### PR TITLE
Make WorkItem a namedtuple

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -12,7 +12,7 @@ import uproot
 import uuid
 import warnings
 from tqdm.auto import tqdm
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from cachetools import LRUCache
 import lz4.frame as lz4f
 from .processor import ProcessorABC
@@ -127,19 +127,17 @@ class FileMeta(object):
                     actual_chunksize = next_chunksize
 
 
-class WorkItem(object):
-    __slots__ = [
-        "dataset",
-        "filename",
-        "treename",
-        "entrystart",
-        "entrystop",
-        "fileuuid",
-        "usermeta",
-    ]
-
-    def __init__(
-        self,
+class WorkItem(namedtuple("WorkItemBase", [
+    "dataset",
+    "filename",
+    "treename",
+    "entrystart",
+    "entrystop",
+    "fileuuid",
+    "usermeta"
+])):
+    def __new__(
+        cls,
         dataset,
         filename,
         treename,
@@ -148,13 +146,16 @@ class WorkItem(object):
         fileuuid,
         usermeta=None,
     ):
-        self.dataset = dataset
-        self.filename = filename
-        self.treename = treename
-        self.entrystart = entrystart
-        self.entrystop = entrystop
-        self.fileuuid = fileuuid
-        self.usermeta = usermeta
+        return cls.__bases__[0].__new__(
+            cls,
+            dataset,
+            filename,
+            treename,
+            entrystart,
+            entrystop,
+            fileuuid,
+            usermeta
+        )
 
     def __len__(self):
         return self.entrystop - self.entrystart

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -754,7 +754,10 @@ def _work_function(
                     elif format == "parquet":
                         rados_parquet_options = {}
                         if ":" in item.filename:
-                            ceph_config_path, item.filename = item.filename.split(":")
+                            ceph_config_path, filename = item.filename.split(":")
+                            item = item._as_dict()
+                            item["filename"] = filename
+                            item = WorkItem(**item)
                             rados_parquet_options["ceph_config_path"] = ceph_config_path
 
                         factory = NanoEventsFactory.from_parquet(

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -127,15 +127,20 @@ class FileMeta(object):
                     actual_chunksize = next_chunksize
 
 
-class WorkItem(namedtuple("WorkItemBase", [
-    "dataset",
-    "filename",
-    "treename",
-    "entrystart",
-    "entrystop",
-    "fileuuid",
-    "usermeta"
-])):
+class WorkItem(
+    namedtuple(
+        "WorkItemBase",
+        [
+            "dataset",
+            "filename",
+            "treename",
+            "entrystart",
+            "entrystop",
+            "fileuuid",
+            "usermeta",
+        ],
+    )
+):
     def __new__(
         cls,
         dataset,
@@ -147,14 +152,7 @@ class WorkItem(namedtuple("WorkItemBase", [
         usermeta=None,
     ):
         return cls.__bases__[0].__new__(
-            cls,
-            dataset,
-            filename,
-            treename,
-            entrystart,
-            entrystop,
-            fileuuid,
-            usermeta
+            cls, dataset, filename, treename, entrystart, entrystop, fileuuid, usermeta
         )
 
     def __len__(self):

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -755,7 +755,7 @@ def _work_function(
                         rados_parquet_options = {}
                         if ":" in item.filename:
                             ceph_config_path, filename = item.filename.split(":")
-                            item = item._as_dict()
+                            item = item._asdict()
                             item["filename"] = filename
                             item = WorkItem(**item)
                             rados_parquet_options["ceph_config_path"] = ceph_config_path


### PR DESCRIPTION
This allows proper comparison between instances while keeping them hashable.

### Issue
While implementing a custom executor, I noticed the `WorkItem` is really not flexible. While the `FileMeta` class has `__eq__` implemented, `WorkItem` doesn't. Not having `__eq__` turned out to be a big drawback because use cases like `item in somelist` are not possible.

### Solution
Inherit from `namedtuple`. This should not affect the current use of `WorkItem` in any way. However it adds several nice advantages, like `__eq__`, `__hash__` and `__str__`.