### PR TITLE
Deprecate nanoevents.methods.vector

### DIFF
--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -46,7 +46,7 @@ import numbers
 import numpy
 import awkward
 import numba
-from awkward.util import deprecate
+from coffea.util import deprecate
 
 deprecate(
     RuntimeError(

--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -46,7 +46,16 @@ import numbers
 import numpy
 import awkward
 import numba
+from awkward.util import deprecate
 
+deprecate(
+        RuntimeError(
+            """nanoevents.methods.vector is deprecated will be replaced by the vector package,
+            there are minor differences, please vet your analysis code."""
+        ),
+        "v0.8.0",
+        "31 Dec 2022",
+    )
 
 @numba.vectorize(
     [

--- a/coffea/nanoevents/methods/vector.py
+++ b/coffea/nanoevents/methods/vector.py
@@ -49,13 +49,14 @@ import numba
 from awkward.util import deprecate
 
 deprecate(
-        RuntimeError(
-            """nanoevents.methods.vector is deprecated will be replaced by the vector package,
+    RuntimeError(
+        """nanoevents.methods.vector is deprecated will be replaced by the vector package,
             there are minor differences, please vet your analysis code."""
-        ),
-        "v0.8.0",
-        "31 Dec 2022",
-    )
+    ),
+    "v0.8.0",
+    "31 Dec 2022",
+)
+
 
 @numba.vectorize(
     [


### PR DESCRIPTION
will be replaced with vector package in 0.8.0