### PR TITLE
Ensure the dask pre_executor starts in clean state

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1049,6 +1049,7 @@ class Runner:
                 if isinstance(self.pre_executor, (FuturesExecutor, ParslExecutor)):
                     pre_arg_override.update({"tailtimeout": None})
                 if isinstance(self.pre_executor, (DaskExecutor)):
+                    self.pre_executor.heavy_input = None
                     pre_arg_override.update({"worker_affinity": False})
                 pre_executor = self.pre_executor.copy(**pre_arg_override)
                 closure = partial(self.automatic_retries, self.metadata_fetcher)


### PR DESCRIPTION
Running `Runner.__call__` over 2 different data sets was causing issues. It was found that the `dask_executor.heavy_input` left over from the first call needs to be reset for file preprocessing of the second call.