### PR TITLE
wq: change default values to those used in topcoffea

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -592,7 +592,7 @@ class WorkQueueExecutor(ExecutorBase):
     memory: Optional[int] = None
     disk: Optional[int] = None
     gpus: Optional[int] = None
-    chunks_per_accum: int = 10
+    chunks_per_accum: int = 25
     chunks_accum_in_mem: int = 2
     chunksize: int = 1024
     dynamic_chunksize: Optional[Dict] = None

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -583,7 +583,7 @@ class WorkQueueExecutor(ExecutorBase):
     password_file: Optional[str] = None
     environment_file: Optional[str] = None
     extra_input_files: List = field(default_factory=list)
-    wrapper: Optional[str] = shutil.which("python_package_run")
+    wrapper: Optional[str] = shutil.which("poncho_package_run")
     resource_monitor: Optional[str] = "off"
     resources_mode: Optional[str] = "max-seen"
     split_on_exhaustion: Optional[bool] = True

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -594,7 +594,7 @@ class WorkQueueExecutor(ExecutorBase):
     gpus: Optional[int] = None
     chunks_per_accum: int = 25
     chunks_accum_in_mem: int = 2
-    chunksize: int = 1024
+    chunksize: int = 100000
     dynamic_chunksize: Optional[Dict] = None
     custom_init: Optional[Callable] = None
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -493,7 +493,7 @@ class WorkQueueExecutor(ExecutorBase):
             - 'watchdog': in addition to measuring resources, tasks are terminated if they
                         go above the cores, memory, or disk specified.
         resources_mode : str
-            one of 'fixed', 'max-seen', or 'max-throughput'. Default is 'fixed'.
+            one of 'fixed', 'max-seen', or 'max-throughput'. Default is 'max-seen'.
             Sets the strategy to automatically allocate resources to tasks.
             - 'fixed': allocate cores, memory, and disk specified for each task.
             - 'max-seen' or 'auto': use the cores, memory, and disk given as maximum values to allocate,
@@ -585,7 +585,7 @@ class WorkQueueExecutor(ExecutorBase):
     extra_input_files: List = field(default_factory=list)
     wrapper: Optional[str] = shutil.which("python_package_run")
     resource_monitor: Optional[str] = "off"
-    resources_mode: Optional[str] = "fixed"
+    resources_mode: Optional[str] = "max-seen"
     split_on_exhaustion: Optional[bool] = True
     fast_terminate_workers: Optional[int] = None
     cores: Optional[int] = None

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -886,6 +886,9 @@ def _declare_resources(exec_defaults):
     # Enable monitoring and auto resource consumption, if desired:
     _wq_queue.tune("category-steady-n-tasks", 3)
 
+    # Evenly divide resources in workers per category
+    _wq_queue.tune("force-proportional-resources", 1)
+
     monitor_enabled = False
 
     # if resource_monitor is given, and not 'off', then monitoring is activated.


### PR DESCRIPTION
This pr changes some of the default values for the wq executor to those we usually set for topcoffea runs. We have observe they give a nice compromise between automatically figuring out the memory used for each task, the number of retries needed, and throughput.