### PR TITLE
Some lookup fixes

### DIFF
--- a/coffea/lookup_tools/evaluator.py
+++ b/coffea/lookup_tools/evaluator.py
@@ -4,8 +4,8 @@ from coffea.lookup_tools.jme_standard_function import jme_standard_function
 from coffea.lookup_tools.jersf_lookup import jersf_lookup
 from coffea.lookup_tools.jec_uncertainty_lookup import jec_uncertainty_lookup
 from coffea.lookup_tools.rochester_lookup import rochester_lookup
+from coffea.lookup_tools.json_lookup import json_lookup
 from coffea.lookup_tools.correctionlib_wrapper import correctionlib_wrapper
-
 
 lookup_types = {
     "dense_lookup": dense_lookup,
@@ -14,6 +14,7 @@ lookup_types = {
     "jersf_lookup": jersf_lookup,
     "jec_uncertainty_lookup": jec_uncertainty_lookup,
     "rochester_lookup": rochester_lookup,
+    "json_lookup": json_lookup,
     "correctionlib_wrapper": correctionlib_wrapper,
 }
 
@@ -49,7 +50,6 @@ class evaluator(object):
             lookup_type = types[names[key]]
             lookup_def = primitives[names[key]]
             self._functions[key] = lookup_types[lookup_type](*lookup_def)
-
     def __dir__(self):
         """dir is overloaded to list all available functions
         in the evaluator

--- a/coffea/lookup_tools/evaluator.py
+++ b/coffea/lookup_tools/evaluator.py
@@ -50,6 +50,7 @@ class evaluator(object):
             lookup_type = types[names[key]]
             lookup_def = primitives[names[key]]
             self._functions[key] = lookup_types[lookup_type](*lookup_def)
+
     def __dir__(self):
         """dir is overloaded to list all available functions
         in the evaluator

--- a/coffea/lookup_tools/extractor.py
+++ b/coffea/lookup_tools/extractor.py
@@ -19,7 +19,7 @@ file_converters = {
         "default": convert_histo_json_file,
         "histo": convert_histo_json_file,
         "corr": convert_correctionlib_file,
-        "pileup": convert_pileup_json_file
+        "pileup": convert_pileup_json_file,
     },
     "txt": {
         "default": convert_jec_txt_file,
@@ -28,7 +28,7 @@ file_converters = {
         "jr": convert_jr_txt_file,
         "junc": convert_junc_txt_file,
         "ea": convert_effective_area_file,
-        "pileup": convert_pileup_json_file
+        "pileup": convert_pileup_json_file,
     },
 }
 
@@ -122,10 +122,10 @@ class extractor(object):
             thetype = "default"
             if len(file_dots) > 2:
                 thetype = file_dots[-2]
-            if 'pileup' in thefile:
-                thetype = 'pileup'
-            if '_SF_' in thefile:
-                thetype = 'jersf'
+            if "pileup" in thefile:
+                thetype = "pileup"
+            if "_SF_" in thefile:
+                thetype = "jersf"
             self._filecache[thefile] = file_converters[theformat][thetype](thefile)
 
     def extract_from_file(self, thefile, name):

--- a/coffea/lookup_tools/extractor.py
+++ b/coffea/lookup_tools/extractor.py
@@ -124,6 +124,8 @@ class extractor(object):
                 thetype = file_dots[-2]
             if 'pileup' in thefile:
                 thetype = 'pileup'
+            if '_SF_' in thefile:
+                thetype = 'jersf'
             self._filecache[thefile] = file_converters[theformat][thetype](thefile)
 
     def extract_from_file(self, thefile, name):

--- a/coffea/lookup_tools/extractor.py
+++ b/coffea/lookup_tools/extractor.py
@@ -9,6 +9,7 @@ from coffea.lookup_tools.json_converters import (
     convert_histo_json_file,
     convert_correctionlib_file,
 )
+from coffea.lookup_tools.json_converters import convert_pileup_json_file
 from coffea.lookup_tools.txt_converters import *
 
 file_converters = {
@@ -18,6 +19,7 @@ file_converters = {
         "default": convert_histo_json_file,
         "histo": convert_histo_json_file,
         "corr": convert_correctionlib_file,
+        "pileup": convert_pileup_json_file
     },
     "txt": {
         "default": convert_jec_txt_file,
@@ -26,6 +28,7 @@ file_converters = {
         "jr": convert_jr_txt_file,
         "junc": convert_junc_txt_file,
         "ea": convert_effective_area_file,
+        "pileup": convert_pileup_json_file
     },
 }
 
@@ -107,6 +110,8 @@ class extractor(object):
             else:
                 weights, thetype = self.extract_from_file(thefile, name)
                 self.add_weight_set(local_name, thetype, weights)
+                if thetype == "json_lookup":
+                    self._names[local_name] = 0
 
     def import_file(self, thefile):
         """cache the whole contents of a file for later processing"""
@@ -117,6 +122,8 @@ class extractor(object):
             thetype = "default"
             if len(file_dots) > 2:
                 thetype = file_dots[-2]
+            if 'pileup' in thefile:
+                thetype = 'pileup'
             self._filecache[thefile] = file_converters[theformat][thetype](thefile)
 
     def extract_from_file(self, thefile, name):

--- a/coffea/lookup_tools/json_converters.py
+++ b/coffea/lookup_tools/json_converters.py
@@ -99,6 +99,7 @@ def convert_correctionlib_file(filename):
 
     return {(key, "correctionlib_wrapper"): (cset[key],) for key in cset.keys()}
 
+
 def convert_pileup_json_file(filename):
     file = open(filename)
     info = json.load(file)
@@ -109,10 +110,10 @@ def convert_pileup_json_file(filename):
         valsdict = {}
         for i in range(len(info[run])):
             lumisection = info[run][i][0]
-            val         = info[run][i][3]
+            val = info[run][i][3]
             valsdict[lumisection] = val
         values[run] = valsdict
     wrapped_up = {}
-    wrapped_up[("pileup","json_lookup")] = []
-    wrapped_up[("pileup","json_lookup")].append(values)
+    wrapped_up[("pileup", "json_lookup")] = []
+    wrapped_up[("pileup", "json_lookup")].append(values)
     return wrapped_up

--- a/coffea/lookup_tools/json_converters.py
+++ b/coffea/lookup_tools/json_converters.py
@@ -98,3 +98,21 @@ def convert_correctionlib_file(filename):
     cset = correctionlib.CorrectionSet.from_file(filename)
 
     return {(key, "correctionlib_wrapper"): (cset[key],) for key in cset.keys()}
+
+def convert_pileup_json_file(filename):
+    file = open(filename)
+    info = json.load(file)
+    file.close()
+
+    values = {}
+    for run in info.keys():
+        valsdict = {}
+        for i in range(len(info[run])):
+            lumisection = info[run][i][0]
+            val         = info[run][i][3]
+            valsdict[lumisection] = val
+        values[run] = valsdict
+    wrapped_up = {}
+    wrapped_up[("pileup","json_lookup")] = []
+    wrapped_up[("pileup","json_lookup")].append(values)
+    return wrapped_up

--- a/coffea/lookup_tools/json_lookup.py
+++ b/coffea/lookup_tools/json_lookup.py
@@ -1,0 +1,14 @@
+class json_lookup:
+    def __init__(self, wrapped_values):
+        self.values = wrapped_values
+
+    def __call__(self,run,lumi):
+        mu = []
+        for i in range(len(run)):
+            run_ = str(run[i])
+            lumi_ = lumi[i]
+            if not run_ in self.values.keys() or not lumi_ in self.values[run_].keys():
+                print("    \033[91m run:lumi %s:%s not found \033[00m"%(run_,lumi_))
+            else:
+                mu.append(self.values[run_][lumi_])
+        return mu

--- a/coffea/lookup_tools/json_lookup.py
+++ b/coffea/lookup_tools/json_lookup.py
@@ -7,8 +7,8 @@ class json_lookup:
         for i in range(len(run)):
             run_ = str(run[i])
             lumi_ = lumi[i]
-            if not run_ in self.values.keys() or not lumi_ in self.values[run_].keys():
-                print("    \033[91m run:lumi %s:%s not found \033[00m"%(run_, lumi_))
+            if run_ not in self.values.keys() or lumi_ not in self.values[run_].keys():
+                print("    \033[91m run:lumi %s:%s not found \033[00m" % (run_, lumi_))
             else:
                 mu.append(self.values[run_][lumi_])
         return mu

--- a/coffea/lookup_tools/json_lookup.py
+++ b/coffea/lookup_tools/json_lookup.py
@@ -2,13 +2,13 @@ class json_lookup:
     def __init__(self, wrapped_values):
         self.values = wrapped_values
 
-    def __call__(self,run,lumi):
+    def __call__(self, run, lumi):
         mu = []
         for i in range(len(run)):
             run_ = str(run[i])
             lumi_ = lumi[i]
             if not run_ in self.values.keys() or not lumi_ in self.values[run_].keys():
-                print("    \033[91m run:lumi %s:%s not found \033[00m"%(run_,lumi_))
+                print("    \033[91m run:lumi %s:%s not found \033[00m"%(run_, lumi_))
             else:
                 mu.append(self.values[run_][lumi_])
         return mu


### PR DESCRIPTION
Two problems
1: get mu (pileup) for data. For MC one can use events.Pileup.nTrueInt, but that is not possible for data. For data the pileup have to be taken from the pileup json, like 
/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/PileUp/UltraLegacy/pileup_latest.txt
/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/PileUp/UltraLegacy/pileup_latest.txt
/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/PileUp/UltraLegacy/pileup_latest.txt
as a function of run and lumisection. Added support for lookup from pileup jsons to be able to get the mu for data.
2: The jet resolution scale factor files from the JRDatabase are not working to get the scale factor, as the code looks for *.jersf.* in the filename. The JER SF files in the JRDatabase are named as *_SF_*, so made a change in the extractor.py function import_file to look for _SF_ and if found set thetype as 'jersf'. 
For some reason thetype = "default" is not working for these files, although it is working for the other JEC files. Either the thetype = 'default' should be made working for JER SF's, or use this fix looking for the filenames. 