### PR TITLE
Unrestrict numpy versions for more recent python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ INSTALL_REQUIRES = [
     "numba>=0.50.0;python_version<3.7",
     "numba>=0.56.0;python_version>3.6",
     "numpy>=1.16.0,<1.22;python_version<3.7",  # <1.22 for numba version restrictions with 1.55 series
-    "numpy>=1.18.0;python_version>3.6", # numba 1.56 available for python > 3.6, no upper numpy requirement
+    "numpy>=1.18.0;python_version>3.6",  # numba 1.56 available for python > 3.6, no upper numpy requirement
     "scipy>=1.1.0",
     "tqdm>=4.27.0",
     "lz4",

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,10 @@ INSTALL_REQUIRES = [
     "pyarrow>=1.0.0",
     "fsspec",
     "matplotlib>=3",
-    "numba>=0.50.0",
-    "numpy>=1.16.0,<1.22",  # <1.22 for numba version restrictions with 1.55 series
+    "numba>=0.50.0;python_version<3.7",
+    "numba>=0.56.0;python_version>3.6",
+    "numpy>=1.16.0,<1.22;python_version<3.7",  # <1.22 for numba version restrictions with 1.55 series
+    "numpy>=1.18.0;python_version>3.6", # numba 1.56 available for python > 3.6, no upper numpy requirement
     "scipy>=1.1.0",
     "tqdm>=4.27.0",
     "lz4",

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,10 @@ INSTALL_REQUIRES = [
     "pyarrow>=1.0.0",
     "fsspec",
     "matplotlib>=3",
-    "numba>=0.50.0;python_version<3.7",
-    "numba>=0.56.0;python_version>3.6",
-    "numpy>=1.16.0,<1.22;python_version<3.7",  # <1.22 for numba version restrictions with 1.55 series
-    "numpy>=1.18.0;python_version>3.6",  # numba 1.56 available for python > 3.6, no upper numpy requirement
+    'numba>=0.50.0;python_version<"3.7"',
+    'numba>=0.56.0;python_version>"3.6"',
+    'numpy>=1.16.0,<1.22;python_version<"3.7"',  # <1.22 for numba version restrictions with 1.55 series
+    'numpy>=1.18.0;python_version>"3.6"',  # numba 1.56 available for python > 3.6, no upper numpy requirement
     "scipy>=1.1.0",
     "tqdm>=4.27.0",
     "lz4",


### PR DESCRIPTION
See if we can specify this in setup.py

Fixes #741 