### PR TITLE
Ordered accumulate

### DIFF
--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -46,6 +46,7 @@ def add(a: Accumulatable, b: Accumulatable) -> Accumulatable:
             )
         out.clear()
         lhs, rhs = set(a), set(b)
+        # Keep the order of elements as far as possible
         for key in a:
             if key in rhs:
                 out[key] = add(a[key], b[key])

--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -73,8 +73,10 @@ def iadd(a: Accumulatable, b: Accumulatable) -> Accumulatable:
                 f"Cannot add two mappings of incompatible type ({type(a)} vs. {type(b)})"
             )
         lhs, rhs = set(a), set(b)
-        for key in lhs & rhs:
-            a[key] = iadd(a[key], b[key])
+        # Keep the order of elements as far as possible
+        for key in a:
+            if key in rhs:
+                a[key] = iadd(a[key], b[key])
         for key in b:
             if key not in lhs:
                 a[key] = copy.deepcopy(b[key])

--- a/coffea/processor/accumulator.py
+++ b/coffea/processor/accumulator.py
@@ -46,12 +46,14 @@ def add(a: Accumulatable, b: Accumulatable) -> Accumulatable:
             )
         out.clear()
         lhs, rhs = set(a), set(b)
-        for key in lhs & rhs:
-            out[key] = add(a[key], b[key])
-        for key in lhs - rhs:
-            out[key] = copy.deepcopy(a[key])
-        for key in rhs - lhs:
-            out[key] = copy.deepcopy(b[key])
+        for key in a:
+            if key in rhs:
+                out[key] = add(a[key], b[key])
+            else:
+                out[key] = copy.deepcopy(a[key])
+        for key in b:
+            if key not in lhs:
+                out[key] = copy.deepcopy(b[key])
         return out
     raise ValueError(
         f"Cannot add accumulators of incompatible type ({type(a)} vs. {type(b)})"
@@ -72,8 +74,9 @@ def iadd(a: Accumulatable, b: Accumulatable) -> Accumulatable:
         lhs, rhs = set(a), set(b)
         for key in lhs & rhs:
             a[key] = iadd(a[key], b[key])
-        for key in rhs - lhs:
-            a[key] = copy.deepcopy(b[key])
+        for key in b:
+            if key not in lhs:
+                a[key] = copy.deepcopy(b[key])
         return a
     raise ValueError(
         f"Cannot add accumulators of incompatible type ({type(a)} vs. {type(b)})"


### PR DESCRIPTION
When dicts are accumulated, the order of the elements in them are shuffled. In case of two dicts with the same keys I don't except the result to have shuffled keys. Additionally this seems very counter intuitive to me because it doesn't happen when the old `dict_accumulator` is used or the inplace accumulation is used. The reason for this behavior is that Coffea keeps the keys around in sets and iterates on them.
This change instead iterates over the Mappings directly. This also applies the the inplace adding. In my tests this even slightly increased the performance.


For testing:
```python
from coffea.processor.accumulator import add, iadd


a = dict.fromkeys(range(10, 0, -1), 0)
b = dict.fromkeys(range(20, 0, -1), 0)

print(add(a, b))
iadd(a, b)
print(a)
```

Output before:
```
{1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 0, 9: 0, 10: 0, 11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0}
{10: 0, 9: 0, 8: 0, 7: 0, 6: 0, 5: 0, 4: 0, 3: 0, 2: 0, 1: 0, 11: 0, 12: 0, 13: 0, 14: 0, 15: 0, 16: 0, 17: 0, 18: 0, 19: 0, 20: 0}
```

Output now:
```
{10: 0, 9: 0, 8: 0, 7: 0, 6: 0, 5: 0, 4: 0, 3: 0, 2: 0, 1: 0, 20: 0, 19: 0, 18: 0, 17: 0, 16: 0, 15: 0, 14: 0, 13: 0, 12: 0, 11: 0}
{10: 0, 9: 0, 8: 0, 7: 0, 6: 0, 5: 0, 4: 0, 3: 0, 2: 0, 1: 0, 20: 0, 19: 0, 18: 0, 17: 0, 16: 0, 15: 0, 14: 0, 13: 0, 12: 0, 11: 0}
```