### PR TITLE
fix: comply with `boost-histogram` 1.4.0

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -582,16 +582,10 @@ class NminusOne:
         else:
             return out
 
-    def print(self, compute=False):
+    def print(self):
         """Prints the statistics of the N-1 selection"""
 
-        if self._delayed_mode and not compute:
-            warnings.warn(
-                "This will compute dask_awkward arrays. If you really want to do this now, call print(compute=True)"
-            )
-            return
-
-        if self._delayed_mode and compute:
+        if self._delayed_mode:
             self._nev = list(dask.compute(*self._nev))
 
         nev = self._nev
@@ -836,16 +830,10 @@ class Cutflow:
         else:
             return out
 
-    def print(self, compute=False):
+    def print(self):
         """Prints the statistics of the Cutflow"""
 
-        if self._delayed_mode and not compute:
-            warnings.warn(
-                "This will compute dask_awkward arrays. If you really want to do this now, call print(compute=True)"
-            )
-            return
-
-        if self._delayed_mode and compute:
+        if self._delayed_mode:
             self._nevonecut, self._nevcutflow = dask.compute(
                 self._nevonecut, self._nevcutflow
             )

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -418,7 +418,7 @@ class Weights:
 
 
 class NminusOneToNpz:
-    """Object to be returned by NmiusOne.to_npz()"""
+    """Object to be returned by NminusOne.to_npz()"""
 
     def __init__(self, file, labels, nev, masks, saver):
         self._file = file

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -582,10 +582,16 @@ class NminusOne:
         else:
             return out
 
-    def print(self):
+    def print(self, compute=False):
         """Prints the statistics of the N-1 selection"""
 
-        if self._delayed_mode:
+        if self._delayed_mode and not compute:
+            warnings.warn(
+                "This will compute dask_awkward arrays. If you really want to do this now, call print(compute=True)"
+            )
+            return
+
+        if self._delayed_mode and compute:
             self._nev = list(dask.compute(*self._nev))
 
         nev = self._nev
@@ -830,10 +836,16 @@ class Cutflow:
         else:
             return out
 
-    def print(self):
+    def print(self, compute=False):
         """Prints the statistics of the Cutflow"""
 
-        if self._delayed_mode:
+        if self._delayed_mode and not compute:
+            warnings.warn(
+                "This will compute dask_awkward arrays. If you really want to do this now, call print(compute=True)"
+            )
+            return
+
+        if self._delayed_mode and compute:
             self._nevonecut, self._nevcutflow = dask.compute(
                 self._nevonecut, self._nevcutflow
             )

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -610,13 +610,13 @@ class NminusOne:
         labels = ["initial"] + [f"N - {i}" for i in self._names] + ["N"]
         if not self._delayed_mode:
             h = hist.Hist(hist.axis.Integer(0, len(labels), name="N-1"))
-            h.fill(numpy.arange(len(labels)), weight=self._nev)
+            h.fill(numpy.arange(len(labels), dtype=int), weight=self._nev)
 
         else:
             h = hist.dask.Hist(hist.axis.Integer(0, len(labels), name="N-1"))
             for i, weight in enumerate(self._masks, 1):
                 h.fill(dask_awkward.full_like(weight, i, dtype=int), weight=weight)
-            h.fill(dask_awkward.zeros_like(weight))
+            h.fill(dask_awkward.zeros_like(weight, dtype=int))
 
         return h, labels
 
@@ -712,7 +712,7 @@ class NminusOne:
                     hist.axis.Integer(0, len(labels), name="N-1"),
                 )
                 arr = awkward.flatten(var)
-                h.fill(arr, awkward.zeros_like(arr))
+                h.fill(arr, awkward.zeros_like(arr, dtype=int))
                 for i, mask in enumerate(self.result().masks, 1):
                     arr = awkward.flatten(var[mask])
                     h.fill(arr, awkward.full_like(arr, i, dtype=int))
@@ -725,7 +725,7 @@ class NminusOne:
                     hist.axis.Integer(0, len(labels), name="N-1"),
                 )
                 arr = dask_awkward.flatten(var)
-                h.fill(arr, dask_awkward.zeros_like(arr))
+                h.fill(arr, dask_awkward.zeros_like(arr, dtype=int))
                 for i, mask in enumerate(self.result().masks, 1):
                     arr = dask_awkward.flatten(var[mask])
                     h.fill(arr, dask_awkward.full_like(arr, i, dtype=int))
@@ -856,8 +856,8 @@ class Cutflow:
             honecut = hist.Hist(hist.axis.Integer(0, len(labels), name="onecut"))
             hcutflow = honecut.copy()
             hcutflow.axes.name = ("cutflow",)
