### PR TITLE
feat: pass `uproot_options` also in `uproot.dask` in `from_root()`

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -268,7 +268,7 @@ class NanoEventsFactory:
             metadata : dict, optional
                 Arbitrary metadata to add to the `base.NanoEvents` object
             uproot_options : dict, optional
-                Any options to pass to ``uproot.open``
+                Any options to pass to ``uproot.open`` or ``uproot.dask``
             access_log : list, optional
                 Pass a list instance to record which branches were lazily accessed by this instance
             use_ak_forth:
@@ -326,6 +326,7 @@ class NanoEventsFactory:
                     ak_add_doc=True,
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
+                    **uproot_options,
                 )
             elif chunks_per_file is None:
                 opener = partial(
@@ -335,6 +336,7 @@ class NanoEventsFactory:
                     open_files=False,
                     ak_add_doc=True,
                     filter_branch=_remove_not_interpretable,
+                    **uproot_options,
                 )
             else:
                 opener = partial(
@@ -345,6 +347,7 @@ class NanoEventsFactory:
                     ak_add_doc=True,
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
+                    **uproot_options,
                 )
             return cls(map_schema, opener, None, cache=None, is_dask=True)
         elif permit_dask and not schemaclass.__dask_capable__:


### PR DESCRIPTION
This should probaly be fine if all `uproot_options` are picklable. It worked fine for me when I tested on a couple.