### PR TITLE
[jersr-lookup] ensure no 0-dimensional arrays for `np.stack`

### DIFF
--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -98,7 +98,7 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.array(parm[bin_tuple]).squeeze() for parm in self._parms],
+            [numpy.atleast_1d(numpy.array(parm[bin_tuple]).squeeze()) for parm in self._parms],  # fmt: skip
             axis=1,
         )
         if parm_values.shape[2:] == (0,):

--- a/coffea/lookup_tools/jersf_lookup.py
+++ b/coffea/lookup_tools/jersf_lookup.py
@@ -98,7 +98,10 @@ class jersf_lookup(lookup_base):
 
         # get parameter values
         parm_values = numpy.stack(
-            [numpy.atleast_1d(numpy.array(parm[bin_tuple]).squeeze()) for parm in self._parms],  # fmt: skip
+            [
+                numpy.atleast_1d(numpy.array(parm[bin_tuple]).squeeze())
+                for parm in self._parms
+            ],
             axis=1,
         )
         if parm_values.shape[2:] == (0,):

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -273,6 +273,18 @@ def test_jec_txt_scalefactors():
     )
     print(jersf_out)
     print(jersf_out_jagged)
+
+    # single jet jersf lookup test:
+    single_jersf_out_1d = evaluator["Spring16_25nsV10_MC_SF_AK4PFPuppi"](
+        np.array([1.4]), np.array([44.0])
+    )
+    single_jersf_out_0d = evaluator["Spring16_25nsV10_MC_SF_AK4PFPuppi"](
+        np.array(1.4), np.array(44.0)
+    )
+    truth_out = np.array([[1.084, 1.095, 1.073]], dtype=np.float32)
+    assert np.all(single_jersf_out_1d == truth_out)
+    assert np.all(single_jersf_out_0d == truth_out)
+
     print(evaluator["Spring16_25nsV10_MC_SF_AK4PFPuppi"])
 
     junc_out = evaluator["Fall17_17Nov2017_V32_MC_Uncertainty_AK4PFPuppi"](


### PR DESCRIPTION
Hi @lgray @nsmith- ,

This PR fixes a very rare corner case, where only 1 jet enters the calculation.

The problem comes from the fact that `np.squeeze()` creates a 0-dimensional array if it has the length of 1:
```python
import numpy as np

np.array([[1, 2, 3]]).squeeze()
>> array([1, 2, 3]) # <- ndim == 1

np.array([[1]]).squeeze()
>> array(1)  # <- ndim == 0
```
In these cases `np.stack([...], axis=1)` failed.

Best, Peter