### PR TITLE
Fix WorkItem.__hash__

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -159,7 +159,7 @@ class WorkItem:
     entrystart: int
     entrystop: int
     fileuuid: str
-    usermeta: Optional[Dict] = None
+    usermeta: Optional[Dict] = field(default=None, compare=False)
 
     def __len__(self) -> int:
         return self.entrystop - self.entrystart

--- a/tests/test_workitem.py
+++ b/tests/test_workitem.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from coffea.processor.executor import WorkItem
+
+
+def test_work_item():
+    item1 = WorkItem("TestDataSet", "/a/b/c.root", "Events", 500, 670, "abc", {})
+    item2 = WorkItem(
+        "TestDataSet", "/a/b/c.root", "Events", 500, 670, "abc", {"meta": "data"}
+    )
+    item3 = WorkItem("TestDataSet", "/a/b/c.root", "Events", 500, 760, "abc", {})
+
+    assert item1 == item1
+    assert item1 == item2
+    assert item1 != item3
+    assert item1.dataset == "TestDataSet"
+    assert item1.filename == "/a/b/c.root"
+    assert item1.treename == "Events"
+    assert item1.entrystart == 500
+    assert item1.entrystop == 670
+    assert item1.fileuuid == "abc"
+    assert len(item1) == 670 - 500
+    assert len(item3) == 760 - 500
+
+    # Test if hashable
+    hash(item2)
+
+    # Test if usermeta is mutable
+    item1.usermeta["user"] = "meta"


### PR DESCRIPTION
Currently getting the hash of a `WorkItem` will often result in a `TypeError`, even though we force the generation of a `__hash__` method inside `WorkItem` using `unsafe_hash=True`. This is because `WorkItem.usermeta` is a dict when it's not None, and a dict is not hashable.

The solution is to exclude the `usermeta` from comparison, which in turn will also exclude it from the hashing.