### PR TITLE
feat: switch permit_dask to True by default

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -245,7 +245,7 @@ class NanoEventsFactory:
         access_log=None,
         iteritems_options={},
         use_ak_forth=True,
-        permit_dask=True,
+        delayed=True,
     ):
         """Quickly build NanoEvents from a root file
 
@@ -277,8 +277,8 @@ class NanoEventsFactory:
                 Pass a list instance to record which branches were lazily accessed by this instance
             use_ak_forth:
                 Toggle using awkward_forth to interpret branches in root file.
-            permit_dask:
-                Allow nanoevents to use dask as a backend.
+            delayed:
+                Nanoevents will use dask as a backend to construct a delayed task graph representing your analysis.
         """
 
         if treepath is not uproot._util.unset and not isinstance(
@@ -291,7 +291,7 @@ class NanoEventsFactory:
             )
 
         if (
-            permit_dask
+            delayed
             and not isinstance(schemaclass, FunctionType)
             and schemaclass.__dask_capable__
         ):
@@ -326,7 +326,7 @@ class NanoEventsFactory:
                     **uproot_options,
                 )
             return cls(map_schema, opener, None, cache=None, is_dask=True)
-        elif permit_dask and not schemaclass.__dask_capable__:
+        elif delayed and not schemaclass.__dask_capable__:
             warnings.warn(
                 f"{schemaclass} is not dask capable despite allowing dask, generating non-dask nanoevents"
             )
@@ -380,7 +380,7 @@ class NanoEventsFactory:
     def from_parquet(
         cls,
         file,
-        treepath="/Events",
+        treepath=uproot._util.unset,
         entry_start=None,
         entry_stop=None,
         runtime_cache=None,
@@ -390,7 +390,7 @@ class NanoEventsFactory:
         parquet_options={},
         skyhook_options={},
         access_log=None,
-        permit_dask=False,
+        delayed=True,
     ):
         """Quickly build NanoEvents from a parquet file
 
@@ -419,6 +419,8 @@ class NanoEventsFactory:
                 Any options to pass to ``pyarrow.parquet.ParquetFile``
             access_log : list, optional
                 Pass a list instance to record which branches were lazily accessed by this instance
+            delayed:
+                Nanoevents will use dask as a backend to construct a delayed task graph representing your analysis.
         """
         import pyarrow
         import pyarrow.dataset as ds
@@ -434,7 +436,7 @@ class NanoEventsFactory:
         )
 
         if (
-            permit_dask
+            delayed
             and not isinstance(schemaclass, FunctionType)
             and schemaclass.__dask_capable__
         ):
@@ -453,7 +455,7 @@ class NanoEventsFactory:
             else:
                 raise TypeError("Invalid file type (%s)" % (str(type(file))))
             return cls(map_schema, opener, None, cache=None, is_dask=True)
-        elif permit_dask and not schemaclass.__dask_capable__:
+        elif delayed and not schemaclass.__dask_capable__:
             warnings.warn(
                 f"{schemaclass} is not dask capable despite allowing dask, generating non-dask nanoevents"
             )

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -20,14 +20,7 @@ from coffea.nanoevents.mapping import (
     TrivialUprootOpener,
     UprootSourceMapping,
 )
-from coffea.nanoevents.schemas import (
-    BaseSchema,
-    DelphesSchema,
-    NanoAODSchema,
-    PFNanoAODSchema,
-    PHYSLITESchema,
-    TreeMakerSchema,
-)
+from coffea.nanoevents.schemas import BaseSchema, NanoAODSchema
 from coffea.nanoevents.util import key_to_tuple, quote, tuple_to_key, unquote
 
 _offsets_label = quote(",!offsets")
@@ -240,7 +233,7 @@ class NanoEventsFactory:
     def from_root(
         cls,
         file,
-        treepath="/Events",
+        treepath=uproot._util.unset,
         entry_start=None,
         entry_stop=None,
         chunks_per_file=uproot._util.unset,
@@ -252,7 +245,7 @@ class NanoEventsFactory:
         access_log=None,
         iteritems_options={},
         use_ak_forth=True,
-        permit_dask=False,
+        permit_dask=True,
     ):
         """Quickly build NanoEvents from a root file
 
@@ -287,42 +280,24 @@ class NanoEventsFactory:
             permit_dask:
                 Allow nanoevents to use dask as a backend.
         """
