### PR TITLE
Added `E` alias for 4-vectors

### DIFF
--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -730,7 +730,7 @@ class PtEtaPhiMLorentzVector(LorentzVector, SphericalThreeVector):
 
     @property
     def E(self):
-        '''Alias for `t`'''
+        """Alias for `t`"""
         return self.t
 
     @property
@@ -852,9 +852,10 @@ class PtEtaPhiELorentzVector(LorentzVector, SphericalThreeVector):
     This mixin class requires the parent class to provide items `pt`, `eta`, `phi`, and `energy`.
     Some additional properties are overridden for performance
     """
+
     @property
     def E(self):
-        '''Alias for `t`'''
+        """Alias for `t`"""
         return self.t
 
     @property

--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -729,6 +729,11 @@ class PtEtaPhiMLorentzVector(LorentzVector, SphericalThreeVector):
     """
 
     @property
+    def E(self):
+      '''Alias for `t`'''
+      return self.t
+
+    @property
     def pt(self):
         """Alias for `r`"""
         return self["pt"]
@@ -847,6 +852,10 @@ class PtEtaPhiELorentzVector(LorentzVector, SphericalThreeVector):
     This mixin class requires the parent class to provide items `pt`, `eta`, `phi`, and `energy`.
     Some additional properties are overridden for performance
     """
+    @property
+    def E(self):
+      '''Alias for `t`'''
+      return self.t
 
     @property
     def pt(self):

--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -730,8 +730,8 @@ class PtEtaPhiMLorentzVector(LorentzVector, SphericalThreeVector):
 
     @property
     def E(self):
-      '''Alias for `t`'''
-      return self.t
+        '''Alias for `t`'''
+        return self.t
 
     @property
     def pt(self):
@@ -854,8 +854,8 @@ class PtEtaPhiELorentzVector(LorentzVector, SphericalThreeVector):
     """
     @property
     def E(self):
-      '''Alias for `t`'''
-      return self.t
+        '''Alias for `t`'''
+        return self.t
 
     @property
     def pt(self):


### PR DESCRIPTION
The fastjet library (https://github.com/scikit-hep/fastjet) expects inputs with an attribute named "E" with the particle energy. This small PR adds this alias to the PtEtaPhiM and PtEtaPhiE Lorentz Vectors to make coffea compatible with fastjet. 