### PR TITLE
fix(wq): count chunks metric fix

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1936,7 +1936,11 @@ class Runner:
             processor_instance.postprocess(wrapped_out["out"])
 
         if "metrics" in wrapped_out.keys():
-            wrapped_out["metrics"]["chunks"] = len(chunks)
+            if isinstance(self.executor, WorkQueueExecutor):
+                wrapped_out["metrics"]["chunks"] = len(wrapped_out["processed"])
+            else:
+                wrapped_out["metrics"]["chunks"] = len(chunks_to_count)
+
             for k, v in wrapped_out["metrics"].items():
                 if isinstance(v, set):
                     wrapped_out["metrics"][k] = list(v)

--- a/src/coffea/processor/work_queue_tools.py
+++ b/src/coffea/processor/work_queue_tools.py
@@ -6,6 +6,7 @@ import re
 import signal
 import textwrap
 from os.path import basename, getsize, join
+from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import cloudpickle
@@ -75,6 +76,7 @@ class CoffeaWQ(WorkQueue):
         self,
         executor,
     ):
+        Path(executor.filepath).mkdir(parents=True, exist_ok=True)
         self._staging_dir_obj = TemporaryDirectory("wq-tmp-", dir=executor.filepath)
 
         self.executor = executor


### PR DESCRIPTION
A couple of small wq fixes:

- Use the count of items processed to report number of chunks in "metrics".  Previous code tried to get a len of a generator, which is not defined.
- Also, ensure that that the parent of the staging directory exists.