### PR TITLE
build: unpin numpy from above, pin numba >= 0.58.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dependencies = [
   "pyarrow>=6.0.0",
   "fsspec",
   "matplotlib>=3",
-  "numba>=0.58.0",
-  "numpy>=1.22.0,<1.26",  # < 1.26 for numba 0.58 series
+  "numba>=0.58.1",
+  "numpy>=1.22.0",
   "scipy>=1.1.0",
   "tqdm>=4.27.0",
   "lz4",


### PR DESCRIPTION
Finally a numba release without the numpy sliding window. 
From here on out I think we can drop it and just keep skooching from below as numpy 1.22 falls out of LTS.

@bendavid should make you incrementally more happy