### PR TITLE
work queue executor refactor

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1448,7 +1448,7 @@ class Runner:
             if filemeta.populated(clusters=self.align_clusters):
                 final_fileset.append(filemeta)
             elif not self.skipbadfiles:
-                raise RuntimeError("Metadata for file {} could not be accessed.")
+                raise RuntimeError(f"Metadata for file {filemeta.filename} could not be accessed.")
         return final_fileset
 
     def _chunk_generator(self, fileset: Dict, treename: str) -> Generator:

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -542,9 +542,7 @@ class WorkQueueExecutor(ExecutorBase):
             Wrapper script to run/open python environment tarball. Defaults to python_package_run found in PATH.
 
         chunks_per_accum : int
-            Number of processed chunks per accumulation task. Defaults is 10.
-        chunks_accum_in_mem : int
-            Maximum number of chunks to keep in memory at each accumulation step in an accumulation task. Default is 2.
+            Number of processed chunks per accumulation task. Defaults is 25.
 
         verbose : bool
             If true, emit a message on each task submission and completion.
@@ -597,7 +595,7 @@ class WorkQueueExecutor(ExecutorBase):
     disk: Optional[int] = None
     gpus: Optional[int] = None
     chunks_per_accum: int = 25
-    chunks_accum_in_mem: int = 2
+    chunks_accum_in_mem: Optional[int] = None
     chunksize: int = 100000
     dynamic_chunksize: Optional[Dict] = None
     custom_init: Optional[Callable] = None
@@ -609,6 +607,16 @@ class WorkQueueExecutor(ExecutorBase):
         accumulator: Accumulatable,
     ):
         from .work_queue_tools import run
