### PR TITLE
test: add skip for missing dependency, fixture for local tests directory

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def tests_directory() -> str:
+    return os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_lookup_tools.py
+++ b/tests/test_lookup_tools.py
@@ -371,24 +371,26 @@ def test_jec_txt_effareas():
     print(evaluator["photon_id_EA_Pho"])
 
 
-def test_rochester():
+def test_rochester(tests_directory):
     rochester_data = lookup_tools.txt_converters.convert_rochester_file(
-        "tests/samples/RoccoR2018.txt.gz", loaduncs=True
+        f"{tests_directory}/samples/RoccoR2018.txt.gz", loaduncs=True
     )
     rochester = lookup_tools.rochester_lookup.rochester_lookup(rochester_data)
 
     # to test 1-to-1 agreement with official Rochester requires loading C++ files
     # instead, preload the correct scales in the sample directory
     # the script tests/samples/rochester/build_rochester.py produces these
-    official_data_k = np.load("tests/samples/nano_dimuon_rochester.npy")
-    official_data_err = np.load("tests/samples/nano_dimuon_rochester_err.npy")
-    official_mc_k = np.load("tests/samples/nano_dy_rochester.npy")
-    official_mc_err = np.load("tests/samples/nano_dy_rochester_err.npy")
-    mc_rand = np.load("tests/samples/nano_dy_rochester_rand.npy")
+    official_data_k = np.load(f"{tests_directory}/samples/nano_dimuon_rochester.npy")
+    official_data_err = np.load(
+        f"{tests_directory}/samples/nano_dimuon_rochester_err.npy"
+    )
+    official_mc_k = np.load(f"{tests_directory}/samples/nano_dy_rochester.npy")
+    official_mc_err = np.load(f"{tests_directory}/samples/nano_dy_rochester_err.npy")
+    mc_rand = np.load(f"{tests_directory}/samples/nano_dy_rochester_rand.npy")
 
     # test against nanoaod
     events = NanoEventsFactory.from_root(
-        {os.path.abspath("tests/samples/nano_dimuon.root"): "Events"},
+        {os.path.abspath(f"{tests_directory}/samples/nano_dimuon.root"): "Events"},
     ).events()
 
     data_k = rochester.kScaleDT(
@@ -404,7 +406,7 @@ def test_rochester():
 
     # test against mc
     events = NanoEventsFactory.from_root(
-        {os.path.abspath("tests/samples/nano_dy.root"): "Events"},
+        {os.path.abspath(f"{tests_directory}/samples/nano_dy.root"): "Events"},
     ).events()
 
     hasgen = ~np.isnan(ak.fill_none(events.Muon.matched_gen.pt, np.nan))
@@ -470,13 +472,13 @@ def test_dense_lookup():
     assert ak.to_list(lookup(a, a)) == [[1.0, 1.0], [1.0]]
 
 
-def test_549():
+def test_549(tests_directory):
     import awkward as ak
 
     from coffea.lookup_tools import extractor
 
     ext = extractor()
-    f_in = "tests/samples/SFttbar_2016_ele_pt.root"
+    f_in = f"{tests_directory}/samples/SFttbar_2016_ele_pt.root"
     ext.add_weight_sets(["ele_pt histo_eff_data %s" % f_in])
     ext.finalize()
     evaluator = ext.make_evaluator()
@@ -486,12 +488,12 @@ def test_549():
     )
 
 
-def test_554():
+def test_554(tests_directory):
     import uproot
 
     from coffea.lookup_tools.root_converters import convert_histo_root_file
 
