### PR TITLE
Simplify chunk generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         conda create --name coffea-env python=3.7
         conda activate coffea-env
         conda install -c conda-forge ndcctools dill
-        python -m pip install .
+        python -m pip install --ignore-installed .
         cd tests
         python wq.py
 

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1475,7 +1475,7 @@ class Runner:
                         nchunks[filemeta.dataset] += 1
                         if nchunks[filemeta.dataset] >= self.maxchunks:
                             break
-                yield from iter(chunks)
+                yield from (c for c in chunks)
         else:
             if self.use_skyhook and not config.get("skyhook", None):
                 print("No skyhook config found, using defaults")
@@ -1790,7 +1790,7 @@ class Runner:
                 processor_instance=pi_to_send,
             )
 
-        if self.format == "root" and self.dynamic_chunksize:
+        if self.format == "root" and isinstance(self.executor, WorkQueueExecutor):
             # keep chunks in generator, use a copy to count number of events
             # this is cheap, as we are reading from the cache
             chunks_to_count = self.preprocess(fileset, treename)

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -109,11 +109,7 @@ class FileMeta(object):
             return False
         return True
 
-    def chunks(self, target_chunksize, align_clusters, dynamic_chunksize):
-        if align_clusters and dynamic_chunksize:
-            raise RuntimeError(
-                "align_clusters cannot be used with a dynamic chunksize."
-            )
+    def chunks(self, target_chunksize, align_clusters):
         if not self.populated(clusters=align_clusters):
             raise RuntimeError
         user_keys = set(self.metadata.keys()) - _PROTECTED_NAMES
@@ -137,12 +133,14 @@ class FileMeta(object):
                 )
             return target_chunksize
         else:
-            n = max(round(self.metadata["numentries"] / target_chunksize), 1)
-            actual_chunksize = math.ceil(self.metadata["numentries"] / n)
-
+            numentries = self.metadata["numentries"]
+            update = True
             start = 0
-            while start < self.metadata["numentries"]:
-                stop = min(self.metadata["numentries"], start + actual_chunksize)
+            while start < numentries:
+                if update:
+                    n = max(round((numentries - start) / target_chunksize), 1)
+                    actual_chunksize = math.ceil((numentries - start) / n)
+                stop = min(numentries, start + actual_chunksize)
                 next_chunksize = yield WorkItem(
                     self.dataset,
                     self.filename,
@@ -153,20 +151,12 @@ class FileMeta(object):
                     user_meta,
                 )
                 start = stop
-                if dynamic_chunksize and next_chunksize:
-                    n = max(
-                        math.ceil(
-                            (self.metadata["numentries"] - start) / next_chunksize
-                        ),
-                        1,
-                    )
-                    actual_chunksize = math.ceil(
-                        (self.metadata["numentries"] - start) / n
-                    )
-            if dynamic_chunksize and next_chunksize:
-                return next_chunksize
-            else:
-                return target_chunksize
+                if next_chunksize and next_chunksize != target_chunksize:
+                    target_chunksize = next_chunksize
+                    update = True
+                else:
+                    update = False
+            return target_chunksize
 
 
 @dataclass(unsafe_hash=True, frozen=True)
@@ -1472,7 +1462,6 @@ class Runner:
                     last_chunksize = yield from filemeta.chunks(
                         last_chunksize,
                         self.align_clusters,
-                        self.dynamic_chunksize,
                     )
             else:
                 # get just enough file info to compute chunking
@@ -1481,9 +1470,7 @@ class Runner:
                 for filemeta in fileset:
                     if nchunks[filemeta.dataset] >= self.maxchunks:
                         continue
-                    for chunk in filemeta.chunks(
-                        self.chunksize, self.align_clusters, dynamic_chunksize=None
-                    ):
+                    for chunk in filemeta.chunks(self.chunksize, self.align_clusters):
                         chunks.append(chunk)
                         nchunks[filemeta.dataset] += 1
                         if nchunks[filemeta.dataset] >= self.maxchunks:

--- a/tests/wq.py
+++ b/tests/wq.py
@@ -85,7 +85,7 @@ set -e
 conda create -y --prefix {tmp_env} python={py_version} conda six dill
 source {tmp_env}/bin/activate
 conda install -y -c conda-forge xrootd conda-pack
-pip install ..
+pip install --ignore-installed ..
 python -c 'import conda_pack; conda_pack.pack(prefix="{tmp_env}", output="{env_file}")'
 """.format(
                 env_file=env_file, tmp_env=tmp_env, py_version=py_version


### PR DESCRIPTION
Cleans the chunk generation a little bit by removing the condition on dynamic_chunksize. Now, the generator correctly responds to updates to the chunksize regardless of whether the currently implemented mechanism for dynamic_chunksize is being used.

If no updates to chunksize are made, then the generator acts exactly as before. (Equally divide a file into chunks of about the same size based on the target chunksize.)

(Giving up for now in making maxchunks work as a generator too. iterators and `yield from` do not work well together.)