### PR TITLE
wq: option to activate ssl between manager and workers

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -531,6 +531,11 @@ class WorkQueueExecutor(ExecutorBase):
             master_name not given.
         password_file: str
             Location of a file containing a password used to authenticate workers.
+        ssl: bool or tuple(str, str)
+            Enable ssl encryption between master and workers. If a tuple, then it
+            should be of the form (key, cert), where key and cert are paths to the files
+            containing the key and certificate in pem format. If True, auto-signed temporary
+            key and cert are generated for the session.
 
         extra_input_files: list
             A list of files in the current working directory to send along with each task.
@@ -589,6 +594,7 @@ class WorkQueueExecutor(ExecutorBase):
     transactions_log: Optional[str] = None
     tasks_accum_log: Optional[str] = None
     password_file: Optional[str] = None
+    ssl: Union[bool, Tuple[str, str]] = False
     environment_file: Optional[str] = None
     extra_input_files: List = field(default_factory=list)
     wrapper: Optional[str] = shutil.which("poncho_package_run")

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -101,6 +101,7 @@ class CoffeaWQ(WorkQueue):
         report_stdout=None,
         report_monitor=None,
         status_display_interval=None,
+        ssl=False,
     ):
         self.report_stdout = report_stdout
         self.report_monitor = report_monitor
@@ -113,6 +114,7 @@ class CoffeaWQ(WorkQueue):
             stats_log=stats_log,
             transactions_log=transactions_log,
             status_display_interval=status_display_interval,
+            ssl=ssl,
         )
 
         # Make use of the stored password file, if enabled.
@@ -636,6 +638,7 @@ def work_queue_main(items, function, accumulator, **kwargs):
             transactions_log=kwargs["transactions_log"],
             tasks_accum_log=kwargs["tasks_accum_log"],
             password_file=kwargs["password_file"],
+            ssl=kwargs["ssl"],
             report_stdout=kwargs["print_stdout"],
             report_monitor=kwargs["resource_monitor"],
             status_display_interval=kwargs["status_display_interval"],


### PR DESCRIPTION
The WorkQueueExecutor accepts the parameter `ssl`. If `ssl=True`, then
temporary autosigned key and certs are generated and used. Otherwise,
ssl=(key,cert) should indicate the paths to a key and cert in pem
format.

When activating ssl in the wq manager, workers should be launched with
the --ssl command line argument.