### PR TITLE
wq: send dictionary with statistics

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1804,16 +1804,16 @@ class Runner:
                 processor_instance=pi_to_send,
             )
 
-        if self.format == "root":
-            if self.dynamic_chunksize:
-                # chunks stay as generator
-                events_total = sum(f.metadata["numentries"] for f in fileset)
-            else:
-                # materialize to list
-                chunks = [c for c in chunks]
-                events_total = sum(len(c) for c in chunks)
+        if self.format == "root" and self.dynamic_chunksize:
+            # keep chunks in generator, use a copy to count number of events
+            # this is cheap, as we are reading from the cache
+            chunks_to_count = self.preprocess(fileset, treename)
         else:
-            chunks = [c for c in chunks]
+            # materialize chunks to list, then count that list
+            chunks = list(chunks)
+            chunks_to_count = chunks
+
+        events_total = sum(len(c) for c in chunks_to_count)
 
         exe_args = {
             "unit": "event"

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -582,6 +582,7 @@ class WorkQueueExecutor(ExecutorBase):
     x509_proxy: Optional[str] = None
     verbose: bool = False
     print_stdout: bool = False
+    status_display_interval: Optional[int] = 10
     bar_format: str = "{desc:<14}{percentage:3.0f}%|{bar}{r_bar:<55}"
     debug_log: Optional[str] = None
     stats_log: Optional[str] = None

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -796,7 +796,7 @@ def _work_queue_processing(
                 )
                 acc_sub = _wq_queue.stats_category("accumulating").tasks_submitted
                 progress_bars["accumulate"].total = math.ceil(
-                    items_total * acc_sub / items_done
+                    1 + (items_total * acc_sub / items_done)
                 )
 
                 # Remove input files as we go to avoid unbounded disk
@@ -805,14 +805,13 @@ def _work_queue_processing(
 
     if items_done < items_total:
         _vprint.printf("\nWARNING: Not all items were processed.\n")
+
     accumulator = _final_accumulation(
         accumulator, tasks_to_accumulate, exec_defaults["compression"]
     )
-
-    progress_bars["accumulate"].total = _wq_queue.stats_category(
-        "accumulating"
-    ).tasks_submitted
+    progress_bars["accumulate"].update(1)
     progress_bars["accumulate"].refresh()
+
     for bar in progress_bars.values():
         bar.close()
 


### PR DESCRIPTION
The main change in this pr is the collection of statistics particular to the WorkQueue executor, such as number of times a chunk that exhausted resources had to be split, the current value of the dynamic chunksize, etc. This statistics can be read by a status display of work queue.

A minor change also included here is a fix to events_total sum computation.  Using metadata['numentries"] did not work anymore. Now we get the information reading the file size cached information from the .preprocess function. The dynamic chunksize does not work with maxchunks anyway, so the cached information should always be present.