### PR TITLE
feat: add public `delta_r` and `delta_phi` kernels for user-specified phis and etas

### DIFF
--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -607,9 +607,7 @@ class LorentzVector(ThreeVector):
 
     def delta_r2(self, other):
         """Squared `delta_r`"""
-        deta = self.eta - other.eta
-        dphi = self.delta_phi(other)
-        return deta * deta + dphi * dphi
+        return _delta_r_kernel(self.eta, self.phi, other.eta, other.phi) ** 2
 
     def delta_r(self, other):
         r"""Distance between two Lorentz vectors in (eta,phi) plane

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -65,7 +65,7 @@ def _mass2_kernel(t, x, y, z):
         numba.float64(numba.float64, numba.float64),
     ]
 )
-def _deltaphi_kernel(a, b):
+def delta_phi(a, b):
     return (a - b + numpy.pi) % (2 * numpy.pi) - numpy.pi
 
 
@@ -75,9 +75,9 @@ def _deltaphi_kernel(a, b):
         numba.float64(numba.float64, numba.float64, numba.float64, numba.float64),
     ]
 )
-def _delta_r_kernel(eta1, phi1, eta2, phi2):
+def delta_r(eta1, phi1, eta2, phi2):
     deta = eta1 - eta2
-    dphi = _deltaphi_kernel(phi1, phi2)
+    dphi = delta_phi(phi1, phi2)
     return numpy.hypot(deta, dphi)
 
 
@@ -213,7 +213,7 @@ class TwoVector:
 
         Returns a value within [-pi, pi)
         """
-        return _deltaphi_kernel(self.phi, other.phi)
+        return delta_phi(self.phi, other.phi)
 
     def dot(self, other):
         """Compute the dot product of two vectors"""
@@ -607,14 +607,14 @@ class LorentzVector(ThreeVector):
 
     def delta_r2(self, other):
         """Squared `delta_r`"""
-        return _delta_r_kernel(self.eta, self.phi, other.eta, other.phi) ** 2
+        return delta_r(self.eta, self.phi, other.eta, other.phi) ** 2
 
     def delta_r(self, other):
         r"""Distance between two Lorentz vectors in (eta,phi) plane
 
         :math:`\sqrt{\Delta\eta^2 + \Delta\phi^2}`
         """
-        return _delta_r_kernel(self.eta, self.phi, other.eta, other.phi)
+        return delta_r(self.eta, self.phi, other.eta, other.phi)
 
     @awkward.mixin_class_method(numpy.negative)
     def negative(self):

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -69,6 +69,18 @@ def _deltaphi_kernel(a, b):
     return (a - b + numpy.pi) % (2 * numpy.pi) - numpy.pi
 
 
+@numba.vectorize(
+    [
+        numba.float32(numba.float32, numba.float32, numba.float32, numba.float32),
+        numba.float64(numba.float64, numba.float64, numba.float64, numba.float64),
+    ]
+)
+def _delta_r_kernel(eta1, phi1, eta2, phi2):
+    deta = eta1 - eta2
+    dphi = _deltaphi_kernel(phi1, phi2)
+    return numpy.hypot(deta, dphi)
+
+
 behavior = {}
 
 
@@ -604,7 +616,7 @@ class LorentzVector(ThreeVector):
 
         :math:`\sqrt{\Delta\eta^2 + \Delta\phi^2}`
         """
-        return numpy.hypot(self.eta - other.eta, self.delta_phi(other))
+        return _delta_r_kernel(self.eta, self.phi, other.eta, other.phi)
 
     @awkward.mixin_class_method(numpy.negative)
     def negative(self):

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -66,6 +66,10 @@ def _mass2_kernel(t, x, y, z):
     ]
 )
 def delta_phi(a, b):
+    """Compute difference in angle given two angles a and b
+
+    Returns a value within [-pi, pi)
+    """
     return (a - b + numpy.pi) % (2 * numpy.pi) - numpy.pi
 
 
@@ -76,6 +80,10 @@ def delta_phi(a, b):
     ]
 )
 def delta_r(eta1, phi1, eta2, phi2):
+    r"""Distance in (eta,phi) plane given two pairs of (eta,phi)
+
+    :math:`\sqrt{\Delta\eta^2 + \Delta\phi^2}`
+    """
     deta = eta1 - eta2
     dphi = delta_phi(phi1, phi2)
     return numpy.hypot(deta, dphi)


### PR DESCRIPTION
Adding a `_delta_r_kernel` so that users can specify their own eta and phi and calculate `delta_r`.
We can also make this kernel public interface.