### PR TITLE
Old executor fix

### DIFF
--- a/coffea/processor/__init__.py
+++ b/coffea/processor/__init__.py
@@ -48,8 +48,7 @@ def _run_x_job(
     chunksize=100000,
     maxchunks=None,
     metadata_cache=None,
-    dynamic_chunksize=False,
-    dynamic_chunksize_targets={},
+    dynamic_chunksize=None,
     format="root",
 ):
     """
@@ -98,7 +97,6 @@ def _run_x_job(
         maxchunks=maxchunks,
         metadata_cache=metadata_cache,
         dynamic_chunksize=dynamic_chunksize,
-        dynamic_chunksize_targets=dynamic_chunksize_targets,
         format=format,
         **executor_args,
     )

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -446,6 +446,8 @@ class IterativeExecutor(ExecutorBase):
             Ignored for iterative executor
     """
 
+    workers: int = 1
+    
     def __call__(
         self,
         items: Iterable,

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -447,7 +447,7 @@ class IterativeExecutor(ExecutorBase):
     """
 
     workers: int = 1
-    
+
     def __call__(
         self,
         items: Iterable,


### PR DESCRIPTION
fixes so that the old-style executors function out of the box. Ran into some issues in a runner.py setup.

@pfackeldey FYI