### PR TITLE
docs: Add Python 3.10 classifier to PyPI metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
This got missed in [release `v0.7.17`](https://github.com/CoffeaTeam/coffea/releases/tag/v0.7.17). I assumed that as the PyPI classifiers for coffea are fairly detailed that this might be forgiveable for perhaps violating

https://github.com/CoffeaTeam/coffea/blob/ce4484a82918fddb16bd9791e16ad0ecc3ef0d60/CONTRIBUTING.md?plain=1#L21

(If not, apologies, but in that case I'd maybe suggest just removing all the Python 3.x version classifiers and just adding a Python 3 only one.)