+
+        if treepath is not uproot._util.unset and not isinstance(
+            file, uproot.reading.ReadOnlyDirectory
+        ):
+            raise ValueError(
+                """Specification of treename by argument to from_root is no longer supported in coffea 2023.
+            Please use one of the allow types for "files" specified by uproot: https://github.com/scikit-hep/uproot5/blob/v5.1.2/src/uproot/_dask.py#L109-L132
+            """
+            )
+
         if (
             permit_dask
             and not isinstance(schemaclass, FunctionType)
             and schemaclass.__dask_capable__
         ):
-            behavior = None
-            if schemaclass is BaseSchema:
-                from coffea.nanoevents.methods import base
-
-                behavior = base.behavior
-            elif schemaclass is NanoAODSchema:
-                from coffea.nanoevents.methods import nanoaod
-
-                behavior = nanoaod.behavior
-            elif schemaclass is PFNanoAODSchema:
-                from coffea.nanoevents.methods import nanoaod
-
-                behavior = nanoaod.behavior
-            elif schemaclass is TreeMakerSchema:
-                from coffea.nanoevents.methods import base, vector
-
-                behavior = {}
-                behavior.update(base.behavior)
-                behavior.update(vector.behavior)
-            elif schemaclass is PHYSLITESchema:
-                from coffea.nanoevents.methods import physlite
-
-                behavior = physlite.behavior
-            elif schemaclass is DelphesSchema:
-                from coffea.nanoevents.methods import delphes
-
-                behavior = delphes.behavior
-
             map_schema = _map_schema_uproot(
                 schemaclass=schemaclass,
-                behavior=dict(behavior),
+                behavior=dict(schemaclass.behavior()),
                 metadata=metadata,
                 version="latest",
             )
@@ -360,7 +335,7 @@ class NanoEventsFactory:
             tree = file[treepath]
         elif "<class 'uproot.rootio.ROOTDirectory'>" == str(type(file)):
             raise RuntimeError(
-                "The file instance (%r) is an uproot3 type, but this module is only compatible with uproot4 or higher"
+                "The file instance (%r) is an uproot3 type, but this module is only compatible with uproot5 or higher"
                 % file
             )
         else:
@@ -463,33 +438,9 @@ class NanoEventsFactory:
             and not isinstance(schemaclass, FunctionType)
             and schemaclass.__dask_capable__
         ):
-            behavior = None
-            if schemaclass is BaseSchema:
-                from coffea.nanoevents.methods import base
-
-                behavior = base.behavior
-            elif schemaclass is NanoAODSchema:
-                from coffea.nanoevents.methods import nanoaod
-
-                behavior = nanoaod.behavior
-            elif schemaclass is TreeMakerSchema:
-                from coffea.nanoevents.methods import base, vector
-
-                behavior = {}
-                behavior.update(base.behavior)
-                behavior.update(vector.behavior)
-            elif schemaclass is PHYSLITESchema:
-                from coffea.nanoevents.methods import physlite
-
-                behavior = physlite.behavior
-            elif schemaclass is DelphesSchema:
-                from coffea.nanoevents.methods import delphes
-
-                behavior = delphes.behavior
-
             map_schema = _map_schema_parquet(
                 schemaclass=schemaclass,
-                behavior=dict(behavior),
+                behavior=dict(schemaclass.behavior()),
                 metadata=metadata,
                 version="latest",
             )
@@ -713,7 +664,7 @@ class NanoEventsFactory:
 
         events = self._events()
         if events is None:
-            behavior = dict(self._schema.behavior)
+            behavior = dict(self._schema.behavior())
             behavior["__events_factory__"] = self
             events = awkward.from_buffers(
                 self._schema.form,

--- a/src/coffea/nanoevents/schemas/auto.py
+++ b/src/coffea/nanoevents/schemas/auto.py
@@ -109,8 +109,8 @@ class auto_schema(BaseSchema):
             v for v in output.values()
         ]
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import base, candidate
 

