### PR TITLE
Drop ServiceX For Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,22 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java-version }}
+
+    - name: Set python 3.6 test settings
+      run: |
+        echo "INSTALL_EXTRAS=[dev,parsl,dask,spark]" >> $GITHUB_ENV
+      if: matrix.python-version == 3.6
+
+    - name: Set python newer than 3.6 test settings
+      run: |
+        echo "INSTALL_EXTRAS=[dev,parsl,dask,spark,servicex]" >> $GITHUB_ENV
+      if: matrix.python-version != 3.6
+
     - name: Install dependencies (Linux/MacOS)
       if: matrix.os != 'windows-latest'
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -q -e .[dev,parsl,dask,spark,servicex]
+        python -m pip install -q -e .${{env.INSTALL_EXTRAS}}
         python -m pip list
         java -version
     - name: Install dependencies (Windows)

--- a/tests/processor/servicex/test_data_source.py
+++ b/tests/processor/servicex/test_data_source.py
@@ -133,18 +133,20 @@ class MockDatset:
     def dataset_as_name(self) -> str:
         return "dataset1"
 
-    async def get_data_rootfiles_url_stream(self, query, title):
+    async def get_data_rootfiles_uri_stream(self, query, title, as_signed_url=False):
         self.called_query = query
         self.title = title
         self.num_calls += 1
+        self.as_signed_url = as_signed_url
 
         for url in self.urls:
             yield url
 
-    async def get_data_parquet_url_stream(self, query, title):
+    async def get_data_parquet_uri_stream(self, query, title, as_signed_url=False):
         self.called_query = query
         self.title = title
         self.num_calls_parquet += 1
+        self.as_signed_url = as_signed_url
 
         for url in self.urls:
             yield url

--- a/tests/processor/servicex/test_executor.py
+++ b/tests/processor/servicex/test_executor.py
@@ -62,7 +62,7 @@ class MockDataSource:
         self.urls = urls
         self.metadata = {"item": "value"}
 
-    async def stream_result_file_urls(self, title):
+    async def stream_result_file_uris(self, title):
         for url in self.urls:
             yield url
 


### PR DESCRIPTION
# Problem
The ServiceX frontend library no longer supports 3.6

# Approach
Added some checks to the GHA to only install and test ServiceX for later versions of Python

Also, there was a function signature problem with the mock ServiceX interfaces. Updated those