+
+        if self.chunks_accum_in_mem:
+            from coffea.util import deprecate
+
+            deprecate(
+                RuntimeError("chunks_accum_in_mem is deprecated"),
+                "v0.8.0",
+                "31 Dec 2022",
+            )
+
         return (
             run(
                 self,

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -608,15 +608,9 @@ class WorkQueueExecutor(ExecutorBase):
         function: Callable,
         accumulator: Accumulatable,
     ):
-        try:
-            import work_queue  # noqa
-            from .work_queue_tools import work_queue_main
-        except ImportError as e:
-            print("You must have Work Queue installed to use WorkQueueExecutor!")
-            raise e
-
+        from .work_queue_tools import run
         return (
-            work_queue_main(
+            run(
                 self,
                 items,
                 function,

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -521,6 +521,11 @@ class WorkQueueExecutor(ExecutorBase):
             master_name not given.
         password_file: str
             Location of a file containing a password used to authenticate workers.
+        ssl: bool or tuple(str, str)
+            Enable ssl encryption between master and workers. If a tuple, then it
+            should be of the form (key, cert), where key and cert are paths to the files
+            containing the key and certificate in pem format. If True, auto-signed temporary
+            key and cert are generated for the session.
 
         extra_input_files: list
             A list of files in the current working directory to send along with each task.
@@ -579,6 +584,7 @@ class WorkQueueExecutor(ExecutorBase):
     transactions_log: Optional[str] = None
     tasks_accum_log: Optional[str] = None
     password_file: Optional[str] = None
+    ssl: Union[bool, Tuple[str, str]] = False
     environment_file: Optional[str] = None
     extra_input_files: List = field(default_factory=list)
     wrapper: Optional[str] = shutil.which("poncho_package_run")

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -457,7 +457,7 @@ class WorkQueueExecutor(ExecutorBase):
 
     Parameters
     ----------
-        items : list or generator
+        items : sequence or generator
             Sequence of input arguments
         function : callable
             A function to be called on each input, which returns an accumulator instance
@@ -474,11 +474,11 @@ class WorkQueueExecutor(ExecutorBase):
             `None`` sets level to 1 (minimal compression)
         # work queue specific options:
         cores : int
-            Number of cores for work queue task. If unset, use a whole worker.
+            Maximum number of cores for work queue task. If unset, use a whole worker.
         memory : int
-            Amount of memory (in MB) for work queue task. If unset, use a whole worker.
+            Maximum amount of memory (in MB) for work queue task. If unset, use a whole worker.
         disk : int
-            Amount of disk space (in MB) for work queue task. If unset, use a whole worker.
+            Maximum amount of disk space (in MB) for work queue task. If unset, use a whole worker.
         gpus : int
             Number of GPUs to allocate to each task.  If unset, use zero.
         resource_monitor : str
@@ -558,6 +558,10 @@ class WorkQueueExecutor(ExecutorBase):
             Filename for tasks lifetime reports output
         tasks_accum_log : str
             Filename for the log of tasks that have been processed and accumulated.
+
+        filepath: str
+            Path to the parent directory where to create the staging directory.
+            Default is "." (current working directory).
 
         custom_init : function, optional
             A function that takes as an argument the queue's WorkQueue object.

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1800,14 +1800,13 @@ class Runner:
         events_total = sum(len(c) for c in chunks_to_count)
 
         exe_args = {
-            "unit": "event"
-            if isinstance(self.executor, WorkQueueExecutor)
-            else "chunk",  # fmt: skip
+            "unit": "chunk",
             "function_name": type(processor_instance).__name__,
         }
-        if self.format == "root" and isinstance(self.executor, WorkQueueExecutor):
+        if isinstance(self.executor, WorkQueueExecutor):
             exe_args.update(
                 {
+                    "unit": "event",
                     "events_total": events_total,
                     "dynamic_chunksize": self.dynamic_chunksize,
                     "chunksize": self.chunksize,

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -610,12 +610,9 @@ class WorkQueueExecutor(ExecutorBase):
     ):
         try:
             import work_queue  # noqa
-            import dill  # noqa
             from .work_queue_tools import work_queue_main
         except ImportError as e:
-            print(
-                "You must have Work Queue and dill installed to use WorkQueueExecutor!"
-            )
+            print("You must have Work Queue installed to use WorkQueueExecutor!")
             raise e
 
         return (

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -541,8 +541,8 @@ class WorkQueueExecutor(ExecutorBase):
         wrapper : str
             Wrapper script to run/open python environment tarball. Defaults to python_package_run found in PATH.
 
-        chunks_per_accum : int
-            Number of processed chunks per accumulation task. Defaults is 25.
+        treereduction : int
+            Number of processed chunks per accumulation task. Defaults is 20.
 
         verbose : bool
             If true, emit a message on each task submission and completion.
@@ -598,7 +598,7 @@ class WorkQueueExecutor(ExecutorBase):
     memory: Optional[int] = None
     disk: Optional[int] = None
     gpus: Optional[int] = None
-    chunks_per_accum: int = 25
+    treereduction: int = 20
     chunksize: int = 100000
     dynamic_chunksize: Optional[Dict] = None
     custom_init: Optional[Callable] = None
@@ -607,6 +607,7 @@ class WorkQueueExecutor(ExecutorBase):
     bar_format: Optional[str] = None
     chunks_accum_in_mem: Optional[int] = None
     master_name: Optional[str] = None
+    chunks_per_accum: Optional[int] = None
 
     def __call__(
         self,

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -516,9 +516,9 @@ class WorkQueueExecutor(ExecutorBase):
         manager_name : str
             Name to refer to this work queue manager.
             Sets port to 0 (any available port) if port not given.
-        port : int
-            Port number for work queue manager program. Defaults to 9123 if
-            manager_name not given.
+        port : int or tuple(int, int)
+            Port number or range (inclusive of ports )for work queue manager program.
+            Defaults to 9123 if manager_name not given.
         password_file: str
             Location of a file containing a password used to authenticate workers.
         ssl: bool or tuple(str, str)
@@ -570,7 +570,7 @@ class WorkQueueExecutor(ExecutorBase):
     retries: int = 2  # task executes at most 3 times
     # wq executor options:
     manager_name: Optional[str] = None
-    port: Optional[int] = None
+    port: Optional[Union[int, Tuple[int, int]]] = None
     filepath: str = "."
     events_total: Optional[int] = None
     x509_proxy: Optional[str] = None

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1448,7 +1448,9 @@ class Runner:
             if filemeta.populated(clusters=self.align_clusters):
                 final_fileset.append(filemeta)
             elif not self.skipbadfiles:
-                raise RuntimeError(f"Metadata for file {filemeta.filename} could not be accessed.")
+                raise RuntimeError(
+                    f"Metadata for file {filemeta.filename} could not be accessed."
+                )
         return final_fileset
 
     def _chunk_generator(self, fileset: Dict, treename: str) -> Generator:

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -471,7 +471,7 @@ class WorkQueueExecutor(ExecutorBase):
             Label of progress bar description
         compression : int, optional
             Compress accumulator outputs in flight with LZ4, at level specified (default 9)
-            Set to ``None`` for no compression.
+            `None`` sets level to 1 (minimal compression)
         # work queue specific options:
         cores : int
             Number of cores for work queue task. If unset, use a whole worker.
@@ -618,17 +618,12 @@ class WorkQueueExecutor(ExecutorBase):
             )
             raise e
 
-        from .work_queue_tools import _get_x509_proxy
-
-        if self.x509_proxy is None:
-            self.x509_proxy = _get_x509_proxy()
-
         return (
             work_queue_main(
+                self,
                 items,
                 function,
                 accumulator,
-                **self.__dict__,
             ),
             0,
         )

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -191,7 +191,7 @@ class CoffeaWQ(WorkQueue):
     def submit(self, task):
         taskid = super().submit(task)
         self.console(
-            "submitted {category} task id {id} item {item}, with {size} {unit}",
+            "submitted {category} task id {id} item {item}, with {size} {unit}(s)",
             category=task.category,
             id=taskid,
             item=task.itemid,

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -416,11 +416,6 @@ class CoffeaWQ(WorkQueue):
         elif executor.resource_monitor == "measure":
             watchdog_enabled = False
 
-        # activate monitoring if it has not been explicitely activated and we are
-        # using an automatic resource allocation.
-        if executor.resources_mode != "fixed":
-            monitor_enabled = True
-
         if monitor_enabled:
             self.enable_monitoring(watchdog=watchdog_enabled)
 
@@ -965,8 +960,12 @@ def run(executor, items, function, accumulator):
     if executor.chunks_per_accum < 2:
         executor.chunks_per_accum = 2
 
-    executor.verbose = executor.verbose or executor.print_stdout
+    # activate monitoring if it has not been explicitely activated and we are
+    # using an automatic resource allocation.
+    if executor.resources_mode != "fixed" and executor.resource_monitor == "off":
+        executor.resource_monitor = "watchdog"
 
+    executor.verbose = executor.verbose or executor.print_stdout
     executor.x509_proxy = _get_x509_proxy(executor.x509_proxy)
 
     global _wq_queue

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -383,7 +383,7 @@ class CoffeaWQ(WorkQueue):
         sc = self.stats_coffea
 
         # Ensure that the items looks like a generator
-        if not isinstance(items, collections.Generator):
+        if not isinstance(items, collections.abc.Generator):
             items = (item for item in items)
 
         # Keep track of total tasks in each state.

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -86,7 +86,6 @@ class CoffeaWQ(WorkQueue):
     ):
         self._staging_dir_obj = TemporaryDirectory("wq-tmp-", dir=executor.filepath)
 
-        self._check_executor_parameters(executor)
         self.executor = executor
         self.stats_coffea = Stats()
 
@@ -239,6 +238,15 @@ class CoffeaWQ(WorkQueue):
     def chunksize_current(self, new_value):
         self._chunksize_current = new_value
         self.stats_coffea.set("chunksize_current", self._chunksize_current)
+
+    @property
+    def executor(self):
+        return self._executor
+
+    @executor.setter
+    def executor(self, new_value):
+        self._executor = new_value
+        self._check_executor_parameters(self._executor)
 
     def function_to_file(self, function, name=None):
         with NamedTemporaryFile(

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -76,7 +76,9 @@ except ImportError:
             raise ImportError("work_queue not available")
 
 
-TaskReport = collections.namedtuple("TaskReport", ["events_count", "wall_time", "memory"])
+TaskReport = collections.namedtuple(
+    "TaskReport", ["events_count", "wall_time", "memory"]
+)
 
 
 class CoffeaWQ(WorkQueue):
@@ -693,7 +695,9 @@ class CoffeaWQTask(Task):
         command = fn_command
 
         if env_file:
-            wrap = './py_wrapper -e env_file -u "$WORK_QUEUE_SANDBOX"/{}-env-{} -- {}'
+            wrap = (
+                './py_wrapper -d -e env_file -u "$WORK_QUEUE_SANDBOX"/{}-env-{} -- {}'
+            )
             command = wrap.format(basename(env_file), os.getpid(), fn_command)
 
         return command

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -625,7 +625,7 @@ class CoffeaWQ(WorkQueue):
         chunks_left = math.ceil(events_left / sc["chunksize_current"])
         items_to_accum += chunks_left
 
-        accums = 0
+        accums = 1
         while True:
             if items_to_accum <= self.executor.treereduction:
                 accums += 1

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -309,14 +309,13 @@ class CoffeaWQ(WorkQueue):
         return accumulator
 
     def _process_events(self, infile_procc_fn, infile_accum_fn, items):
-        stats = self.stats_coffea
-        while (not self.empty) or stats.get("events_processed") < stats.get(
-            "events_total"
-        ):
-            if early_terminate and self.empty():
-                # all pending accumulation tasks after getting the signal have
-                # finished
-                break
+        s = self.stats_coffea
+        while True:
+            if self.empty():
+                if early_terminate:
+                    break
+                if s.get("events_total") <= s.get("events_processed"):
+                    break
 
             self._submit_processing_tasks(infile_procc_fn, items)
 

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -6,7 +6,7 @@ import signal
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from os.path import basename, join, getsize
 
-from collections import namedtuple
+import collections
 
 import math
 import numpy
@@ -76,7 +76,7 @@ except ImportError:
             raise ImportError("work_queue not available")
 
 
-TaskReport = namedtuple("TaskReport", ["events_count", "wall_time", "memory"])
+TaskReport = collections.namedtuple("TaskReport", ["events_count", "wall_time", "memory"])
 
 
 class CoffeaWQ(WorkQueue):
@@ -380,8 +380,8 @@ class CoffeaWQ(WorkQueue):
         executor = self.executor
         sc = self.stats_coffea
 
-        # if not dynamic_chunksize, ensure that the items looks like a generator
-        if isinstance(items, list):
+        # Ensure that the items looks like a generator
+        if not isinstance(items, collections.Generator):
             items = (item for item in items)
 
         # Keep track of total tasks in each state.

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -605,6 +605,7 @@ class CoffeaWQ(WorkQueue):
 
         self.stats_coffea["chunks_processed"] = 0
         self.stats_coffea["accumulations_done"] = 0
+        self.stats_coffea["accumulations_submitted"] = 0
         self.stats_coffea["estimated_total_accumulations"] = accums
 
         self._update_bars()
@@ -617,8 +618,7 @@ class CoffeaWQ(WorkQueue):
             if sc["accumulations_submitted"] <= sc["accumulations_done"]:
                 return sc["accumulations_done"]
 
-        items_to_accum = sc["accumulations_done"]
-        items_to_accum += sc["chunks_processed"]
+        items_to_accum = sc["chunks_processed"]
         items_to_accum += sc["accumulations_submitted"]
 
         events_left = sc["events_total"] - sc["events_processed"]

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -157,6 +157,7 @@ class CoffeaWQ(WorkQueue):
                 "v0.8.0",
                 "31 Dec 2022",
             )
+            executor.manager_name = executor.master_name
 
         if not executor.port:
             executor.port = 0 if executor.manager_name else 9123

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -101,6 +101,7 @@ class CoffeaWQ(WorkQueue):
         report_stdout=None,
         report_monitor=None,
         status_display_interval=None,
+        ssl=False,
     ):
         self.report_stdout = report_stdout
         self.report_monitor = report_monitor
@@ -113,6 +114,7 @@ class CoffeaWQ(WorkQueue):
             stats_log=stats_log,
             transactions_log=transactions_log,
             status_display_interval=status_display_interval,
+            ssl=ssl,
         )
 
         # Make use of the stored password file, if enabled.
@@ -636,6 +638,7 @@ def work_queue_main(items, function, accumulator, **kwargs):
             transactions_log=kwargs["transactions_log"],
             tasks_accum_log=kwargs["tasks_accum_log"],
             password_file=kwargs["password_file"],
+            ssl=kwargs["ssl"],
             report_stdout=kwargs["print_stdout"],
             report_monitor=kwargs["resource_monitor"],
             status_display_interval=kwargs["status_display_interval"],

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -103,7 +103,7 @@ class CoffeaWQ(WorkQueue):
             ssl=self.executor.ssl,
         )
 