--- a/src/coffea/nanoevents/schemas/base.py
+++ b/src/coffea/nanoevents/schemas/base.py
@@ -125,8 +125,8 @@ class BaseSchema:
         """Awkward form of this schema"""
         return self._form
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import base
 

--- a/src/coffea/nanoevents/schemas/delphes.py
+++ b/src/coffea/nanoevents/schemas/delphes.py
@@ -297,8 +297,8 @@ class DelphesSchema(BaseSchema):
 
         return output
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import delphes
 

--- a/src/coffea/nanoevents/schemas/nanoaod.py
+++ b/src/coffea/nanoevents/schemas/nanoaod.py
@@ -321,8 +321,8 @@ class NanoAODSchema(BaseSchema):
 
         return output.keys(), output.values()
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import nanoaod
 

--- a/src/coffea/nanoevents/schemas/pdune.py
+++ b/src/coffea/nanoevents/schemas/pdune.py
@@ -225,8 +225,8 @@ class PDUNESchema(BaseSchema):
     #    }
     #    return form
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import pdune
 

--- a/src/coffea/nanoevents/schemas/physlite.py
+++ b/src/coffea/nanoevents/schemas/physlite.py
@@ -157,8 +157,8 @@ class PHYSLITESchema(BaseSchema):
         }
         return form
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import physlite
 

--- a/src/coffea/nanoevents/schemas/treemaker.py
+++ b/src/coffea/nanoevents/schemas/treemaker.py
@@ -164,8 +164,8 @@ class TreeMakerSchema(BaseSchema):
 
         return branch_forms
 
-    @property
-    def behavior(self):
+    @classmethod
+    def behavior(cls):
         """Behaviors necessary to implement this schema"""
         from coffea.nanoevents.methods import base, vector
 

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1678,7 +1678,7 @@ class Runner:
                         schemaclass=schema,
                         metadata=metadata,
                         access_log=materialized,
-                        permit_dask=True,
+                        delayed=True,
                     )
                     events = factory.events()[item.entrystart : item.entrystop]
                 elif format == "parquet":

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -12,7 +12,7 @@ eagerevents = NanoEventsFactory.from_root(
     {os.path.abspath(fname): "Events"},
     schemaclass=NanoAODSchema,
     metadata={"dataset": "DYJets"},
-    permit_dask=False,
+    delayed=False,
 ).events()
 dakevents = NanoEventsFactory.from_root(
     {os.path.abspath(fname): "Events"},

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -12,12 +12,12 @@ eagerevents = NanoEventsFactory.from_root(
     {os.path.abspath(fname): "Events"},
     schemaclass=NanoAODSchema,
     metadata={"dataset": "DYJets"},
+    permit_dask=False,
 ).events()
 dakevents = NanoEventsFactory.from_root(
     {os.path.abspath(fname): "Events"},
     schemaclass=NanoAODSchema,
     metadata={"dataset": "DYJets"},
-    permit_dask=True,
 ).events()
 uprootevents = uproot.dask({fname: "Events"})
 

--- a/tests/test_analysis_tools.py
+++ b/tests/test_analysis_tools.py
@@ -10,7 +10,7 @@ from coffea.nanoevents import NanoAODSchema, NanoEventsFactory
 fname = "tests/samples/nano_dy.root"
 eagerevents = NanoEventsFactory.from_root(
     {os.path.abspath(fname): "Events"},
-    schemaclass=NanoAODSchema.v6,
+    schemaclass=NanoAODSchema,
     metadata={"dataset": "DYJets"},
 ).events()
 dakevents = NanoEventsFactory.from_root(

--- a/tests/test_fix823.py
+++ b/tests/test_fix823.py
@@ -11,7 +11,6 @@ def test_explicit_delete_after_assign():
         {testfile: "Events"},
         metadata={"dataset": "nano_dy"},
         schemaclass=NanoAODSchema,
-        permit_dask=True,
     ).events()
 
     genpart = events["GenPart"]

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -724,7 +724,6 @@ def test_corrected_jets_factory(optimization_enabled):
         events = NanoEventsFactory.from_root(
             {os.path.abspath("tests/samples/nano_dy.root"): "Events"},
             metadata={},
-            permit_dask=True,
         ).events()
 
         jec_stack_names = [

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -389,7 +389,6 @@ def test_rochester():
     # test against nanoaod
     events = NanoEventsFactory.from_root(
         {os.path.abspath("tests/samples/nano_dimuon.root"): "Events"},
-        permit_dask=True,
     ).events()
 
     data_k = rochester.kScaleDT(
@@ -406,7 +405,6 @@ def test_rochester():
     # test against mc
     events = NanoEventsFactory.from_root(
         {os.path.abspath("tests/samples/nano_dy.root"): "Events"},
-        permit_dask=True,
     ).events()
 
     hasgen = ~np.isnan(ak.fill_none(events.Muon.matched_gen.pt, np.nan))

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -75,7 +75,7 @@ def test_read_nanomc(suffix):
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
         {path: "Events"},
         schemaclass=nanoversion,
-        permit_dask=False,
+        delayed=False,
     )
     events = factory.events()
 
@@ -138,7 +138,7 @@ def test_read_from_uri(suffix):
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
         {path: "Events"},
         schemaclass=nanoversion,
-        permit_dask=False,
+        delayed=False,
     )
     events = factory.events()
 
@@ -153,7 +153,7 @@ def test_read_nanodata(suffix):
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
         {path: "Events"},
         schemaclass=nanoversion,
-        permit_dask=False,
+        delayed=False,
     )
     events = factory.events()
 
