### PR TITLE
build: depend on fsspec-xrootd for convenience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "dask-histogram>=2023.10.0",
   "correctionlib>=2.3.3",
   "pyarrow>=6.0.0",
-  "fsspec",
+  "fsspec-xrootd>=0.2.2",
   "matplotlib>=3",
   "numba>=0.58.1",
   "numpy>=1.22.0",


### PR DESCRIPTION
rather than fsspec alone, which will shortly be handled in uproot.