### PR TITLE
Exposed parquet's file opening interface correctly in `from_parquet`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,22 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java-version }}
+
+    - name: Set python 3.6 test settings
+      run: |
+        echo "INSTALL_EXTRAS=[dev,parsl,dask,spark]" >> $GITHUB_ENV
+      if: matrix.python-version == 3.6
+
+    - name: Set python newer than 3.6 test settings
+      run: |
+        echo "INSTALL_EXTRAS=[dev,parsl,dask,spark,servicex]" >> $GITHUB_ENV
+      if: matrix.python-version != 3.6
+
     - name: Install dependencies (Linux/MacOS)
       if: matrix.os != 'windows-latest'
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q -e .[dev,parsl,dask,spark,servicex]
+        python -m pip install -q -e .${{env.INSTALL_EXTRAS}}
         python -m pip list
         java -version
     - name: Install dependencies (Windows)

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -221,14 +221,14 @@ class NanoEventsFactory:
         )
 
         format_ = "parquet"
+        dataset = None
         if len(skyhook_options) > 0:
             format_ = ds.SkyhookFileFormat(
                 "parquet",
                 skyhook_options["ceph_config_path"].encode(),
                 skyhook_options["ceph_data_pool"].encode(),
             )
-
-        dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
+            dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
 
         shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
         mapping.preload_column_source(partition_key[0], partition_key[1], shim)

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -222,6 +222,7 @@ class NanoEventsFactory:
 
         format_ = "parquet"
         dataset = None
+        shim = None
         if len(skyhook_options) > 0:
             format_ = ds.SkyhookFileFormat(
                 "parquet",
@@ -229,8 +230,10 @@ class NanoEventsFactory:
                 skyhook_options["ceph_data_pool"].encode(),
             )
             dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
+            shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
+        else:
+            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset)
 
-        shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
         mapping.preload_column_source(partition_key[0], partition_key[1], shim)
 
         base_form = mapping._extract_base_form(table_file.schema_arrow)

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -194,7 +194,7 @@ class NanoEventsFactory:
         if isinstance(file, ftypes):
             table_file = pyarrow.parquet.ParquetFile(file, **parquet_options)
         elif isinstance(file, str):
-            fs_file = fsspec.open(file, "rb")
+            fs_file = fsspec.open(file, "rb").open()  # Call open to materialize the file
             table_file = pyarrow.parquet.ParquetFile(fs_file, **parquet_options)
         elif isinstance(file, pyarrow.parquet.ParquetFile):
             table_file = file
@@ -232,7 +232,7 @@ class NanoEventsFactory:
             dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
             shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
         else:
-            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset)
+            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset, openfile=fs_file)
 
         mapping.preload_column_source(partition_key[0], partition_key[1], shim)
 

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -194,7 +194,9 @@ class NanoEventsFactory:
         if isinstance(file, ftypes):
             table_file = pyarrow.parquet.ParquetFile(file, **parquet_options)
         elif isinstance(file, str):
-            fs_file = fsspec.open(file, "rb").open()  # Call open to materialize the file
+            fs_file = fsspec.open(
+                file, "rb"
+            ).open()  # Call open to materialize the file
             table_file = pyarrow.parquet.ParquetFile(fs_file, **parquet_options)
         elif isinstance(file, pyarrow.parquet.ParquetFile):
             table_file = file
@@ -232,7 +234,9 @@ class NanoEventsFactory:
             dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
             shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
         else:
-            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset, openfile=fs_file)
+            shim = TrivialParquetOpener.UprootLikeShim(
+                table_file, dataset, openfile=fs_file
+            )
 
         mapping.preload_column_source(partition_key[0], partition_key[1], shim)
 

--- a/coffea/nanoevents/mapping/parquet.py
+++ b/coffea/nanoevents/mapping/parquet.py
@@ -2,6 +2,9 @@ import warnings
 import awkward
 import numpy
 import json
+
+from fsspec.core import OpenFile
+
 from coffea.nanoevents.mapping.base import UUIDOpener, BaseSourceMapping
 from coffea.nanoevents.util import quote, tuple_to_key
 
@@ -10,9 +13,27 @@ from coffea.nanoevents.util import quote, tuple_to_key
 #              Later we should use the ParquetFile common_metadata to populate.
 class TrivialParquetOpener(UUIDOpener):
     class UprootLikeShim:
-        def __init__(self, file, dataset=None):
+        def __init__(self, file, dataset=None, openfile: OpenFile = None):
+            """
+            Shim to allow uproot to read parquet files via pyArrow
+            :param file: Open ParquetReader handle
+            :param dataset: Optional dataset to support SkyHook
+            :param openfile: If the source for the Parquet used fsspec then we may need to
+                             explicitly close the OpenFile instance to clean up any
+                             materialized copies.
+            """
             self.file = file
             self.dataset = dataset
+            self.openfile = openfile
+
+        def __del__(self):
+            """
+            If we used fsspec to open the ParquetReader then there may be a
+            materialized view of the file floating around. Make sure we close it to
+            remove it from the local drive
+            """
+            if self.openfile:
+                self.openfile.close()
 
         def read(self, column_name):
             # make sure uproot is single-core since our calling context might not be

--- a/coffea/nanoevents/mapping/parquet.py
+++ b/coffea/nanoevents/mapping/parquet.py
@@ -10,13 +10,16 @@ from coffea.nanoevents.util import quote, tuple_to_key
 #              Later we should use the ParquetFile common_metadata to populate.
 class TrivialParquetOpener(UUIDOpener):
     class UprootLikeShim:
-        def __init__(self, file, dataset):
+        def __init__(self, file, dataset=None):
             self.file = file
             self.dataset = dataset
 
         def read(self, column_name):
             # make sure uproot is single-core since our calling context might not be
