### PR TITLE
fix(ci): no need to run outdated PR hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
   schedule:
     - cron:  '1 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     name: pre-commit


### PR DESCRIPTION
update CI so it kills previous CI jobs if something new is pushed