-            honecut.fill(numpy.arange(len(labels)), weight=self._nevonecut)
-            hcutflow.fill(numpy.arange(len(labels)), weight=self._nevcutflow)
+            honecut.fill(numpy.arange(len(labels), dtype=int), weight=self._nevonecut)
+            hcutflow.fill(numpy.arange(len(labels), dtype=int), weight=self._nevcutflow)
 
         else:
             honecut = hist.dask.Hist(hist.axis.Integer(0, len(labels), name="onecut"))
@@ -868,12 +868,12 @@ class Cutflow:
                 honecut.fill(
                     dask_awkward.full_like(weight, i, dtype=int), weight=weight
                 )
-            honecut.fill(dask_awkward.zeros_like(weight))
+            honecut.fill(dask_awkward.zeros_like(weight, dtype=int))
             for i, weight in enumerate(self._maskscutflow, 1):
                 hcutflow.fill(
                     dask_awkward.full_like(weight, i, dtype=int), weight=weight
                 )
-            hcutflow.fill(dask_awkward.zeros_like(weight))
+            hcutflow.fill(dask_awkward.zeros_like(weight, dtype=int))
 
         return honecut, hcutflow, labels
 
@@ -975,8 +975,8 @@ class Cutflow:
                 hcutflow.axes.name = name, "cutflow"
 
                 arr = awkward.flatten(var)
-                honecut.fill(arr, awkward.zeros_like(arr))
-                hcutflow.fill(arr, awkward.zeros_like(arr))
+                honecut.fill(arr, awkward.zeros_like(arr, dtype=int))
+                hcutflow.fill(arr, awkward.zeros_like(arr, dtype=int))
 
                 for i, mask in enumerate(self.result().masksonecut, 1):
                     arr = awkward.flatten(var[mask])
@@ -998,8 +998,8 @@ class Cutflow:
                 hcutflow.axes.name = name, "cutflow"
 
                 arr = dask_awkward.flatten(var)
-                honecut.fill(arr, dask_awkward.zeros_like(arr))
-                hcutflow.fill(arr, dask_awkward.zeros_like(arr))
+                honecut.fill(arr, dask_awkward.zeros_like(arr, dtype=int))
+                hcutflow.fill(arr, dask_awkward.zeros_like(arr, dtype=int))
 
                 for i, mask in enumerate(self.result().masksonecut, 1):
                     arr = dask_awkward.flatten(var[mask])

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -544,7 +544,7 @@ class NminusOne:
         labels = ["initial"] + [f"N - {i}" for i in self._names] + ["N"]
         return NminusOneResult(labels, self._nev, self._masks)
 
-    def to_npz(self, file, compressed=False, compute=True):
+    def to_npz(self, file, compressed=False, compute=False):
         """Saves the results of the N-1 selection to a .npz file
 
         Parameters
@@ -560,7 +560,7 @@ class NminusOne:
             compute : bool, optional
                 Whether to immediately start writing or to return an object
                 that the user can choose when to start writing by calling compute().
-                Default is True.
+                Default is False.
 
         Returns
         -------
@@ -790,7 +790,7 @@ class Cutflow:
             self._maskscutflow,
         )
 
-    def to_npz(self, file, compressed=False, compute=True):
+    def to_npz(self, file, compressed=False, compute=False):
         """Saves the results of the cutflow to a .npz file
 
         Parameters
@@ -806,7 +806,7 @@ class Cutflow:
             compute : bool, optional
                 Whether to immediately start writing or to return an object
                 that the user can choose when to start writing by calling compute().
-                Default is True.
+                Default is False.
 
         Returns
         -------

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -586,6 +586,9 @@ class NminusOne:
         """Prints the statistics of the N-1 selection"""
 
         if self._delayed_mode:
+            warnings.warn(
+                "Printing the N-1 selection statistics is going to compute dask_awkward objects."
+            )
             self._nev = list(dask.compute(*self._nev))
 
         nev = self._nev
@@ -834,6 +837,9 @@ class Cutflow:
         """Prints the statistics of the Cutflow"""
 
         if self._delayed_mode:
+            warnings.warn(
+                "Printing the cutflow statistics is going to compute dask_awkward objects."
+            )
             self._nevonecut, self._nevcutflow = dask.compute(
                 self._nevonecut, self._nevcutflow
             )

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -513,14 +513,14 @@ def test_packed_selection_nminusone():
     ):
         assert np.all(mask == truth)
 
-    nminusone.to_npz("nminusone.npz", compressed=False)
+    nminusone.to_npz("nminusone.npz", compressed=False).compute()
     with np.load("nminusone.npz") as file:
         assert np.all(file["labels"] == labels)
         assert np.all(file["nev"] == nev)
         assert np.all(file["masks"] == masks)
     os.remove("nminusone.npz")
 
