### PR TITLE
repin awkward and numpy

### DIFF
--- a/coffea/hist/__init__.py
+++ b/coffea/hist/__init__.py
@@ -30,7 +30,7 @@ from .export import export1d
 
 from coffea.util import deprecate
 
-deprecate(ImportError("coffea.hist is deprecated"), "v0.8.0", "31 Dec 2022")
+deprecate(ImportError("coffea.hist is deprecated"), "v2023.3.0", "31 Mar 2023")
 
 __all__ = [
     "Hist",

--- a/coffea/lookup_tools/csv_converters.py
+++ b/coffea/lookup_tools/csv_converters.py
@@ -12,7 +12,7 @@ def convert_btag_csv_file(csvFilePath):
         RuntimeError(
             "Auto-conversion of btag CSV files is deprecated and will be removed. Try coffea.btag_tools.BTagScaleFactor or correctionlib!"
         ),
-        "v2023.4.0",
+        "v2023.3.0",
         "31 Mar 2023",
     )
 

--- a/coffea/lookup_tools/csv_converters.py
+++ b/coffea/lookup_tools/csv_converters.py
@@ -12,8 +12,8 @@ def convert_btag_csv_file(csvFilePath):
         RuntimeError(
             "Auto-conversion of btag CSV files is deprecated and will be removed. Try coffea.btag_tools.BTagScaleFactor or correctionlib!"
         ),
-        "v0.8.0",
-        "31 Dec 2022",
+        "v2023.4.0",
+        "31 Mar 2023",
     )
 
     fopen = open

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def get_description():
 
 
 INSTALL_REQUIRES = [
-    "awkward>=1.5.1,<2",
+    "awkward>=1.10.3,<2",
     "uproot>=4.1.6,==4.*,!=4.2.4,!=4.3.0,!=4.3.1",
     "uproot3-methods>=0.10.0",
     "uproot3>=3.14.1",
@@ -67,7 +67,7 @@ INSTALL_REQUIRES = [
     'numba>=0.50.0;python_version<"3.7"',
     'numba>=0.56.0;python_version>"3.6"',
     'numpy>=1.16.0,<1.22;python_version<"3.7"',  # <1.22 for numba version restrictions with 1.55 series
-    'numpy>=1.18.0;python_version>"3.6"',  # numba 1.56 available for python > 3.6, no upper numpy requirement
+    'numpy>=1.18.0,<1.24;python_version>"3.6"',  # numba 1.56 available for python > 3.6, upper requirement for higher python versions
     "scipy>=1.1.0",
     "tqdm>=4.27.0",
     "lz4",


### PR DESCRIPTION
awkward - without memory leak
numpy - upper bound for numba / higher python versions

This will be the last PR before coffea 0.7.21, which will be the last release before coffea 2023.3.0 (or 2023.4.0 depending on how long wrap up takes).