### PR TITLE
fix: test that demoted version of missing event id actually tries to extract from file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward>=2.4.6",
-  "uproot>=5.1.1",
+  "uproot>=5.1.2",
   "dask[array]>=2023.4.0",
   "dask-awkward>=2023.10.0",
   "dask-histogram>=2023.10.0",

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -172,7 +172,7 @@ def test_missing_eventIds_warning():
     ):
         NanoAODSchema.error_missing_event_ids = False
         factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
-        events = factory.events()
+        factory.events()
 
 
 def test_missing_eventIds_warning_dask():

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -174,8 +174,11 @@ def test_missing_eventIds_warning():
         factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
         events = factory.events()
 
+
 def test_missing_eventIds_warning_dask():
     path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
     NanoAODSchema.error_missing_event_ids = False
-    events = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=True).events()
+    events = NanoEventsFactory.from_root(
+        path, schemaclass=NanoAODSchema, permit_dask=True
+    ).events()
     events.Muon.pt.compute(scheduler="processes")

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -172,6 +172,6 @@ def test_missing_eventIds_warning():
     ):
         NanoAODSchema.error_missing_event_ids = False
         factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
-        factory.events()
+        events = factory.events()
 
         events.Muon.pt.compute(scheduler="processes")

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -174,4 +174,8 @@ def test_missing_eventIds_warning():
         factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
         events = factory.events()
 
-        events.Muon.pt.compute(scheduler="processes")
+def test_missing_eventIds_warning_dask():
+    path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
+    NanoAODSchema.error_missing_event_ids = False
+    events = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=True).events()
+    events.Muon.pt.compute(scheduler="processes")

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -173,3 +173,5 @@ def test_missing_eventIds_warning():
         NanoAODSchema.error_missing_event_ids = False
         factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
         factory.events()
+
+        events.Muon.pt.compute(scheduler="processes")


### PR DESCRIPTION
Current testing was missing a case when demoted to warning where the dask workers would still error!