### PR TITLE
chore: remove ci based release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,14 +170,7 @@ jobs:
     - name: Build package for PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python setup.py sdist bdist_wheel --universal
-    - name: Create Release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_OAUTH }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        python setup.py sdist bdist_wheel --universal    
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
     - name: Build package for PyPI
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python setup.py sdist bdist_wheel --universal    
+        python setup.py sdist bdist_wheel --universal
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.6
       with:


### PR DESCRIPTION
Now we will create releases from the page on github, that will push a tag, and the tag push will deploy the release to pypi.

@nsmith- FYI