### PR TITLE
feat: recoverable processing + merging

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1734,12 +1734,18 @@ class Runner:
         else:
             processor_instance.postprocess(wrapped_out["out"])
 
+        def make_j_serializable(metrics):
+            for k, v in metrics.items():
+                if isinstance(v, set):
+                    metrics[k] = list(v)
+            return metrics
+
         _return = (wrapped_out["out"],)
         if hasattr(self.executor, "recoverable") and self.executor.recoverable:
             _return = *_return, list(wrapped_out["processed"])
         if self.savemetrics and not self.use_dataframes:
             wrapped_out["metrics"]["chunks"] = len(chunks)
-            _return = *_return, wrapped_out["metrics"]
+            _return = *_return, make_j_serializable(wrapped_out["metrics"])
         return _return if len(_return) > 1 else _return[0]
 
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1729,11 +1729,11 @@ class Runner:
         executor = self.executor.copy(**exe_args)
 
         wrapped_out, e = executor(chunks, closure, None)
-        wrapped_out["exception"] = e
         if wrapped_out is None:
             raise ValueError(
-                "No chunks were processed, veryify ``processor`` instance structure."
+                "No chunks returned results, verify ``processor`` instance structure."
             )
+        wrapped_out["exception"] = e
         if not self.use_dataframes:
             processor_instance.postprocess(wrapped_out["out"])
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -117,7 +117,7 @@ def test_processor_newaccumulator():
         proc.process,
         None,
     )
-    assert out == {"itemsum": 45}
+    assert out == ({"itemsum": 45}, 0)
 
     class TestOldStyle(ProcessorABC):
         @property
@@ -140,4 +140,4 @@ def test_processor_newaccumulator():
         proc.process,
         proc.accumulator,
     )
-    assert out["itemsum"] == 45
+    assert out[0]["itemsum"] == 45


### PR DESCRIPTION
We discussed in the past how it's bad when a big job crashes and many hours and core hours can be lost. Here's a draft of how we could go about solving that (ignore some of the merge logic, I used the `FutureHolder` class from my job merging PR because this needs a bit finer control than the `_futures_handler` generator, but it's not necessarily connected)

Workflow can look like this. 

```
run_instance = processor.Runner(....
)

filemeta = run_instance(samples, "Events", processor_instance=MyZPeak(), prepro_only=True)` 
# save it in a pickle or sth for reference

# passing existing pre-made chunks to the Runner instance will skip the prepro step
output, processed, metrics = run_instance(filemeta , "Events", processor_instance=MyZPeak())` 
# WorkItem is attached to the accumulator like metrics are
# if exception is raised, report it, but return futures that already finished

missing = set(filemeta) - set(processed)
# resubmit
output, processed, metrics = run_instance(list(missing), "Events", processor_instance=MyZPeak())` 
```

@nsmith- 