### PR TITLE
move ipywidgets to spark spec. (reduce bloat)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,14 +70,13 @@ INSTALL_REQUIRES = [
     "cloudpickle>=1.2.3",
     "mplhep>=0.1.18",
     "packaging",
-    "ipywidgets",
     "pandas",
     "hist>=2",
     'typing-extensions;python_version<"3.8"',
     "cachetools",
 ]
 EXTRAS_REQUIRE = {}
-EXTRAS_REQUIRE["spark"] = ["pyspark>=2.4.1,<3.0.0", "jinja2"]
+EXTRAS_REQUIRE["spark"] = ["ipywidgets", "pyspark>=2.4.1,<3.0.0", "jinja2"]
 EXTRAS_REQUIRE["parsl"] = ["parsl>=1.1"]
 EXTRAS_REQUIRE["dask"] = [
     "dask[dataframe]>=2.6.0",


### PR DESCRIPTION
As in title.

I think @perilousapricot requested this for easy packaging in his cluster. 
I've set it up so that `pip install coffea[spark]` with spark already installed will do the same thing, that should be manageable?
Let me know if not, otherwise I'd just kinda prefer people `pip install coffea ipywidgets` if they need it like that.

This chops a little over 100MB off the install size for coffea and appropriately factorizes coffea from jupyter/ipython.