### PR TITLE
NanoEvents can handle a parquet file sourced from an http request

### DIFF
--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -194,7 +194,7 @@ class NanoEventsFactory:
         if isinstance(file, ftypes):
             table_file = pyarrow.parquet.ParquetFile(file, **parquet_options)
         elif isinstance(file, str):
-            fs_file = fsspec.open(file, "rb")
+            fs_file = fsspec.open(file, "rb").open()  # Call open to materialize the file
             table_file = pyarrow.parquet.ParquetFile(fs_file, **parquet_options)
         elif isinstance(file, pyarrow.parquet.ParquetFile):
             table_file = file
@@ -232,7 +232,7 @@ class NanoEventsFactory:
             dataset = ds.dataset(file, schema=table_file.schema_arrow, format=format_)
             shim = TrivialParquetOpener.UprootLikeShim(file, dataset)
         else:
-            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset)
+            shim = TrivialParquetOpener.UprootLikeShim(table_file, dataset, openfile=fs_file)
 
         mapping.preload_column_source(partition_key[0], partition_key[1], shim)
 

--- a/coffea/nanoevents/mapping/parquet.py
+++ b/coffea/nanoevents/mapping/parquet.py
@@ -2,6 +2,9 @@ import warnings
 import awkward
 import numpy
 import json
+
+from fsspec.core import OpenFile
+
 from coffea.nanoevents.mapping.base import UUIDOpener, BaseSourceMapping
 from coffea.nanoevents.util import quote, tuple_to_key
 
@@ -10,9 +13,27 @@ from coffea.nanoevents.util import quote, tuple_to_key
 #              Later we should use the ParquetFile common_metadata to populate.
 class TrivialParquetOpener(UUIDOpener):
     class UprootLikeShim:
-        def __init__(self, file, dataset=None):
+        def __init__(self, file, dataset=None, openfile: OpenFile = None):
+            """
+            Shim to allow uproot to read parquet files via pyArrow
+            :param file: Open ParquetReader handle
+            :param dataset: Optional dataset to support SkyHook
+            :param openfile: If the source for the Parquet used fsspec then we may need to
+                             explicitly close the OpenFile instance to clean up any
+                             materialized copies.
+            """
             self.file = file
             self.dataset = dataset
+            self.openfile = openfile
+
+        def __del__(self):
+            """
+            If we used fsspec to open the ParquetReader then there may be a
+            materialized view of the file floating around. Make sure we close it to
+            remove it from the local drive
+            """
+            if self.openfile:
+                self.openfile.close()
 
         def read(self, column_name):
             # make sure uproot is single-core since our calling context might not be

--- a/coffea/processor/servicex/dask_executor.py
+++ b/coffea/processor/servicex/dask_executor.py
@@ -56,12 +56,13 @@ class DaskExecutor(Executor):
         else:
             assert provided_dask_client.asynchronous
             self.dask = provided_dask_client
+            self.is_local = False
 
     def get_result_file_stream(self, datasource, title):
         if self.is_local:
             return datasource.stream_result_files(title)
         else:
-            return datasource.stream_result_file_urls(title)
+            return datasource.stream_result_file_uris(title)
 
     def run_async_analysis(
         self,

--- a/coffea/processor/servicex/data_source.py
+++ b/coffea/processor/servicex/data_source.py
@@ -61,7 +61,7 @@ class DataSource:
         event_dataset.return_qastle = True  # type: ignore
         return await self.query.value_async()
 
-    async def stream_result_file_urls(
+    async def stream_result_file_uris(
         self, title: Optional[str] = None
     ) -> AsyncGenerator[Tuple[str, str, StreamInfoUrl], None]:
         """Launch all datasources off to servicex
@@ -75,13 +75,13 @@ class DataSource:
         for dataset in self.datasets:
             data_type = dataset.first_supported_datatype(["parquet", "root"])
             if data_type == "root":
-                async for file in dataset.get_data_rootfiles_url_stream(
-                    qastle, title=title
+                async for file in dataset.get_data_rootfiles_uri_stream(
+                    qastle, title=title, as_signed_url=True
                 ):
                     yield (data_type, dataset.dataset_as_name, file)
             elif data_type == "parquet":
-                async for file in dataset.get_data_parquet_url_stream(
-                    qastle, title=title
+                async for file in dataset.get_data_parquet_uri_stream(
+                    qastle, title=title, as_signed_url=True
                 ):
                     yield (data_type, dataset.dataset_as_name, file)
             else:

--- a/coffea/processor/servicex/executor.py
+++ b/coffea/processor/servicex/executor.py
@@ -50,7 +50,7 @@ class Executor(ABC):
         raise NotImplementedError
 
     def get_result_file_stream(self, datasource, title: Optional[str] = None):
-        return datasource.stream_result_file_urls(title)
+        return datasource.stream_result_file_uris(title)
 
     async def execute(self, analysis, datasource, title: Optional[str] = None):
         """

--- a/tests/processor/servicex/test_data_source.py
+++ b/tests/processor/servicex/test_data_source.py
@@ -53,7 +53,7 @@ class TestDataSource:
         )
         data_source = DataSource(query=query, metadata={}, datasets=[dataset])  # type: ignore
 
-        url_stream = [url async for url in data_source.stream_result_file_urls()]
+        url_stream = [url async for url in data_source.stream_result_file_uris()]
         assert url_stream == [
             ("root", "dataset1", "http://foo.bar.com/yyy.ROOT"),
             ("root", "dataset1", "http://baz.bar.com/xxx.ROOT"),
@@ -72,7 +72,7 @@ class TestDataSource:
         )
         data_source = DataSource(query=query, metadata={}, datasets=[dataset])  # type: ignore
 
-        url_stream = [url async for url in data_source.stream_result_file_urls()]
+        url_stream = [url async for url in data_source.stream_result_file_uris()]
         assert url_stream == [
             ("parquet", "dataset1", "http://foo.bar.com/yyy.ROOT"),
             ("parquet", "dataset1", "http://baz.bar.com/xxx.ROOT"),


### PR DESCRIPTION
# Problem
The pyArrow ParquetReader can accept an fsspec OpenFile instance as a file-like object, however anything other than a local file will require the OpenFile to be "opened" which will cause the remote file to be "materialized". Doing so will create a local copy of the file, which could be leaked unless the `OpenFile` instance is explicitly closed. See the [documentation for OpenFile](https://filesystem-spec.readthedocs.io/en/latest/features.html#openfile-instances). The suggested way to work with OpenFile is to create a context:
>The way to work with OpenFile s is to isolate interaction with in a with context. It is the initiation of the context which actually does the work of creating file-like instances.

Unfortunately we cache the open file from the factory, and then do the read much later. If we use the context then the file is closed and the subsequent reads in the NanoEvents mapper will fail

# Approach
1. Updated the ServiceX.data_source to make the correct calls to the ServiceX frontend to get back http urls
2. Explicitly open the `OpenFile` instance created by the fsspec.
3. Update the `UprootLikeShim` class to optionally keep track of the source OpenFile
4. If there was an OpenFile passed into the constructor, then close it when the UprootLikeShim is deconstructed