### PR TITLE
JEC: Fix eval var clamp columns shadowing

### DIFF
--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -68,15 +68,17 @@ def _parse_jme_formatted_file(
     columns = []
     dtypes = []
     offset = 1
+    prefix = "" if parmsFromColumns else "binned_"
     for i in range(nBinnedVars):
-        columns.extend(["%s%s" % (layout[i + offset], mm) for mm in minMax])
+        columns.extend(["%s%s%s" % (prefix, layout[i + offset], mm) for mm in minMax])
         dtypes.extend(["<f4", "<f4"])
     columns.append("NVars")
     dtypes.append("<i8")
     offset += nBinnedVars + 1
+    prefix = "" if parmsFromColumns else "eval_"
     if not interpolatedFunc:
         for i in range(nEvalVars):
-            columns.extend(["%s%s" % (layout[i + offset], mm) for mm in minMax])
+            columns.extend(["%s%s%s" % (prefix, layout[i + offset], mm) for mm in minMax])
             dtypes.extend(["<f4", "<f4"])
     for i in range(nParms):
         columns.append("p%i" % i)

--- a/coffea/lookup_tools/txt_converters.py
+++ b/coffea/lookup_tools/txt_converters.py
@@ -78,7 +78,9 @@ def _parse_jme_formatted_file(
     prefix = "" if parmsFromColumns else "eval_"
     if not interpolatedFunc:
         for i in range(nEvalVars):
-            columns.extend(["%s%s%s" % (prefix, layout[i + offset], mm) for mm in minMax])
+            columns.extend(
+                ["%s%s%s" % (prefix, layout[i + offset], mm) for mm in minMax]
+            )
             dtypes.extend(["<f4", "<f4"])
     for i in range(nParms):
         columns.append("p%i" % i)


### PR DESCRIPTION
The column names for binning and evaluation variables may be same if they contain the same variable (e.g. `JetPt`). This in turn will cause the clamping ranges for the evaluation be (erroneously) take from the binning ranges. This in turn will cause the evaluation produce wrong values, as it it evaluated outside of it's validity bound.

In our specific case the following "bin", from [Fall17_17Nov2017_V32_MC_L2Relative_AK4PFchs.txt](https://github.com/cms-jet/JECDatabase/blob/master/textFiles/Fall17_17Nov2017_V32_MC/Fall17_17Nov2017_V32_MC_L2Relative_AK4PFchs.txt)
`-3.139  -2.964     0.001   8.16034     7           8   8.1603353      1.585668383      7.954240808    0.09264927288      6.651879445       -22.662578`
used the wrong minimuim `JetPt` of 0.001 instead of 8 which caused low pT jets to produce highly unphysical calibration values >10.

The proposed fix alleviates this by by prefixing the columns - however, this is not done in the case of `parmsFromColumns=True` as it may expect column names to be specific values.