### PR TITLE
wq: use a memory target to dynamically adapt the chunksize of processing tasks

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -978,7 +978,7 @@ def _chunk_generator(
     chunksize,
     align_clusters,
     maxchunks,
-    dynamic_chunksize=False,
+    dynamic_chunksize=None,
 ):
     if maxchunks is None:
         for filemeta in fileset:
@@ -991,7 +991,7 @@ def _chunk_generator(
             if nchunks[filemeta.dataset] >= maxchunks:
                 continue
             for chunk in filemeta.chunks(
-                chunksize, align_clusters, dynamic_chunksize=False
+                chunksize, align_clusters, dynamic_chunksize=None
             ):
                 chunks.append(chunk)
                 nchunks[filemeta.dataset] += 1
@@ -1011,8 +1011,7 @@ def run_uproot_job(
     chunksize=100000,
     maxchunks=None,
     metadata_cache=None,
-    dynamic_chunksize=False,
-    dynamic_chunksize_targets={},
+    dynamic_chunksize=None,
 ):
     """A tool to run a processor using uproot for data delivery
 
@@ -1070,13 +1069,12 @@ def run_uproot_job(
             determine chunking.  Defaults to a in-memory LRU cache that holds 100k entries
             (about 1MB depending on the length of filenames, etc.)  If you edit an input file
             (please don't) during a session, the session can be restarted to clear the cache.
-        dynamic_chunksize : bool, optional
-            Whether to adapt the chunksize for units of work to run in
-            dynamic_chunksize_target_time.
-        dynamic_chunksize_targets : dict, optional
-            The target execution measurements per chunk when using dynamic
-            chunksize. The chunksize will be modified to approximate these
-            measurements. Currently only supported is 'walltime' (default 60s).
+        dynamic_chunksize : dict, optional
+            Whether to adapt the chunksize for units of work to run in the targets given.
+            Currently supported are 'wall_time' (in seconds), and 'memory' (in MB).
+            E.g., with {"wall_time": 120, "memory": 2048}, the chunksize will
+            be dynamically adapted so that processing jobs each run in about
+            two minutes, using two GB of memory.
     """
 
     import warnings
@@ -1217,9 +1215,8 @@ def run_uproot_job(
         "function_name": type(processor_instance).__name__,
         "use_dataframes": use_dataframes,
         "events_total": events_total,
-        "dynamic_chunksize": dynamic_chunksize,
         "chunksize": chunksize,
-        "dynamic_chunksize_targets": dynamic_chunksize_targets,
+        "dynamic_chunksize": dynamic_chunksize,
     }
 
     exe_args.update(executor_args)

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -510,8 +510,7 @@ def work_queue_main(items, function, accumulator, **kwargs):
         "chunks_per_accum": 10,
         "chunks_accum_in_mem": 2,
         "chunksize": 1024,
-        "dynamic_chunksize": False,
-        "dynamic_chunksize_targets": {},
+        "dynamic_chunksize": {},
     }
 
     _update_deprecated_kwords(kwargs)
@@ -519,6 +518,8 @@ def work_queue_main(items, function, accumulator, **kwargs):
 
     # create new dictionary fillining kwargs defaults
     kwargs = {**default_kwargs, **kwargs}
+
+    _check_dynamic_chunksize_targets(kwargs["dynamic_chunksize"])
 
     clevel = kwargs["compression"]
     if clevel is not None:
@@ -1017,6 +1018,13 @@ def _warn_unknown_kwords(default_kwargs, kwargs):
     for key in sorted(kwargs):
         if key not in default_kwargs:
             warnings.warn("work_queue_executor key {} is unknown.".format(key))
+
+
+def _check_dynamic_chunksize_targets(targets):
+    if targets:
+        for k in targets:
+            if k not in ["wall_time", "memory"]:
+                raise KeyError("dynamic chunksize resource {} is unknown.".format(k))
 
 
 class ResultUnavailable(Exception):


### PR DESCRIPTION
This pr allows to use the work queue executor as:

```python
run_uproot_job(..., executor=work_queue_executor, chunksize=base_chunksize, dynamic_chunksize={"memory": target_memory})
```
where `base_chunksize` is some intial chunksize, and `target_memory` is a desired memory usage per processing job. As tasks are run, data is collected to find some relation between the chunksize and the memory consumption. The data is used to compute new chunksizes for later tasks. The final computed chunksize can then be used as the base_chunksize for later runs.

This can be used in conjunction with the `"memory"` argument of executor arguments to ensure that processing jobs are executed in the available resources.  If a job goes above the cores, memory, or disk given in the execution arguments, the processing job is split in two and retried, until the maximum number of retries is reached.

Note that this pr simplifies `dynamic_chunksize_targets`. Instead it converts `dynamic_chunksize` into a dictionary with the targets. Before, `dynamic_chunksize` was simply a boolean to activate the dynamic chunksize computation.


