### PR TITLE
feat: also pass `uproot_options` to `uproot.dask` in `from_root()`

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -232,7 +232,7 @@ class NanoEventsFactory:
         treepath="/Events",
         entry_start=None,
         entry_stop=None,
-        chunks_per_file=None,
+        chunks_per_file=1,
         runtime_cache=None,
         persistent_cache=None,
         schemaclass=NanoAODSchema,

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -232,7 +232,7 @@ class NanoEventsFactory:
         treepath="/Events",
         entry_start=None,
         entry_stop=None,
-        chunks_per_file=1,
+        chunks_per_file=uproot._util.unset,
         runtime_cache=None,
         persistent_cache=None,
         schemaclass=NanoAODSchema,
@@ -327,17 +327,7 @@ class NanoEventsFactory:
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
                     **uproot_options,
-                )
-            elif chunks_per_file is None:
-                opener = partial(
-                    uproot.dask,
-                    file,
-                    full_paths=True,
-                    open_files=False,
-                    ak_add_doc=True,
-                    filter_branch=_remove_not_interpretable,
-                    **uproot_options,
-                )
+                )           
             else:
                 opener = partial(
                     uproot.dask,

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -327,7 +327,7 @@ class NanoEventsFactory:
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
                     **uproot_options,
-                )           
+                )
             else:
                 opener = partial(
                     uproot.dask,

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -232,7 +232,7 @@ class NanoEventsFactory:
         treepath="/Events",
         entry_start=None,
         entry_stop=None,
-        chunks_per_file=1,
+        chunks_per_file=None,
         runtime_cache=None,
         persistent_cache=None,
         schemaclass=NanoAODSchema,
@@ -268,7 +268,7 @@ class NanoEventsFactory:
             metadata : dict, optional
                 Arbitrary metadata to add to the `base.NanoEvents` object
             uproot_options : dict, optional
-                Any options to pass to ``uproot.open``
+                Any options to pass to ``uproot.open`` or ``uproot.dask``
             access_log : list, optional
                 Pass a list instance to record which branches were lazily accessed by this instance
             use_ak_forth:
@@ -326,6 +326,17 @@ class NanoEventsFactory:
                     ak_add_doc=True,
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
+                    **uproot_options,
+                )
+            elif chunks_per_file is None:
+                opener = partial(
+                    uproot.dask,
+                    file,
+                    full_paths=True,
+                    open_files=False,
+                    ak_add_doc=True,
+                    filter_branch=_remove_not_interpretable,
+                    **uproot_options,
                 )
             else:
                 opener = partial(
@@ -336,6 +347,7 @@ class NanoEventsFactory:
                     ak_add_doc=True,
                     filter_branch=_remove_not_interpretable,
                     steps_per_file=chunks_per_file,
+                    **uproot_options,
                 )
             return cls(map_schema, opener, None, cache=None, is_dask=True)
         elif permit_dask and not schemaclass.__dask_capable__:


### PR DESCRIPTION
I also had to comply to the other changes in nanoevents in `local_executors_to_dask` which were changing the `chunks_per_file` to `None` and also adding this `elif chunks_per_file is None`.