### PR TITLE
wq: allow custom configurations to the WorkQueue object

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -363,6 +363,11 @@ class WorkQueueExecutor(ExecutorBase):
             Filename for tasks lifetime reports output
         print_stdout : bool
             If true (default), print the standard output of work queue task on completion.
+
+        custom_init : function, optional
+            A function that takes as an argument the queue's WorkQueue object.
+            The function is called just before the first work unit is submitted
+            to the queue.
     """
 
     # Standard executor options:
@@ -395,6 +400,7 @@ class WorkQueueExecutor(ExecutorBase):
     chunks_accum_in_mem: int = 2
     chunksize: int = 1024
     dynamic_chunksize: Optional[Dict] = None
+    custom_init: Optional[Callable] = None
 
     def __call__(
         self,

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -525,6 +525,9 @@ def work_queue_main(items, function, accumulator, **kwargs):
             accumulate_fn, prefix_name="accum", tmpdir=tmpdir
         )
 
+        if kwargs["custom_init"]:
+            kwargs["custom_init"](_wq_queue)
+
         if kwargs["desc"] == "Preprocessing":
             return _work_queue_preprocessing(
                 items, accumulator, fn_wrapper, infile_function, tmpdir, kwargs


### PR DESCRIPTION
There are some low level WorkQueue parameters that seldom used, but that
are helpful for setting up test scenarios (e.g. modify timeouts, default
bandwidths, etc.) Rather than add these parameters to the executor API,
this pr adds the argument custom_init, which if given, should be a
function that takes as its argument the WorkQueue object, e.g.:

def myinit(q):
    q.block_host("some-bad-worker-host.net")

exec_args = {
    ...
    "custom_init": myinit
}