### PR TITLE
Fixed jersf_lookup for 0 jets 

### DIFF
--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -87,6 +87,7 @@ class jersf_lookup(lookup_base):
             bin_indices.append(
                 masked_bin_eval(bin_indices[0], self._bins[binname], bin_vals[binname])
             )
+        bin_indices.append(0)
         bin_tuple = tuple(bin_indices)
 
         # get clamp values and clip the inputs
@@ -98,7 +99,7 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parm)[bin_tuple].squeeze() for parm in self._parms],
+            [numpy.array(parm[bin_tuple]) for parm in self._parms],
             axis=1,
         )
         return parm_values

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -98,7 +98,7 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parms)[..., 0][bin_tuple] for parm in self._parms],
+            [numpy.array(parm)[..., 0][bin_tuple] for parm in self._parms],
             axis=1,
         )
         return parm_values

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -98,7 +98,7 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parm)[..., 0][bin_tuple] for parm in self._parms],
+            [numpy.array(parm)[bin_tuple].squeeze() for parm in self._parms],
             axis=1,
         )
         return parm_values

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -87,7 +87,6 @@ class jersf_lookup(lookup_base):
             bin_indices.append(
                 masked_bin_eval(bin_indices[0], self._bins[binname], bin_vals[binname])
             )
-        bin_indices.append(0)
         bin_tuple = tuple(bin_indices)
 
         # get clamp values and clip the inputs
@@ -99,7 +98,7 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parm[bin_tuple]) for parm in self._parms],
+            [numpy.array(parm[..., 0][bin_tuple]) for parm in self._parms],
             axis=1,
         )
         return parm_values

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -98,9 +98,11 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parm[..., 0][bin_tuple]) for parm in self._parms],
+            [numpy.array(parm[bin_tuple]).squeeze() for parm in self._parms],
             axis=1,
         )
+        if parm_values.shape[2:] == (0,):
+            parm_values.shape = parm_values.shape[:2]
         return parm_values
 
     @property

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -97,11 +97,9 @@ class jersf_lookup(lookup_base):
             eval_values.append(numpy.clip(eval_vals[eval_name], clamp_mins, clamp_maxs))
 
         # get parameter values
-        parm_values_central = numpy.array(self._parms[0][bin_tuple]).squeeze()
-        parm_values_up = numpy.array(self._parms[1][bin_tuple]).squeeze()
-        parm_values_down = numpy.array(self._parms[2][bin_tuple]).squeeze()
         parm_values = numpy.stack(
-            [parm_values_central, parm_values_up, parm_values_down], axis=1
+            [numpy.array(parms)[..., 0][bin_tuple] for parm in self._parms],
+            axis=1,
         )
         return parm_values
 

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -492,7 +492,7 @@ def test_jet_resolution_sf_2d():
     print(resosf)
 
     # 0-jet compatibility
-    assert resosf.getScaleFactor(JetPt=test_pt[:0], JetEta=test_eta[:0]).shape == (0, 3) 
+    assert resosf.getScaleFactor(JetPt=test_pt[:0], JetEta=test_eta[:0]).shape == (0, 3)
 
     resosfs = resosf.getScaleFactor(JetPt=test_pt, JetEta=test_eta)
     resosfs_jag = resosf.getScaleFactor(JetPt=test_pt_jag, JetEta=test_eta_jag)

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -442,6 +442,9 @@ def test_jet_resolution_sf():
 
     print(resosf)
 
+    # 0-jet compatibility
+    assert resosf.getScaleFactor(JetEta=test_eta[:0]).shape == (0, 3)
+
     resosfs = resosf.getScaleFactor(JetEta=test_eta)
     resosfs_jag = resosf.getScaleFactor(JetEta=test_eta_jag)
     assert ak.all(resosfs == ak.flatten(resosfs_jag))
@@ -487,6 +490,9 @@ def test_jet_resolution_sf_2d():
     )
 
     print(resosf)
+
+    # 0-jet compatibility
+    assert resosf.getScaleFactor(JetPt=test_pt[:0], JetEta=test_eta[:0]).shape == (0, 3) 
 
     resosfs = resosf.getScaleFactor(JetPt=test_pt, JetEta=test_eta)
     resosfs_jag = resosf.getScaleFactor(JetPt=test_pt_jag, JetEta=test_eta_jag)


### PR DESCRIPTION
When passing arguments to `jersf_lookup` (both `__call__` and `_evaluate`) that have an effective shape of `(N...)`, where `N...` has an `0` in its shape i.e. `numpy` shape `(0,)`, the function returns an effective shape of `(N..., 3, 0)` instead of the expected `(N..., 3)`. This is caused by an [difference in behavior of fancy indexing on awkward arrays vs. numpy arrays](https://github.com/scikit-hep/awkward-1.0/discussions/1047). The proposed change uses the assumption that the inner most dimension of the arrays in `self._parms` is consistent, since it ought to be because it is actually not fed into any function to be evaluated but rather a constant.