### PR TITLE
docs: Add sphinx-copybutton support

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,8 +48,14 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
+    'sphinx_copybutton',
     # 'IPython.sphinxext.ipython_console_highlighting',
 ]
+
+# sphinx-copybutton configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+copybutton_here_doc_delimiter = "EOF"
 
 numpydoc_show_class_members = False
 nbsphinx_execute = 'never'

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ EXTRAS_REQUIRE["dev"] = [
     "nbsphinx",
     "sphinx-rtd-theme",
     "sphinx-automodapi",
+    "sphinx-copybutton>=0.3.2",
     "pyinstrument",
     "ipython",
 ]


### PR DESCRIPTION
Resolves #744 

* Add sphinx-copybutton to allow for code examples to be copied out with a button click.
* Add copybutton_prompt_text regex support to allow for the prompt character to be `>>>`, `$`, or `...` to handle newlines.
   - c.f. https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells
* Add support for HERE-document syntax with $ prompt.
* Set minimum required version of sphinx-copybutton to v0.3.2 to ensure HERE-document support.