### PR TITLE
Allow Cat growth when converted to Boost Hist to retain Coffea behavior

### DIFF
--- a/coffea/hist/hist_tools.py
+++ b/coffea/hist/hist_tools.py
@@ -1494,6 +1494,7 @@ class Hist(AccumulatorABC):
                 identifiers = self.identifiers(axis)
                 newaxis = boost_histogram.axis.StrCategory(
                     [x.name for x in identifiers],
+                    growth=True,
                 )
                 newaxis.name = axis.name
                 newaxis.label = axis.label


### PR DESCRIPTION
After converting a Coffea histogram that has Cats using `to_boost` or `to_hist`, filling it with a category that was not there before will have the fill go into flow bin. This is very different from Coffea's behavior, where the new category bin would be created. This functionality is however also present within boost_histogram and can be very easily enabled. The change does exactly that.
For me this is an important change, because I do not necessarily know all the category bins during histogram creation. Coffea's behavior and boost_histogram's behavior with `growth=True` is very useful, but I run into trouble if I also want to use `to_hist` in-between.