### PR TITLE
wq: cleanup to be friendly to jupyter

### DIFF
--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -138,9 +138,12 @@ class CoffeaWQ(WorkQueue):
 
 
 class CoffeaWQTask(Task):
+    tasks_counter = 0
+
     def __init__(
         self, fn_wrapper, infile_function, item_args, itemid, tmpdir, exec_defaults
     ):
+        CoffeaWQTask.tasks_counter += 1
         self.itemid = itemid
 
         self.py_result = ResultUnavailable()
@@ -358,16 +361,13 @@ class CoffeaWQTask(Task):
 
 
 class PreProcCoffeaWQTask(CoffeaWQTask):
-    tasks_counter = 0
     infile_function = None
 
     def __init__(
         self, fn_wrapper, infile_function, item, tmpdir, exec_defaults, itemid=None
     ):
-        PreProcCoffeaWQTask.tasks_counter += 1
-
         if not itemid:
-            itemid = "pre_{}".format(PreProcCoffeaWQTask.tasks_counter)
+            itemid = "pre_{}".format(CoffeaWQTask.tasks_counter)
 
         self.item = item
 
@@ -413,16 +413,13 @@ class PreProcCoffeaWQTask(CoffeaWQTask):
 
 
 class ProcCoffeaWQTask(CoffeaWQTask):
-    tasks_counter = 0
-
     def __init__(
         self, fn_wrapper, infile_function, item, tmpdir, exec_defaults, itemid=None
     ):
         self.size = len(item)
 
-        ProcCoffeaWQTask.tasks_counter += 1
         if not itemid:
-            itemid = "p_{}".format(ProcCoffeaWQTask.tasks_counter)
+            itemid = "p_{}".format(CoffeaWQTask.tasks_counter)
 
         self.item = item
 
@@ -513,8 +510,6 @@ class ProcCoffeaWQTask(CoffeaWQTask):
 
 
 class AccumCoffeaWQTask(CoffeaWQTask):
-    tasks_counter = 0
-
     def __init__(
         self,
         fn_wrapper,
@@ -524,10 +519,8 @@ class AccumCoffeaWQTask(CoffeaWQTask):
         exec_defaults,
         itemid=None,
     ):
-        AccumCoffeaWQTask.tasks_counter += 1
-
         if not itemid:
-            itemid = "accum_{}".format(AccumCoffeaWQTask.tasks_counter)
+            itemid = "accum_{}".format(CoffeaWQTask.tasks_counter)
 
         self.tasks_to_accumulate = tasks_to_accumulate
         self.size = sum(len(t) for t in self.tasks_to_accumulate)

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -622,7 +622,9 @@ def work_queue_main(items, function, accumulator, **kwargs):
 
     # Working within a custom temporary directory:
     try:
-        tmpdir_inst = tempfile.TemporaryDirectory(prefix="wq-executor-tmp-", dir=kwargs["filepath"])
+        tmpdir_inst = tempfile.TemporaryDirectory(
+            prefix="wq-executor-tmp-", dir=kwargs["filepath"]
+        )
         tmpdir = tmpdir_inst.name
 
         fn_wrapper = _create_fn_wrapper(kwargs["x509_proxy"], tmpdir=tmpdir)
@@ -651,7 +653,7 @@ def work_queue_main(items, function, accumulator, **kwargs):
                 infile_accum_fn,
                 tmpdir,
                 kwargs,
-                )
+            )
             _wq_queue = None
     except Exception as e:
         _wq_queue = None
@@ -769,8 +771,9 @@ def _work_queue_processing(
                     tmpdir,
                     exec_defaults,
                 )
+                acc_sub = _wq_queue.stats_category("accumulating").tasks_submitted
                 progress_bars["accumulate"].total = math.ceil(
-                    items_total * _wq_queue.stats_category("accumulating").tasks_submitted / items_done
+                    items_total * acc_sub / items_done
                 )
 
                 # Remove input files as we go to avoid unbounded disk
@@ -783,7 +786,9 @@ def _work_queue_processing(
         accumulator, tasks_to_accumulate, exec_defaults["compression"]
     )
 
-    progress_bars["accumulate"].total = math.ceil(_wq_queue.stats_category("accumulating").tasks_submitted)
+    progress_bars["accumulate"].total = _wq_queue.stats_category(
+        "accumulating"
+    ).tasks_submitted
     progress_bars["accumulate"].refresh()
     for bar in progress_bars.values():
         bar.close()

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -628,9 +628,10 @@ def work_queue_main(items, function, accumulator, **kwargs):
     _declare_resources(kwargs)
 
     # Working within a custom temporary directory:
-    with tempfile.TemporaryDirectory(
-        prefix="wq-executor-tmp-", dir=kwargs["filepath"]
-    ) as tmpdir:
+    try:
+        tmpdir_inst = tempfile.TemporaryDirectory(prefix="wq-executor-tmp-", dir=kwargs["filepath"])
+        tmpdir = tmpdir_inst.name
+
         fn_wrapper = _create_fn_wrapper(kwargs["x509_proxy"], tmpdir=tmpdir)
         infile_function = _function_to_file(
             function, prefix_name=kwargs["function_name"], tmpdir=tmpdir
@@ -656,6 +657,8 @@ def work_queue_main(items, function, accumulator, **kwargs):
                 tmpdir,
                 kwargs,
             )
+    finally:
+        tmpdir_inst.cleanup()
 
 
 def _work_queue_processing(


### PR DESCRIPTION
A handful of changes to the WorkQueueExecutor so that the bar display and queue lifetime are friendly to jupyter notebooks. The queue is reset on exceptions and on finishing accumulations so that statistics are isolated between cells.