@@ -165,7 +165,7 @@ def test_missing_eventIds_error():
     path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
     with pytest.raises(RuntimeError):
         factory = NanoEventsFactory.from_root(
-            path, schemaclass=NanoAODSchema, permit_dask=False
+            path, schemaclass=NanoAODSchema, delayed=False
         )
         factory.events()
 
@@ -177,7 +177,7 @@ def test_missing_eventIds_warning():
     ):
         NanoAODSchema.error_missing_event_ids = False
         factory = NanoEventsFactory.from_root(
-            path, schemaclass=NanoAODSchema, permit_dask=False
+            path, schemaclass=NanoAODSchema, delayed=False
         )
         factory.events()
 
@@ -186,6 +186,8 @@ def test_missing_eventIds_warning_dask():
     path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
     NanoAODSchema.error_missing_event_ids = False
     events = NanoEventsFactory.from_root(
-        path, schemaclass=NanoAODSchema, permit_dask=True
+        path,
+        schemaclass=NanoAODSchema,
+        delayed=True,
     ).events()
     events.Muon.pt.compute(scheduler="processes")

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -71,9 +71,11 @@ suffixes = [
 def test_read_nanomc(suffix):
     path = os.path.abspath(f"tests/samples/nano_dy.{suffix}")
     # parquet files were converted from even older nanoaod
-    nanoversion = NanoAODSchema.v6 if suffix == "root" else NanoAODSchema.v5
+    nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, schemaclass=nanoversion
+        {path: "Events"}, 
+        schemaclass=nanoversion,
+        permit_dask=False,
     )
     events = factory.events()
 
@@ -132,9 +134,11 @@ def test_read_from_uri(suffix):
 
     path = Path(os.path.abspath(f"tests/samples/nano_dy.{suffix}")).as_uri()
 
-    nanoversion = NanoAODSchema.v6 if suffix == "root" else NanoAODSchema.v5
+    nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, schemaclass=nanoversion
+        {path: "Events"}, 
+        schemaclass=nanoversion,
+        permit_dask=False,
     )
     events = factory.events()
 
@@ -145,9 +149,11 @@ def test_read_from_uri(suffix):
 def test_read_nanodata(suffix):
     path = os.path.abspath(f"tests/samples/nano_dimuon.{suffix}")
     # parquet files were converted from even older nanoaod
-    nanoversion = NanoAODSchema.v6 if suffix == "root" else NanoAODSchema.v5
+    nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, schemaclass=nanoversion
+        {path: "Events"}, 
+        schemaclass=nanoversion,
+        permit_dask=False,
     )
     events = factory.events()
 
