### PR TITLE
wq: enable fast termination on workers

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -300,6 +300,12 @@ def work_queue_executor(items, function, accumulator, **kwargs):
                       throughput.
         resource-monitor : bool
             If true, (false is the default) turns on resource monitoring for Work Queue.
+        fast_terminate_workers: int
+            Terminate workers on which tasks have been running longer than average.
+            The time limit is computed by multiplying the average runtime of tasks
+            by the value of 'fast_terminate_workers'. Since there are
+            legitimately slow tasks, no task may trigger fast termination in
+            two distinct workers. Less than 1 disables it.
 
         master-name : str
             Name to refer to this work queue master.

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -443,6 +443,7 @@ def work_queue_main(items, function, accumulator, **kwargs):
         "wrapper": shutil.which("python_package_run"),
         "resource_monitor": False,
         "resources_mode": "fixed",
+        "fast_terminate_workers": None,
         "cores": None,
         "memory": None,
         "disk": None,
@@ -706,6 +707,15 @@ def _declare_resources(exec_defaults):
 
         if exec_defaults["resources_mode"] == "auto":
             _wq_queue.specify_category_mode(category, wq.WORK_QUEUE_ALLOCATION_MODE_MAX)
+
+        # enable fast termination of workers
+        if (
+            exec_defaults["fast_terminate_workers"]
+            and exec_defaults["fast_terminate_workers"] > 1
+        ):
+            _wq_queue.activate_fast_abort_category(
+                category, exec_defaults["fast_terminate_workers"]
+            )
 
 
 def _submit_proc_task(


### PR DESCRIPTION
Since Work Queue is build to run with heterogeneous resources, sometimes
some of those resources are significantly less powerful than the rest.
In such cases, it is better to terminate the slow workers and move the
tasks to other resources.

This pr activates the fast termination on workers of Work Queue. Tasks
that run for longer than task average time * fast_terminate_workers are
move to other workers, and the worker itself is released. Since there
are legitimately slow tasks, no task may trigger fast termination in two
different workers.

The default of fast_terminate_workers is None. Any value less than 1
disables it.

(This adds another parameter to the wq executor, which may produce a conflict with pr #557.)