-    nminusone.to_npz("nminusone.npz", compressed=True)
+    nminusone.to_npz("nminusone.npz", compressed=True).compute()
     with np.load("nminusone.npz") as file:
         assert np.all(file["labels"] == labels)
         assert np.all(file["nev"] == nev)
@@ -619,7 +619,7 @@ def test_packed_selection_cutflow():
     ):
         assert np.all(mask == truth)
 
-    cutflow.to_npz("cutflow.npz", compressed=False)
+    cutflow.to_npz("cutflow.npz", compressed=False).compute()
     with np.load("cutflow.npz") as file:
         assert np.all(file["labels"] == labels)
         assert np.all(file["nevonecut"] == nevonecut)
@@ -628,7 +628,7 @@ def test_packed_selection_cutflow():
         assert np.all(file["maskscutflow"] == maskscutflow)
     os.remove("cutflow.npz")
 
-    cutflow.to_npz("cutflow.npz", compressed=True)
+    cutflow.to_npz("cutflow.npz", compressed=True).compute()
     with np.load("cutflow.npz") as file:
         assert np.all(file["labels"] == labels)
         assert np.all(file["nevonecut"] == nevonecut)
@@ -854,14 +854,14 @@ def test_packed_selection_nminusone_dak(optimization_enabled):
         ):
             assert np.all(mask.compute() == truth.compute())
 
-        nminusone.to_npz("nminusone.npz", compressed=False)
+        nminusone.to_npz("nminusone.npz", compressed=False).compute()
         with np.load("nminusone.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nev"] == list(dask.compute(*nev)))
             assert np.all(file["masks"] == list(dask.compute(*masks)))
         os.remove("nminusone.npz")
 
-        nminusone.to_npz("nminusone.npz", compressed=True)
+        nminusone.to_npz("nminusone.npz", compressed=True).compute()
         with np.load("nminusone.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nev"] == list(dask.compute(*nev)))
@@ -978,7 +978,7 @@ def test_packed_selection_cutflow_dak(optimization_enabled):
         ):
             assert np.all(mask.compute() == truth.compute())
 
-        cutflow.to_npz("cutflow.npz", compressed=False)
+        cutflow.to_npz("cutflow.npz", compressed=False).compute()
         with np.load("cutflow.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nevonecut"] == list(dask.compute(*nevonecut)))
@@ -987,7 +987,7 @@ def test_packed_selection_cutflow_dak(optimization_enabled):
             assert np.all(file["maskscutflow"] == list(dask.compute(*maskscutflow)))
         os.remove("cutflow.npz")
 
-        cutflow.to_npz("cutflow.npz", compressed=True)
+        cutflow.to_npz("cutflow.npz", compressed=True).compute()
         with np.load("cutflow.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nevonecut"] == list(dask.compute(*nevonecut)))
@@ -1109,14 +1109,14 @@ def test_packed_selection_nminusone_dak_uproot_only(optimization_enabled):
         ):
             assert np.all(mask.compute() == truth.compute())
 
-        nminusone.to_npz("nminusone.npz", compressed=False)
+        nminusone.to_npz("nminusone.npz", compressed=False).compute()
         with np.load("nminusone.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nev"] == list(dask.compute(*nev)))
             assert np.all(file["masks"] == list(dask.compute(*masks)))
         os.remove("nminusone.npz")
 
-        nminusone.to_npz("nminusone.npz", compressed=True)
+        nminusone.to_npz("nminusone.npz", compressed=True).compute()
         with np.load("nminusone.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nev"] == list(dask.compute(*nev)))
@@ -1233,7 +1233,7 @@ def test_packed_selection_cutflow_dak_uproot_only(optimization_enabled):
         ):
             assert np.all(mask.compute() == truth.compute())
 
-        cutflow.to_npz("cutflow.npz", compressed=False)
+        cutflow.to_npz("cutflow.npz", compressed=False).compute()
         with np.load("cutflow.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nevonecut"] == list(dask.compute(*nevonecut)))
@@ -1242,7 +1242,7 @@ def test_packed_selection_cutflow_dak_uproot_only(optimization_enabled):
             assert np.all(file["maskscutflow"] == list(dask.compute(*maskscutflow)))
         os.remove("cutflow.npz")
 
-        cutflow.to_npz("cutflow.npz", compressed=True)
+        cutflow.to_npz("cutflow.npz", compressed=True).compute()
         with np.load("cutflow.npz") as file:
             assert np.all(file["labels"] == labels)
             assert np.all(file["nevonecut"] == list(dask.compute(*nevonecut)))


### PR DESCRIPTION
`boost-histogram` 1.4.0 now states that "filling an integer-based axis requires an integer array - a floating point array is disallowed (a single float was always disallowed), due to issues with rounding around 0". So, I add `dtype=int` to all `ak.zeros_like` and `np.arange` in analysis_tools.