@@ -158,7 +164,7 @@ def test_read_nanodata(suffix):
 def test_missing_eventIds_error():
     path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
     with pytest.raises(RuntimeError):
-        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
+        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=False)
         factory.events()
 
 
@@ -168,7 +174,7 @@ def test_missing_eventIds_warning():
         RuntimeWarning, match=r"Missing event_ids \: \[\'luminosityBlock\'\]"
     ):
         NanoAODSchema.error_missing_event_ids = False
-        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema)
+        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=False)
         factory.events()
 
 

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -73,7 +73,7 @@ def test_read_nanomc(suffix):
     # parquet files were converted from even older nanoaod
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, 
+        {path: "Events"},
         schemaclass=nanoversion,
         permit_dask=False,
     )
@@ -136,7 +136,7 @@ def test_read_from_uri(suffix):
 
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, 
+        {path: "Events"},
         schemaclass=nanoversion,
         permit_dask=False,
     )
@@ -151,7 +151,7 @@ def test_read_nanodata(suffix):
     # parquet files were converted from even older nanoaod
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
-        {path: "Events"}, 
+        {path: "Events"},
         schemaclass=nanoversion,
         permit_dask=False,
     )
@@ -164,7 +164,9 @@ def test_read_nanodata(suffix):
 def test_missing_eventIds_error():
     path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
     with pytest.raises(RuntimeError):
-        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=False)
+        factory = NanoEventsFactory.from_root(
+            path, schemaclass=NanoAODSchema, permit_dask=False
+        )
         factory.events()
 
 
@@ -174,7 +176,9 @@ def test_missing_eventIds_warning():
         RuntimeWarning, match=r"Missing event_ids \: \[\'luminosityBlock\'\]"
     ):
         NanoAODSchema.error_missing_event_ids = False
-        factory = NanoEventsFactory.from_root(path, schemaclass=NanoAODSchema, permit_dask=False)
+        factory = NanoEventsFactory.from_root(
+            path, schemaclass=NanoAODSchema, permit_dask=False
+        )
         factory.events()
 
 

--- a/tests/test_nanoevents_delphes.py
+++ b/tests/test_nanoevents_delphes.py
@@ -10,7 +10,9 @@ from coffea.nanoevents import DelphesSchema, NanoEventsFactory
 def _events():
     path = os.path.abspath("tests/samples/delphes.root")
     factory = NanoEventsFactory.from_root(
-        {path: "Delphes"}, schemaclass=DelphesSchema, permit_dask=True
+        {path: "Delphes"},
+        schemaclass=DelphesSchema,
+        delayed=True,
     )
     return factory.events()
 

--- a/tests/test_nanoevents_pfnano.py
+++ b/tests/test_nanoevents_pfnano.py
@@ -9,7 +9,9 @@ from coffea.nanoevents import NanoEventsFactory, PFNanoAODSchema
 def events():
     path = os.path.abspath("tests/samples/pfnano.root")
     events = NanoEventsFactory.from_root(
-        {path: "Events"}, schemaclass=PFNanoAODSchema, permit_dask=True
+        {path: "Events"},
+        schemaclass=PFNanoAODSchema,
+        delayed=True,
     ).events()
     return events
 

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -11,7 +11,7 @@ def _events():
     factory = NanoEventsFactory.from_root(
         {path: "CollectionTree"},
         schemaclass=PHYSLITESchema,
-        permit_dask=True,
+        delayed=True,
     )
     return factory.events()
 

--- a/tests/test_nanoevents_treemaker.py
+++ b/tests/test_nanoevents_treemaker.py
@@ -11,7 +11,7 @@ from coffea.nanoevents import NanoEventsFactory, TreeMakerSchema
 def events():
     path = os.path.abspath("tests/samples/treemaker.root")
     events = NanoEventsFactory.from_root(
-        {path: "PreSelection"}, schemaclass=TreeMakerSchema, permit_dask=True
+        {path: "PreSelection"}, schemaclass=TreeMakerSchema, delayed=True
     ).events()
     return events
 


### PR DESCRIPTION
This PR makes dask-based nanoevents the default.

Currently there are some unrelated blockers for from (dask-)awkward related to numpy reducers.