### PR TITLE
fix: Daskify Elementlinks in PHYSLITE schema

### DIFF
--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -102,7 +102,7 @@ def _get_target_offsets(load_column, event_index):
     if isinstance(event_index, Number):
         return offsets[event_index]
 
-    # nescessary to stick it into the `NumpyArray` constructor
+    # necessary to stick it into the `NumpyArray` constructor
     # if typetracer is passed through
     offsets = awkward.typetracer.length_zero_if_typetracer(
         load_column.layout.offsets.data

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -105,7 +105,8 @@ def _get_target_offsets(load_column, event_index):
     # let the necessary column optimization know that we need to load this
     # column to get the offsets
     if awkward.backend(load_column) == "typetracer":
-        awkward.typetracer.touch_data(load_column)
+        # awkward.typetracer.touch_data(load_column) # available in awkward > 2.3.3
+        load_column.layout._touch_data(recursive=True)
 
     # necessary to stick it into the `NumpyArray` constructor
     # if typetracer is passed through

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -122,7 +122,12 @@ def _get_target_offsets(load_column, event_index):
 
 
 def _get_global_index(target, eventindex, index):
-    load_column = target[target.fields[0]]
+    for field in target.fields:
+        # fetch first column to get offsets from
+        # (but try to avoid the double-jagged ones if possible)
+        load_column = target[field]
+        if load_column.ndim < 3:
+            break
     target_offsets = _get_target_offsets(load_column, eventindex)
     return target_offsets + index
 

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -102,6 +102,11 @@ def _get_target_offsets(load_column, event_index):
     if isinstance(event_index, Number):
         return offsets[event_index]
 
+    # let the necessary column optimization know that we need to load this
+    # column to get the offsets
+    if awkward.backend(load_column) == "typetracer":
+        awkward.typetracer.touch_data(load_column)
+
     # necessary to stick it into the `NumpyArray` constructor
     # if typetracer is passed through
     offsets = awkward.typetracer.length_zero_if_typetracer(

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -192,9 +192,9 @@ class Electron(Particle):
     """Electron collection, following `xAOD::Electron_v1
     <https://gitlab.cern.ch/atlas/athena/-/blob/21.2/Event/xAOD/xAODEgamma/Root/Electron_v1.cxx>`_.
     """
+
     @property
     def trackParticles(self, _dask_array_=None):
-
         if _dask_array_ is not None:
             target = _dask_array_.behavior["__original_array__"]().GSFTrackParticles
             links = _dask_array_.trackParticleLinks
@@ -215,7 +215,9 @@ class Electron(Particle):
         )
 
     @property
-    def trackParticle(self):
+    def trackParticle(self, _dask_array_=None):
+        if _dask_array_ is not None:
+            self = _dask_array_  # TODO: is this what i should be doing?
         trackParticles = self.trackParticles
         return self.trackParticles[
             tuple([slice(None) for i in range(trackParticles.ndim - 1)] + [0])

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -204,12 +204,12 @@ class Electron(Particle):
 
     @property
     def trackParticle(self, _dask_array_=None):
-        if _dask_array_ is not None:
-            self = _dask_array_  # TODO: is this what i should be doing?
-        trackParticles = self.trackParticles
-        return self.trackParticles[
-            tuple([slice(None) for i in range(trackParticles.ndim - 1)] + [0])
-        ]
+        trackParticles = _element_link_method(
+            self, "trackParticleLinks", "GSFTrackParticles", _dask_array_
+        )
+        # Ellipsis (..., 0) slicing not supported yet by dask_awkward
+        slicer = tuple([slice(None) for i in range(trackParticles.ndim - 1)] + [0])
+        return trackParticles[slicer]
 
     @property
     def caloClusters(self, _dask_array_=None):

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -2,8 +2,8 @@
 from numbers import Number
 
 import awkward
-import numpy
 import dask_awkward
+import numpy
 
 from coffea.nanoevents.methods import base, vector
 

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -105,8 +105,7 @@ def _get_target_offsets(load_column, event_index):
     # let the necessary column optimization know that we need to load this
     # column to get the offsets
     if awkward.backend(load_column) == "typetracer":
-        # awkward.typetracer.touch_data(load_column) # available in awkward > 2.3.3
-        load_column.layout._touch_data(recursive=True)
+        awkward.typetracer.touch_data(load_column)
 
     # necessary to stick it into the `NumpyArray` constructor
     # if typetracer is passed through

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -59,6 +59,10 @@ def _element_link_method(self, link_name, target_name, _dask_array_):
 
 
 def _element_link_multiple(events, obj, link_field, with_name=None):
+    # currently not working in dask because:
+    # - we don't know the resulting type beforehand
+    # - also not the targets, so no way to find out which columns to load?
+    # - could consider to treat the case of truth collections by just loading all truth columns
     link = obj[link_field]
     key = link.m_persKey
     index = link.m_persIndex

--- a/src/coffea/nanoevents/schemas/physlite.py
+++ b/src/coffea/nanoevents/schemas/physlite.py
@@ -53,6 +53,7 @@ class PHYSLITESchema(BaseSchema):
         "GSFTrackParticles": "TrackParticle",
         "InDetTrackParticles": "TrackParticle",
         "MuonSpectrometerTrackParticles": "TrackParticle",
+        "CaloCalTopoClusters": "NanoCollection",
     }
     """Default configuration for mixin types, based on the collection name.
 

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -5,9 +5,10 @@ import pytest
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
 
-from coffea.nanoevents.methods.physlite import _get_global_index
+from coffea.nanoevents.methods.physlite import _get_global_index, _element_link
 
 import dask
+import dask_awkward as dak
 dask.config.set({"awkward.optimization.enabled": False, "awkward.raise-failed-meta": True, "awkward.optimization.on-fail": "raise"})
 
 pytestmark = pytest.mark.skip(reason="uproot is upset with this file...")
@@ -25,7 +26,18 @@ def _events():
 
 events = _events()
 
-gi = _get_global_index(events.GSFTrackParticles, events.Electrons._eventindex, events.Electrons.trackParticleLinks.m_persIndex)
+gi = _get_global_index(
+    events.GSFTrackParticles,
+    events.Electrons._eventindex,
+    events.Electrons.trackParticleLinks.m_persIndex
+)
+
+el = _element_link(
+    events.GSFTrackParticles,
+    events.Electrons._eventindex,
+    events.Electrons.trackParticleLinks.m_persIndex,
+    events.Electrons.trackParticleLinks.m_persKey
+)
 
 # @pytest.fixture(scope="module")
 # def events():

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -5,6 +5,11 @@ import pytest
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
 
+from coffea.nanoevents.methods.physlite import _get_global_index
+
+import dask
+dask.config.set({"awkward.optimization.enabled": False, "awkward.raise-failed-meta": True, "awkward.optimization.on-fail": "raise"})
+
 pytestmark = pytest.mark.skip(reason="uproot is upset with this file...")
 
 
@@ -13,64 +18,68 @@ def _events():
     factory = NanoEventsFactory.from_root(
         {path: "CollectionTree"},
         schemaclass=PHYSLITESchema,
-        permit_dask=False,
+        permit_dask=True,
+        #permit_dask=False,
     )
     return factory.events()
 
+events = _events()
 
-@pytest.fixture(scope="module")
-def events():
-    return _events()
+gi = _get_global_index(events.GSFTrackParticles, events.Electrons._eventindex, events.Electrons.trackParticleLinks.m_persIndex)
 
-
-@pytest.mark.parametrize("do_slice", [False, True])
-def test_electron_track_links(events, do_slice):
-    if do_slice:
-        events = events[np.random.randint(2, size=len(events)).astype(bool)]
-    for event in events:
-        for electron in event.Electrons:
-            for link_index, link in enumerate(electron.trackParticleLinks):
-                track_index = link.m_persIndex
-                print(track_index)
-                print(event.GSFTrackParticles)
-                print(electron.trackParticleLinks)
-                print(electron.trackParticles)
-
-                assert (
-                    event.GSFTrackParticles[track_index].z0
-                    == electron.trackParticles[link_index].z0
-                )
+# @pytest.fixture(scope="module")
+# def events():
+#     return _events()
 
 
-# from MetaData/EventFormat
-_hash_to_target_name = {
-    13267281: "TruthPhotons",
-    342174277: "TruthMuons",
-    368360608: "TruthNeutrinos",
-    375408000: "TruthTaus",
-    394100163: "TruthElectrons",
-    614719239: "TruthBoson",
-    660928181: "TruthTop",
-    779635413: "TruthBottom",
-}
+# @pytest.mark.parametrize("do_slice", [False, True])
+# def test_electron_track_links(events, do_slice):
+#     if do_slice:
+#         events = events[np.random.randint(2, size=len(events)).astype(bool)]
+#     for event in events:
+#         for electron in event.Electrons:
+#             for link_index, link in enumerate(electron.trackParticleLinks):
+#                 track_index = link.m_persIndex
+#                 print(track_index)
+#                 print(event.GSFTrackParticles)
+#                 print(electron.trackParticleLinks)
+#                 print(electron.trackParticles)
+
+#                 assert (
+#                     event.GSFTrackParticles[track_index].z0
+#                     == electron.trackParticles[link_index].z0
+#                 )
 
 
-def test_truth_links_toplevel(events):
-    children_px = events.TruthBoson.children.px
-    for i_event, event in enumerate(events):
-        for i_particle, particle in enumerate(event.TruthBoson):
-            for i_link, link in enumerate(particle.childLinks):
-                assert (
-                    event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
-                    == children_px[i_event][i_particle][i_link]
-                )
+# # from MetaData/EventFormat
+# _hash_to_target_name = {
+#     13267281: "TruthPhotons",
+#     342174277: "TruthMuons",
+#     368360608: "TruthNeutrinos",
+#     375408000: "TruthTaus",
+#     394100163: "TruthElectrons",
+#     614719239: "TruthBoson",
+#     660928181: "TruthTop",
+#     779635413: "TruthBottom",
+# }
 
 
-def test_truth_links(events):
-    for i_event, event in enumerate(events):
-        for i_particle, particle in enumerate(event.TruthBoson):
-            for i_link, link in enumerate(particle.childLinks):
-                assert (
-                    event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
-                    == particle.children[i_link].px
-                )
+# def test_truth_links_toplevel(events):
+#     children_px = events.TruthBoson.children.px
+#     for i_event, event in enumerate(events):
+#         for i_particle, particle in enumerate(event.TruthBoson):
+#             for i_link, link in enumerate(particle.childLinks):
+#                 assert (
+#                     event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
+#                     == children_px[i_event][i_particle][i_link]
+#                 )
+
+
+# def test_truth_links(events):
+#     for i_event, event in enumerate(events):
+#         for i_particle, particle in enumerate(event.TruthBoson):
+#             for i_link, link in enumerate(particle.childLinks):
+#                 assert (
+#                     event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
+#                     == particle.children[i_link].px
+#                 )

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -1,6 +1,5 @@
 import os
 
-import numpy as np
 import pytest
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -1,5 +1,6 @@
 import os
 
+import dask
 import pytest
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
@@ -21,7 +22,8 @@ def events():
 
 
 def test_load_single_field_of_linked(events):
-    events.Electrons.caloClusters.calE.compute()
+    with dask.config.set({"awkward.raise-failed-meta": True}):
+        events.Electrons.caloClusters.calE.compute()
 
 
 @pytest.mark.parametrize("do_slice", [False, True])

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -5,14 +5,6 @@ import pytest
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
 
-from coffea.nanoevents.methods.physlite import _get_global_index, _element_link
-
-import dask
-import dask_awkward as dak
-dask.config.set({"awkward.optimization.enabled": False, "awkward.raise-failed-meta": True, "awkward.optimization.on-fail": "raise"})
-
-pytestmark = pytest.mark.skip(reason="uproot is upset with this file...")
-
 
 def _events():
     path = os.path.abspath("tests/samples/DAOD_PHYSLITE_21.2.108.0.art.pool.root")
@@ -20,78 +12,29 @@ def _events():
         {path: "CollectionTree"},
         schemaclass=PHYSLITESchema,
         permit_dask=True,
-        #permit_dask=False,
     )
     return factory.events()
 
-events = _events()
 
-gi = _get_global_index(
-    events.GSFTrackParticles,
-    events.Electrons._eventindex,
-    events.Electrons.trackParticleLinks.m_persIndex
-)
-
-el = _element_link(
-    events.GSFTrackParticles,
-    events.Electrons._eventindex,
-    events.Electrons.trackParticleLinks.m_persIndex,
-    events.Electrons.trackParticleLinks.m_persKey
-)
-
-# @pytest.fixture(scope="module")
-# def events():
-#     return _events()
+@pytest.fixture(scope="module")
+def events():
+    return _events()
 
 
-# @pytest.mark.parametrize("do_slice", [False, True])
-# def test_electron_track_links(events, do_slice):
-#     if do_slice:
-#         events = events[np.random.randint(2, size=len(events)).astype(bool)]
-#     for event in events:
-#         for electron in event.Electrons:
-#             for link_index, link in enumerate(electron.trackParticleLinks):
-#                 track_index = link.m_persIndex
-#                 print(track_index)
-#                 print(event.GSFTrackParticles)
-#                 print(electron.trackParticleLinks)
-#                 print(electron.trackParticles)
-
-#                 assert (
-#                     event.GSFTrackParticles[track_index].z0
-#                     == electron.trackParticles[link_index].z0
-#                 )
+def test_load_single_field_of_linked(events):
+    events.Electrons.caloClusters.calE.compute()
 
 
-# # from MetaData/EventFormat
-# _hash_to_target_name = {
-#     13267281: "TruthPhotons",
-#     342174277: "TruthMuons",
-#     368360608: "TruthNeutrinos",
-#     375408000: "TruthTaus",
-#     394100163: "TruthElectrons",
-#     614719239: "TruthBoson",
-#     660928181: "TruthTop",
-#     779635413: "TruthBottom",
-# }
-
-
-# def test_truth_links_toplevel(events):
-#     children_px = events.TruthBoson.children.px
-#     for i_event, event in enumerate(events):
-#         for i_particle, particle in enumerate(event.TruthBoson):
-#             for i_link, link in enumerate(particle.childLinks):
-#                 assert (
-#                     event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
-#                     == children_px[i_event][i_particle][i_link]
-#                 )
-
-
-# def test_truth_links(events):
-#     for i_event, event in enumerate(events):
-#         for i_particle, particle in enumerate(event.TruthBoson):
-#             for i_link, link in enumerate(particle.childLinks):
-#                 assert (
-#                     event[_hash_to_target_name[link.m_persKey]][link.m_persIndex].px
-#                     == particle.children[i_link].px
-#                 )
+@pytest.mark.parametrize("do_slice", [False, True])
+def test_electron_track_links(events, do_slice):
+    if do_slice:
+        events = events[::2]
+    trackParticles = events.Electrons.trackParticles.compute()
+    for i, event in enumerate(events[["Electrons", "GSFTrackParticles"]].compute()):
+        for j, electron in enumerate(event.Electrons):
+            for link_index, link in enumerate(electron.trackParticleLinks):
+                track_index = link.m_persIndex
+                assert (
+                    event.GSFTrackParticles[track_index].z0
+                    == trackParticles[i][j][link_index].z0
+                )


### PR DESCRIPTION
Thanks to the help from @lgray i managed to daskify part of the cross referencing functionality in the PHYSLITE schema. So, for example, this now works:

```python
import os
from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema

def _events():
    path = os.path.abspath("tests/samples/DAOD_PHYSLITE_21.2.108.0.art.pool.root")
    factory = NanoEventsFactory.from_root(
        {path: "CollectionTree"},
        schemaclass=PHYSLITESchema,
        permit_dask=True,
    )
    return factory.events()

events = _events()
```
```pycon
>>> events.Electrons.trackParticles.pt.compute()
<Array [[], [], ..., [[2.78e+04, 1.87e+04]]] type='40 * var * var * ?float32'>
```
:+1: 

However, there are a couple of issues ...

1) (this is what the currently failing test `test_load_single_field_of_linked` shows) In some constellations the information on the necessary column for loading the offsets to calculate the global index is being lost. For example if i manually run the `_get_global_index` function:

```python
from coffea.nanoevents.methods.physlite import _get_global_index
gi = _get_global_index(
    events.CaloCalTopoClusters,
    events.Electrons._eventindex,
    events.Electrons.caloClusterLinks.m_persIndex,
)
import dask_awkward as dak
```
we see it knows it has to load the `rawE` column because the `_get_global_index` function picks the first column to get the offsets
```
>>> dak.necessary_columns(gi)
{'from-uproot-c0bb25dde97be6a3f9868eea400e2eb2': ['CaloCalTopoClusters.rawE', 'Electrons.caloClusterLinks.m_persIndex', 'Electrons._eventindex']}
```
However in the full picture when i use this to get the linked `caloClusters` this gets lost once i then select a single field of the `caloClusters`:

```pycon
>>> dak.necessary_columns(events.Electrons.caloClusters.calE)
{'from-uproot-d7496f2416955eff723b64b6e72e9c5b': ['Electrons.caloClusterLinks.m_persKey',
  'Electrons._eventindex',
  'CaloCalTopoClusters.calE',
  'Electrons.caloClusterLinks.m_persIndex']}
```

... no more `rawE` in there and consequently it will fail when i do `.compute()`, complaining it can't find `rawE`

Not quite sure yet where the information gets lost - let me know if you have any ideas

2) The concept of linking into a location based on what the `m_persKey` field in the ElementLink tells us does not play well with dask since we don't know then which columns to load beforehand and worst case not even the type of the resulting array. So for now the linking into multiple collections which we don't know beforehand doesn't work. This is probably not a huge issue because i think we only have this for the Truth Collection. And for that one it could be possible to work around it by just loading all corresponding truth columns and make a homogeneous type with only common fields. But for now i left this broken ...