-        self.bar = StatusBar()
+        self.bar = StatusBar(enabled=executor.status)
         self.console = VerbosePrint(self.bar.console, executor.status, executor.verbose)
 
         self._declare_resources()

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -75,6 +75,7 @@ try:
     from work_queue import WorkQueue, Task
     import work_queue as wq
 except ImportError:
+    wq = None
     print("work_queue module not available")
 
     class Task:
@@ -926,14 +927,14 @@ class AccumCoffeaWQTask(CoffeaWQTask):
         )
 
 
-def work_queue_main(executor, items, function, accumulator):
+def run(executor, items, function, accumulator):
     """Execute using Work Queue
     For more information, see :ref:`intro-coffea-wq`
     """
-
-    global _wq_queue
-
-    _check_dynamic_chunksize_targets(executor.dynamic_chunksize)
+    if not wq:
+        print("You must have Work Queue installed to use WorkQueueExecutor!")
+        # raise an import error for work queue
+        import work_queue
 
     if executor.environment_file and not executor.environment_file.wrapper:
         raise ValueError(

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -813,8 +813,8 @@ class CoffeaWQTask(Task):
 
         if not (self.successful() or self.exhausted()):
             info = self.debug_info()
-            queue.console.printf(
-                "task id {} item {} failed: [red]{}[/red]\n    {}",
+            queue.console.warn(
+                "task id {} item {} failed: {}\n    {}",
                 self.id,
                 self.itemid,
                 result_str,
@@ -1195,7 +1195,10 @@ class VerbosePrint:
         self.print(msg)
 
     def warn(self, format_str, *args, **kwargs):
-        format_str = "[red]WARNING:[/red] " + format_str
+        if self.status_mode:
+            format_str = "[red]WARNING:[/red] " + format_str
+        else:
+            format_str = "WARNING: " + format_str
         self.printf(format_str, *args, **kwargs)
 
 

--- a/coffea/processor/work_queue_tools.py
+++ b/coffea/processor/work_queue_tools.py
@@ -799,7 +799,7 @@ class CoffeaWQTask(Task):
         if queue.executor.resource_monitor and queue.executor.resource_monitor != "off":
             queue.console.printf(
                 "    measured cores: {:.1f}, memory: {:.0f} MB, disk {:.0f} MB, gpus: {:.1f}, runtime {:.1f} s",
-                self.resources_measured.cores,
+                self.resources_measured.cores + 0.0,  # +0.0 trick to clear any -0.0
                 self.resources_measured.memory,
                 self.resources_measured.disk,
                 self.resources_measured.gpus,

--- a/tests/wq.py
+++ b/tests/wq.py
@@ -9,18 +9,16 @@ except ImportError:
     sys.exit(0)
 
 
-def template_analysis(environment_file, filelist, executor, compression):
+def template_analysis(environment_file, filelist, executor):
     from coffea.processor import Runner
     from coffea.processor.test_items import NanoTestProcessor
 
     executor = executor(
-        compression=compression,
         environment_file=environment_file,
-        resources_mode="fixed",
         cores=2,
         memory=500,  # MB
         disk=1000,  # MB
-        master_name="coffea_test",
+        manager_name="coffea_test",
         port=work_queue_port,
         print_stdout=True,
     )
@@ -55,8 +53,7 @@ def work_queue_example(environment_file):
     workers.disk = 4000  # MB
 
     with workers:
-        # template_analysis(environment_file, filelist, work_queue_executor, compression=0)
-        template_analysis(environment_file, filelist, WorkQueueExecutor, compression=2)
+        template_analysis(environment_file, filelist, WorkQueueExecutor)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A much needed refactor of the wq code. It changes some things to match the rest of coffea, such as:

- change from tqdm to rich_bar
- change from dill to cloud_pickle
- on error, accumulate as much as possible so that run can be restarted (e.g. with wrapped_out["unprocessed'])
- update documentation to show use of ssl and passwords.
- reduce parameter clutter using executor object
- update chunksize on chunk split with memory exhaustion
- deprecated chunks_in_mem_accum  (always 2)
- deprecated chunks_per_accum, renamed to treereduction
- deprecated master_name, renamed to manager_name

Most of it was moving the executor functions to methods of class representing the queue. 