### PR TITLE
update wq ci to use python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
   testwq:
     runs-on: ubuntu-latest
     needs: linter
+    strategy:
+      matrix:
+        python-version: ["3.10"]
     name: test coffea-workqueue
 
     steps:
@@ -125,16 +128,16 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2.0.0
       with:
         auto-update-conda: true
-        python-version: 3.7
+        python-version: ${{ matrix.python-version }}
     - name: Test work_queue
       shell: bash -l {0}
       run: |
-        conda create --name coffea-env python=3.7
+        conda create --yes --name coffea-env -c conda-forge python=${{ matrix.python-version }} ndcctools dill conda-pack conda
         conda activate coffea-env
-        conda install -c conda-forge ndcctools dill
         python -m pip install --ignore-installed .
         cd tests
-        python wq.py
+        conda-pack --output coffea-env.tar.gz
+        python wq.py coffea-env.tar.gz
 
 #  testskyhookjob:
 #    runs-on: ubuntu-latest


### PR DESCRIPTION
- updates wq ci to use python 3.10
- the test now reuses the environment created by the ci. This avoids creating a conda environment twice.