### PR TITLE
Use `fsspec` to open `parquet` files in nanoevents factory

### DIFF
--- a/coffea/processor/servicex/dask_executor.py
+++ b/coffea/processor/servicex/dask_executor.py
@@ -59,8 +59,7 @@ class DaskExecutor(Executor):
         meta_data: Dict[str, str],
         process_func: Callable,
     ):
-        '''Create a dask future for a dask task to run the analysis.
-        '''
+        """Create a dask future for a dask task to run the analysis."""
         data_result = self.dask.submit(
             run_coffea_processor,
             events_url=file_url,

--- a/coffea/processor/servicex/dask_executor.py
+++ b/coffea/processor/servicex/dask_executor.py
@@ -59,6 +59,8 @@ class DaskExecutor(Executor):
         meta_data: Dict[str, str],
         process_func: Callable,
     ):
+        '''Create a dask future for a dask task to run the analysis.
+        '''
         data_result = self.dask.submit(
             run_coffea_processor,
             events_url=file_url,

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ INSTALL_REQUIRES = [
     "uproot3-methods>=0.10.0",
     "uproot3>=3.14.1",
     "pyarrow>=1.0.0",
+    "fsspec",
     "matplotlib>=3",
     "numba>=0.50.0",
     "numpy>=1.16.0",

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ EXTRAS_REQUIRE["dask"] = [
 EXTRAS_REQUIRE["servicex"] = [
     "aiostream",
     "tenacity",
-    "func-adl_servicex==1.1.1",
+    "func-adl_servicex==1.1.2b1",
 ]
 EXTRAS_REQUIRE["dev"] = [
     "flake8",

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ EXTRAS_REQUIRE["dask"] = [
 EXTRAS_REQUIRE["servicex"] = [
     "aiostream",
     "tenacity",
-    "func-adl_servicex==1.1.2b1",
+    "func-adl_servicex==1.1.2",
 ]
 EXTRAS_REQUIRE["dev"] = [
     "flake8",

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -1,7 +1,9 @@
 import os
+from pathlib import Path
+
 import awkward as ak
-from coffea.nanoevents import NanoEventsFactory, NanoAODSchema
 import pytest
+from coffea.nanoevents import NanoAODSchema, NanoEventsFactory
 
 
 def genroundtrips(genpart):
@@ -98,6 +100,20 @@ def test_read_nanomc(suffix):
             False,
             True,
         ]
+
+
+@pytest.mark.parametrize("suffix", suffixes)
+def test_read_from_uri(suffix):
+    "Make sure we can properly open the file when a uri is used"
+    path = Path(os.path.abspath(f"tests/samples/nano_dy.{suffix}")).as_uri()
+
+    nanoversion = NanoAODSchema.v6 if suffix == "root" else NanoAODSchema.v5
+    factory = getattr(NanoEventsFactory, f"from_{suffix}")(
+        path, schemaclass=nanoversion
+    )
+    events = factory.events()
+
+    assert len(events) == 40 if suffix == "root" else 10
 
 
 @pytest.mark.parametrize("suffix", suffixes)


### PR DESCRIPTION
* Enable alternate file sources for `parquet` files, like `file://...` and 'http://...` for the `from_parquet` class method of `nanoevents`.

Approach:
* Take advantage of the `fsspec` library, which is already included in the `coffea` distribution (pulled in, I think, by `pyarrow`.

This is a draft until:
* [x] Externally test that other URI's (like `http://...`) work.