### PR TITLE
fix: use uproot.open's dict-interface to avoid colon-parsing

### DIFF
--- a/coffea/lookup_tools/root_converters.py
+++ b/coffea/lookup_tools/root_converters.py
@@ -15,7 +15,7 @@ graphTypes = ["TGraphAsymmErrors", "TGraph2D"]
 
 def convert_histo_root_file(file):
     converted_file = {}
-    fin = uproot.open(file.strip())
+    fin = uproot.open({file.strip(): None})
     for path, item in fin.iteritems(recursive=True):
         if isinstance(item, uproot.ReadOnlyDirectory):
             continue

--- a/coffea/nanoevents/factory.py
+++ b/coffea/nanoevents/factory.py
@@ -92,7 +92,7 @@ class NanoEventsFactory:
                 Pass a list instance to record which branches were lazily accessed by this instance
         """
         if isinstance(file, str):
-            tree = uproot.open(file, **uproot_options)[treepath]
+            tree = uproot.open({file: None}, **uproot_options)[treepath]
         elif isinstance(file, uproot.reading.ReadOnlyDirectory):
             tree = file[treepath]
         elif "<class 'uproot.rootio.ROOTDirectory'>" == str(type(file)):

--- a/coffea/nanoevents/mapping/uproot.py
+++ b/coffea/nanoevents/mapping/uproot.py
@@ -13,7 +13,7 @@ class TrivialUprootOpener(UUIDOpener):
 
     def open_uuid(self, uuid):
         pfn = self._uuid_pfnmap[uuid]
-        rootdir = uproot.open(pfn, **self._uproot_options)
+        rootdir = uproot.open({pfn: None}, **self._uproot_options)
         if str(rootdir.file.uuid) != uuid:
             raise RuntimeError(
                 f"UUID of file {pfn} does not match expected value ({uuid})"

--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -1414,7 +1414,7 @@ class Runner:
     def metadata_fetcher(
         xrootdtimeout: int, align_clusters: bool, item: FileMeta
     ) -> Accumulatable:
-        with uproot.open(item.filename, timeout=xrootdtimeout) as file:
+        with uproot.open({item.filename: None}, timeout=xrootdtimeout) as file:
             try:
                 tree = file[item.treename]
             except uproot.exceptions.KeyInFileError as e:
@@ -1573,7 +1573,7 @@ class Runner:
 
         if format == "root":
             filecontext = uproot.open(
-                item.filename,
+                {item.filename: None},
                 timeout=xrootdtimeout,
                 file_handler=uproot.MemmapSource
                 if mmap

--- a/coffea/processor/parsl/detail.py
+++ b/coffea/processor/parsl/detail.py
@@ -45,7 +45,7 @@ def derive_chunks(filename, treename, chunksize, ds, timeout=10):
 
     uproot.XRootDSource.defaults["parallel"] = False
 
-    afile = uproot.open(filename)
+    afile = uproot.open({filename: None})
 
     tree = None
     if isinstance(treename, str):

--- a/coffea/processor/servicex/executor.py
+++ b/coffea/processor/servicex/executor.py
@@ -114,7 +114,7 @@ class Executor(ABC):
             # Determine the tree name if we've not gotten it already
             if data_type == "root":
                 if tree_name is None:
-                    with uproot.open(file_url) as sample:
+                    with uproot.open({file_url: None}) as sample:
                         tree_name = sample.keys()[0]
 
             # Invoke the implementation's task launcher

--- a/tests/processor/servicex/test_executor.py
+++ b/tests/processor/servicex/test_executor.py
@@ -105,7 +105,7 @@ class TestExecutor:
 
         hist_stream = [f async for f in executor.execute(analysis, datasource)]
         assert len(hist_stream) == 2
-        mock_uproot_open.assert_called_with("http://foo.bar/foo")
+        mock_uproot_open.assert_called_with({"http://foo.bar/foo": None})
         assert executor.tree_name == "myTree"
         assert executor.data_type == "root"
         assert executor.meta_data == {"dataset": "dataset1", "item": "value"}
@@ -182,9 +182,9 @@ class TestExecutor:
         hist_stream = [f async for f in executor.execute(analysis, datsource)]
 
         if os.name != "nt":
-            mock_uproot_open.assert_called_with("file:///foo/root1.ROOT")
+            mock_uproot_open.assert_called_with({"file:///foo/root1.ROOT": None})
         else:
-            mock_uproot_open.assert_called_with("file:///c:/foo/root1.ROOT")
+            mock_uproot_open.assert_called_with({"file:///c:/foo/root1.ROOT": None})
 
         assert len(hist_stream) == 2
 


### PR DESCRIPTION
The interpretation of the first argument to `uproot.open` is complicated by the fact that colons are interpreted as separators between the file path or URL and an object path for objects within the file. It has caused numerous issues.

  * https://github.com/scikit-hep/uproot5/issues/47
  * https://github.com/scikit-hep/uproot5/issues/79
  * https://github.com/scikit-hep/uproot5/pull/80
  * https://github.com/scikit-hep/uproot5/pull/81
  * https://github.com/scikit-hep/uproot5/issues/129
  * https://github.com/scikit-hep/uproot5/discussions/365
  * https://github.com/scikit-hep/uproot5/discussions/541
  * https://github.com/scikit-hep/uproot5/discussions/543
  * https://github.com/scikit-hep/uproot5/issues/669
  * https://github.com/scikit-hep/uproot5/pull/670

For this reason, there's another way to access a file and object:

```
"file_path:object_path" →  →  → {"file_path": "object_path"}
```

and the object path may be `None`. In this form, there's considerably less ambiguity about how to parse the file path.

It looks (to me) like _all_ of Coffea's uses of a file path in `uproot.open` would not have an object path in the same string. If this is true, then it's always safer/more robust to use the dict form, rather than the string form. This PR applies that uniformly.

I also searched for instances of `uproot.iterate` and `uproot.concatenate`, which interpret the first argument in the same way. I didn't find any. It's also possible that the `open` function was imported from `uproot` and used in an unqualified way, but I doubt it, since that would conflict with the builtin Python `open`. (I didn't see any strange `import` shenanigans, either. I'm 99.7300203936740% sure I got all the cases.)