### PR TITLE
"Balancing" the accumulation tree

### DIFF
--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -973,7 +973,7 @@ def _submit_accum_tasks(
     if chunks_per_accum < 2 or chunks_accum_in_mem < 2:
         raise RuntimeError("A minimum of two chunks should be used when accumulating")
 
-    if len(tasks_to_accumulate) != 2 * chunks_per_accum - 1 and not force_last_accum:
+    if len(tasks_to_accumulate) < 2 * chunks_per_accum - 1 and not force_last_accum:
         return tasks_to_accumulate
 
     tasks_to_accumulate.sort(key=lambda t: t.fout_size)

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -973,6 +973,10 @@ def _submit_accum_tasks(
     if chunks_per_accum < 2 or chunks_accum_in_mem < 2:
         raise RuntimeError("A minimum of two chunks should be used when accumulating")
 
+    if len(tasks_to_accumulate) != 2 * chunks_per_accum - 1 and not force_last_accum:
+        return tasks_to_accumulate
+
+    tasks_to_accumulate.sort(key=lambda t: t.fout_size)
     for next_to_accum in _group_lst(tasks_to_accumulate, chunks_per_accum):
         # return immediately if not enough for a single accumulation
         if len(next_to_accum) < 2:


### PR DESCRIPTION
This change to `work_queue_tools.py` in `coffea/processor` attempts to address the bottleneck of large data transfers between the manager and the workers. As tasks accumulate, the data being transferred to and from workers with accumulator functions can grow to be quite large. For example, in a full-scale topEFT run, final accumulations are processing data in the order of GB.

To mitigate this, we developed an approach where tasks are sorted by output file size and accumulated smallest to largest, eliminating the repeated transfer of larger data. Currently, the coffea executor waits until `chunks_per_accum` tasks finish before submitting an accumulation. Completed tasks are stored in a list, and the list is returned until an accumulation occurs and "empties" the list. In this new approach, the executor waits until `2 * chunks_per_accum - 1` tasks finish, sorts the completed tasks by output size, accumulates the smallest `chunks_per_accum` tasks, and returns the list of remaining tasks. This cycle continues, sending particularly large tasks to the bottom of the list and delaying their accumulation until final processing. 

The result of this approach is a more "balanced" accumulation tree. All tasks of a given size are accumulated before the program moves on to the next batch. See below a before/after of the workflow visualization. 

Without sorting:
![workflow-graph-unsorted](https://user-images.githubusercontent.com/71721997/180858303-637c2d4c-2d2a-4e56-88bb-e4f4192b3c31.png)

With sorting:
![workflow-graph-sorted](https://user-images.githubusercontent.com/71721997/180858438-dca1d5f4-a5e8-47cd-8d60-8da267f168e1.png)