### PR TITLE
feat: support custom schema specification with ServiceX executor

### DIFF
--- a/coffea/processor/servicex/dask_executor.py
+++ b/coffea/processor/servicex/dask_executor.py
@@ -71,6 +71,7 @@ class DaskExecutor(Executor):
         data_type: str,
         meta_data: Dict[str, str],
         process_func: Callable,
+        schema,
     ):
         """Create a dask future for a dask task to run the analysis."""
         data_result = self.dask.submit(
@@ -80,6 +81,7 @@ class DaskExecutor(Executor):
             data_type=data_type,
             meta_data=meta_data,
             proc=process_func,
+            schema=schema,
         )
 
         return data_result

--- a/coffea/processor/servicex/local_executor.py
+++ b/coffea/processor/servicex/local_executor.py
@@ -43,6 +43,7 @@ class LocalExecutor(Executor):
         data_type: str,
         meta_data: Dict[str, str],
         process_func: Callable,
+        schema,
     ):
         # TODO: Do we need a second routine here? Can we just use this one?
         return self._async_analysis(
@@ -51,10 +52,11 @@ class LocalExecutor(Executor):
             data_type=data_type,
             meta_data=meta_data,
             process_func=process_func,
+            schema=schema,
         )
 
     async def _async_analysis(
-        self, events_url, tree_name, data_type, meta_data, process_func
+        self, events_url, tree_name, data_type, meta_data, process_func, schema
     ):
         return run_coffea_processor(
             events_url=events_url,
@@ -62,4 +64,5 @@ class LocalExecutor(Executor):
             data_type=data_type,
             meta_data=meta_data,
             proc=process_func,
+            schema=schema,
         )

--- a/tests/processor/servicex/test_executor.py
+++ b/tests/processor/servicex/test_executor.py
@@ -48,6 +48,7 @@ class TestableExecutor(Executor):
         data_type: str,
         meta_data: Dict[str, str],
         process_func: Callable,
+        schema,
     ):
 
         # Record the tree name so we can verify it later


### PR DESCRIPTION
The schema used with the ServiceX executor was previously hardcoded to `auto_schema`. This adds a new `schema` keyword argument to `coffea.processors.servicex.LocalExecutor.execute` and `coffea.processors.servicex.DaskExecutor.execute` to set a schema. The default value of `None` is resolved in `run_coffea_processor` to again make use of the `auto_schema`.

The `LocalExecutor` path works, `DaskExecutor` is currently untested (I cannot get coffea+ServiceX+dask to work locally, and this is not as easy to test on coffea-casa as I think I would need to propagate the changes to workers as well).