### PR TITLE
fix Processor.process exception handling

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -20,7 +20,7 @@ from .processor import ProcessorABC
 from .accumulator import accumulate, set_accumulator, Accumulatable
 from .dataframe import LazyDataFrame
 from ..nanoevents import NanoEventsFactory, schemas
-from ..util import _hash
+from ..util import _hash, _exception_chain
 
 from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass, field, asdict
@@ -979,12 +979,13 @@ class Runner:
             # catch xrootd errors and optionally skip
             # or retry to read the file
             except Exception as e:
-                if skipbadfiles and isinstance(e, FileNotFoundError):
+                chain = _exception_chain(e)
+                if skipbadfiles and any(isinstance(c, FileNotFoundError) for c in chain):
                     warnings.warn(str(e))
                     break
                 if (
                     not skipbadfiles
-                    or "Auth failed" in str(e)
+                    or any("Auth failed" in str(c) for c in chain)
                     or retries == retry_count
                 ):
                     raise e
@@ -1234,10 +1235,7 @@ class Runner:
             try:
                 out = processor_instance.process(events)
             except Exception as e:
-                file_trace = f"\n\nFailed processing file: {item!r}"
-                raise type(e)(str(e) + file_trace).with_traceback(
-                    sys.exc_info()[2]
-                ) from None
+                raise Exception(f"Failed processing file: {item!r}") from e
             if out is None:
                 raise ValueError(
                     "Output of process() should not be None. Make sure your processor's process() function returns an accumulator."

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -980,7 +980,9 @@ class Runner:
             # or retry to read the file
             except Exception as e:
                 chain = _exception_chain(e)
-                if skipbadfiles and any(isinstance(c, FileNotFoundError) for c in chain):
+                if skipbadfiles and any(
+                    isinstance(c, FileNotFoundError) for c in chain
+                ):
                     warnings.warn(str(e))
                     break
                 if (

--- a/coffea/util.py
+++ b/coffea/util.py
@@ -81,7 +81,7 @@ def _ensure_flat(array, allow_missing=False):
 
 
 def _exception_chain(exc: BaseException) -> List[BaseException]:
-    """ Retrieves the entire exception chain as a list. """
+    """Retrieves the entire exception chain as a list."""
     ret = []
     while isinstance(exc, BaseException):
         ret.append(exc)

--- a/coffea/util.py
+++ b/coffea/util.py
@@ -1,6 +1,7 @@
 """Utility functions
 
 """
+from typing import List
 import awkward
 import hashlib
 import numpy
@@ -77,6 +78,15 @@ def _ensure_flat(array, allow_missing=False):
     if isinstance(array, ak.Array):
         array = ak.to_numpy(array, allow_missing=allow_missing)
     return array
+
+
+def _exception_chain(exc: BaseException) -> List[BaseException]:
+    """ Retrieves the entire exception chain as a list. """
+    ret = []
+    while isinstance(exc, BaseException):
+        ret.append(exc)
+        exc = exc.__cause__
+    return ret
 
 
 # lifted from awkward - https://github.com/scikit-hep/awkward-1.0/blob/5fe31a916bf30df6c2ea10d4094f6f1aefcf3d0c/src/awkward/_util.py#L47-L61 # noqa


### PR DESCRIPTION
Fixes the exception handling behavior for the Processor.process call by correctly chaining exceptions.

Reintroduces the benefits of #360.
Reintroduces the behavior of #370, since this is working as intended in python's `concurrent/futures`.
Retrains the fix for #438.
Fixes #649.