-            return self.dataset.to_table(use_threads=False, columns=[column_name])
+            if self.dataset is not None:
+                return self.dataset.to_table(use_threads=False, columns=[column_name])
+            else:
+                return self.file.read([column_name], use_threads=False)
 
         # for right now spoof the notion of directories in files
         # parquet can do it but we've gotta convince people to

--- a/coffea/processor/servicex/dask_executor.py
+++ b/coffea/processor/servicex/dask_executor.py
@@ -56,12 +56,13 @@ class DaskExecutor(Executor):
         else:
             assert provided_dask_client.asynchronous
             self.dask = provided_dask_client
+            self.is_local = False
 
     def get_result_file_stream(self, datasource, title):
         if self.is_local:
             return datasource.stream_result_files(title)
         else:
-            return datasource.stream_result_file_urls(title)
+            return datasource.stream_result_file_uris(title)
 
     def run_async_analysis(
         self,

--- a/coffea/processor/servicex/data_source.py
+++ b/coffea/processor/servicex/data_source.py
@@ -61,7 +61,7 @@ class DataSource:
         event_dataset.return_qastle = True  # type: ignore
         return await self.query.value_async()
 
-    async def stream_result_file_urls(
+    async def stream_result_file_uris(
         self, title: Optional[str] = None
     ) -> AsyncGenerator[Tuple[str, str, StreamInfoUrl], None]:
         """Launch all datasources off to servicex
@@ -75,13 +75,13 @@ class DataSource:
         for dataset in self.datasets:
             data_type = dataset.first_supported_datatype(["parquet", "root"])
             if data_type == "root":
-                async for file in dataset.get_data_rootfiles_url_stream(
-                    qastle, title=title
+                async for file in dataset.get_data_rootfiles_uri_stream(
+                    qastle, title=title, as_signed_url=True
                 ):
                     yield (data_type, dataset.dataset_as_name, file)
             elif data_type == "parquet":
-                async for file in dataset.get_data_parquet_url_stream(
-                    qastle, title=title
+                async for file in dataset.get_data_parquet_uri_stream(
+                    qastle, title=title, as_signed_url=True
                 ):
                     yield (data_type, dataset.dataset_as_name, file)
             else:

--- a/coffea/processor/servicex/executor.py
+++ b/coffea/processor/servicex/executor.py
@@ -50,7 +50,7 @@ class Executor(ABC):
         raise NotImplementedError
 
     def get_result_file_stream(self, datasource, title: Optional[str] = None):
-        return datasource.stream_result_file_urls(title)
+        return datasource.stream_result_file_uris(title)
 
     async def execute(self, analysis, datasource, title: Optional[str] = None):
         """

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,8 @@ EXTRAS_REQUIRE["dask"] = [
 EXTRAS_REQUIRE["servicex"] = [
     "aiostream",
     "tenacity",
-    "func-adl_servicex==1.1.2",
+    "servicex>=2.5.3",
+    "func-adl_servicex",
 ]
 EXTRAS_REQUIRE["dev"] = [
     "flake8",

--- a/tests/processor/servicex/test_data_source.py
+++ b/tests/processor/servicex/test_data_source.py
@@ -53,7 +53,7 @@ class TestDataSource:
         )
         data_source = DataSource(query=query, metadata={}, datasets=[dataset])  # type: ignore
 
-        url_stream = [url async for url in data_source.stream_result_file_urls()]
+        url_stream = [url async for url in data_source.stream_result_file_uris()]
         assert url_stream == [
             ("root", "dataset1", "http://foo.bar.com/yyy.ROOT"),
             ("root", "dataset1", "http://baz.bar.com/xxx.ROOT"),
@@ -72,7 +72,7 @@ class TestDataSource:
         )
         data_source = DataSource(query=query, metadata={}, datasets=[dataset])  # type: ignore
 
-        url_stream = [url async for url in data_source.stream_result_file_urls()]
+        url_stream = [url async for url in data_source.stream_result_file_uris()]
         assert url_stream == [
             ("parquet", "dataset1", "http://foo.bar.com/yyy.ROOT"),
             ("parquet", "dataset1", "http://baz.bar.com/xxx.ROOT"),

--- a/tests/processor/servicex/test_data_source.py
+++ b/tests/processor/servicex/test_data_source.py
@@ -133,18 +133,20 @@ class MockDatset:
     def dataset_as_name(self) -> str:
         return "dataset1"
 
-    async def get_data_rootfiles_url_stream(self, query, title):
+    async def get_data_rootfiles_uri_stream(self, query, title, as_signed_url=False):
         self.called_query = query
         self.title = title
         self.num_calls += 1
+        self.as_signed_url = as_signed_url
 
         for url in self.urls:
             yield url
 
-    async def get_data_parquet_url_stream(self, query, title):
+    async def get_data_parquet_uri_stream(self, query, title, as_signed_url=False):
         self.called_query = query
         self.title = title
         self.num_calls_parquet += 1
+        self.as_signed_url = as_signed_url
 
         for url in self.urls:
             yield url

--- a/tests/processor/servicex/test_executor.py
+++ b/tests/processor/servicex/test_executor.py
@@ -62,7 +62,7 @@ class MockDataSource:
         self.urls = urls
         self.metadata = {"item": "value"}
 
-    async def stream_result_file_urls(self, title):
+    async def stream_result_file_uris(self, title):
         for url in self.urls:
             yield url
 


### PR DESCRIPTION
Following discussions with @JayjeetAtGithub, @BenGalewsky @jpivarski

Long story short in the mean time I am making it so that if skyhook is present then we use the hacked dataset interface and if it is not then we expose the standard parquet file opening interface.

This will eventually move to only exposing the normal parquet file-opening interfaces.