-    f_in = "tests/samples/PR554_SkipReadOnlyDirectory.root"
+    f_in = f"{tests_directory}/samples/PR554_SkipReadOnlyDirectory.root"
     rf = uproot.open(f_in)
 
     # check that input file contains uproot.ReadOnlyDirectory

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import awkward as ak
@@ -69,8 +68,8 @@ suffixes = [
 
 
 @pytest.mark.parametrize("suffix", suffixes)
-def test_read_nanomc(suffix):
-    path = os.path.abspath(f"tests/samples/nano_dy.{suffix}")
+def test_read_nanomc(tests_directory, suffix):
+    path = f"{tests_directory}/samples/nano_dy.{suffix}"
     # parquet files were converted from even older nanoaod
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
@@ -130,10 +129,9 @@ def test_read_nanomc(suffix):
 
 
 @pytest.mark.parametrize("suffix", suffixes)
-def test_read_from_uri(suffix):
-    "Make sure we can properly open the file when a uri is used"
-
-    path = Path(os.path.abspath(f"tests/samples/nano_dy.{suffix}")).as_uri()
+def test_read_from_uri(tests_directory, suffix):
+    """Make sure we can properly open the file when a uri is used"""
+    path = Path(f"{tests_directory}/samples/nano_dy.{suffix}").as_uri()
 
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
@@ -147,8 +145,8 @@ def test_read_from_uri(suffix):
 
 
 @pytest.mark.parametrize("suffix", suffixes)
-def test_read_nanodata(suffix):
-    path = os.path.abspath(f"tests/samples/nano_dimuon.{suffix}")
+def test_read_nanodata(tests_directory, suffix):
+    path = f"{tests_directory}/samples/nano_dimuon.{suffix}"
     # parquet files were converted from even older nanoaod
     nanoversion = NanoAODSchema
     factory = getattr(NanoEventsFactory, f"from_{suffix}")(
@@ -162,8 +160,8 @@ def test_read_nanodata(suffix):
     crossref(events[ak.num(events.Jet) > 2])
 
 
-def test_missing_eventIds_error():
-    path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
+def test_missing_eventIds_error(tests_directory):
+    path = f"{tests_directory}/samples/missing_luminosityBlock.root:Events"
     with pytest.raises(RuntimeError):
         factory = NanoEventsFactory.from_root(
             path, schemaclass=NanoAODSchema, delayed=False
@@ -171,8 +169,8 @@ def test_missing_eventIds_error():
         factory.events()
 
 
-def test_missing_eventIds_warning():
-    path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
+def test_missing_eventIds_warning(tests_directory):
+    path = f"{tests_directory}/samples/missing_luminosityBlock.root:Events"
     with pytest.warns(
         RuntimeWarning, match=r"Missing event_ids \: \[\'luminosityBlock\'\]"
     ):
@@ -183,8 +181,8 @@ def test_missing_eventIds_warning():
         factory.events()
 
 
-def test_missing_eventIds_warning_dask():
-    path = os.path.abspath("tests/samples/missing_luminosityBlock.root") + ":Events"
+def test_missing_eventIds_warning_dask(tests_directory):
+    path = f"{tests_directory}/samples/missing_luminosityBlock.root:Events"
     NanoAODSchema.error_missing_event_ids = False
     with Client() as _:
         events = NanoEventsFactory.from_root(

--- a/tests/test_nanoevents_pfnano.py
+++ b/tests/test_nanoevents_pfnano.py
@@ -6,8 +6,8 @@ from coffea.nanoevents import NanoEventsFactory, PFNanoAODSchema
 
 
 @pytest.fixture(scope="module")
-def events():
-    path = os.path.abspath("tests/samples/pfnano.root")
+def events(tests_directory):
+    path = os.path.join(tests_directory, "samples/pfnano.root")
     events = NanoEventsFactory.from_root(
         {path: "Events"},
         schemaclass=PFNanoAODSchema,


### PR DESCRIPTION
While working on https://github.com/CoffeaTeam/coffea/pull/930 I had to run the tests locally and I ran into some problems that other new users may face when running tests:

- I only installed the `dev` dependencies (did not install `dask` dependencies) at first. Tests were failing due to missing dependencies. I added a pytest import skip if `dask.distributed` is missing.
- I use the PyCharm IDE and when running a given test function from the IDE it fails as PyCharm tries to run the test function from the location of the code file, instead of running it from the root directory. I added a pytest fixture so that test sample file paths are independant of the directory where the test is run. I didn't cover all instances where a local samples path appears but covered many instances.