### PR TITLE
Remove awkward form workaround for PHYSLITE schema

### DIFF
--- a/coffea/nanoevents/mapping/uproot.py
+++ b/coffea/nanoevents/mapping/uproot.py
@@ -62,6 +62,7 @@ def _lazify_form(form, prefix, docstr=None):
 
 class UprootSourceMapping(BaseSourceMapping):
     _debug = False
+    _fix_awkward_form_of_iter = True
 
     def __init__(self, fileopener, cache=None, access_log=None):
         super(UprootSourceMapping, self).__init__(fileopener, cache, access_log)
@@ -97,9 +98,10 @@ class UprootSourceMapping(BaseSourceMapping):
                 )
                 continue
             # until awkward-forth is available, this fixer is necessary
-            form = uproot._util.recursively_fix_awkward_form_of_iter(
-                awkward, branch.interpretation, form
-            )
+            if cls._fix_awkward_form_of_iter:
+                form = uproot._util.recursively_fix_awkward_form_of_iter(
+                    awkward, branch.interpretation, form
+                )
             form = uproot._util.awkward_form_remove_uproot(awkward, form)
             form = json.loads(
                 form.tojson()

--- a/coffea/nanoevents/schemas/physlite.py
+++ b/coffea/nanoevents/schemas/physlite.py
@@ -24,8 +24,6 @@ class PHYSLITESchema(BaseSchema):
     each collection.
     """
 
-    _hack_for_elementlink_int64 = True
-
     truth_collections = [
         "TruthPhotons",
         "TruthMuons",
@@ -74,17 +72,6 @@ class PHYSLITESchema(BaseSchema):
             top_key = key_fields[0]
             sub_key = ".".join(key_fields[1:])
             objname = top_key.replace("Analysis", "").replace("AuxDyn", "")
-
-            # temporary hack to have the correct type for the ElementLinks
-            # (uproot loses the type information somewhere on the way and they end up int64)
-            if self._hack_for_elementlink_int64:
-                try:
-                    for k in ["m_persIndex", "m_persKey"]:
-                        form = ak_form["content"]["content"]["contents"][k]
-                        form["itemsize"] = 8
-                        form["primitive"] = "int64"
-                except KeyError:
-                    pass
 
             zip_groups[objname].append(((key, sub_key), ak_form))
 


### PR DESCRIPTION
The PHYSLITE schema had a workaround to hardcode the data types of ElementLinks to be int64 instead of uint32 which is their actually stored type. The reason for this is, as you know, that uproot reads such branches with `from_iter`.

Since @nsmith- fixed this centrally in scikit-hep/uproot4#441 (thanks!) which is now applied in `UprootSourceMapping` i can remove the workaround in the PHYSLITE schema.

I also added a class-level variable in `UprootSourceMapping` that could potentially turn the fix off again. I would like to have this because i'm experimenting with custom deserialization (and also AwkwardForth) - using this: https://gitlab.cern.ch/nihartma/physlite-experiments/-/blob/master/physlite_experiments/deserialization_hacks.py which then produces the correct types and should use the original form. Such a variable would allow me to try that out also with NanoEvents e.g. by monkey-patching the `extract_column` method of `UprootSourceMapping`