### PR TITLE
simultaneously pickle and compress results of user functions

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -196,7 +196,11 @@ def _compress(item, compression):
 
 def _decompress(item):
     if isinstance(item, bytes):
-        return pickle.loads(lz4f.decompress(item))
+        # warning: if item is not exactly of type bytes, BytesIO(item) will
+        # make a copy of it, increasing the memory usage.
+        with BytesIO(item) as bf:
+            with lz4f.open(bf, mode="rb") as f:
+                return pickle.load(f)
     else:
         return item
 


### PR DESCRIPTION
See issue #699.  In the original implementation, coffea held in memory the item to be compressed, its pickled representation, and the compressed representation. Using a BytesIO object, we only need space (roughly) for the item and the compressed representation when decompressing, and the item and two times the compressed representation when compressing.

When compressing, the compressed representation has to be copied out of the BytesIO object, and that is why it has to be accounted twice. The memory savings come from the difference between the pickled and the compressed representation. This may open some opportunity for improvement if a scheme can be found where this copy is not necessary.

As an example of memory savings, one of topcoffea's workflows reduced its max memory consumption from 20.6GB to 13.7GB.