### PR TITLE
test: taskvine with remote env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,8 @@ jobs:
       run: |
         conda create --yes --prefix ./coffea-conda-test-env -c conda-forge python=${{ matrix.python-version }} ndcctools
         conda activate ./coffea-conda-test-env
-        python -m pip install -e ".[dev,dask]"
+        python -m pip install .
+        python -m pip pytest
     - name: Test with pytest
       run: |
         conda run --prefix ./coffea-conda-test-env pytest tests/test_taskvine.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
         conda create --yes --prefix ./coffea-conda-test-env -c conda-forge python=${{ matrix.python-version }} ndcctools
         conda activate ./coffea-conda-test-env
         python -m pip install .
-        python -m pip pytest
+        python -m pip install pytest
     - name: Test with pytest
       run: |
         conda run --prefix ./coffea-conda-test-env pytest tests/test_taskvine.py

--- a/tests/test_taskvine.py
+++ b/tests/test_taskvine.py
@@ -1,5 +1,4 @@
 import os
-from sys import version_info
 
 import hist.dask as hda
 import pytest

--- a/tests/test_taskvine.py
+++ b/tests/test_taskvine.py
@@ -48,7 +48,7 @@ def test_taskvine_local_env():
         assert result.sum() == 40.0
 
 
-@pytest.mark.skip(reason="need to investigate how to do conda-pack in ci")
+@pytest.mark.skipif("'CONDA_PREFIX' not in os.environ", reason="test needs a conda environment with coffea and ndcctools")
 def test_taskvine_remote_env():
     try:
         from ndcctools.poncho import package_create
@@ -56,23 +56,8 @@ def test_taskvine_remote_env():
     except ImportError:
         print("taskvine is not installed. Omitting test.")
         return
-
-    py_version = f"{version_info[0]}.{version_info[1]}.{version_info[2]}"
-
-    poncho_spec = {
-        "conda": {
-            "channels": ["conda-forge"],
-            "dependencies": [
-                f"python={py_version}",
-                "ndcctools",
-                "pip",
-            ],
-        },
-        "pip": ["coffea"],
-    }
-
     env_filename = "vine-env.tar.gz"
-    package_create.pack_env_from_dict(poncho_spec, env_filename)
+    package_create.pack_env(os.environ['CONDA_PREFIX'], env_filename)
 
     m = DaskVine(port=0)
     env = m.declare_poncho(env_filename, cache=True)

--- a/tests/test_taskvine.py
+++ b/tests/test_taskvine.py
@@ -48,7 +48,10 @@ def test_taskvine_local_env():
         assert result.sum() == 40.0
 
 
-@pytest.mark.skipif("'CONDA_PREFIX' not in os.environ", reason="test needs a conda environment with coffea and ndcctools")
+@pytest.mark.skipif(
+    "'CONDA_PREFIX' not in os.environ",
+    reason="test needs a conda environment with coffea and ndcctools",
+)
 def test_taskvine_remote_env():
     try:
         from ndcctools.poncho import package_create
@@ -57,7 +60,7 @@ def test_taskvine_remote_env():
         print("taskvine is not installed. Omitting test.")
         return
     env_filename = "vine-env.tar.gz"
-    package_create.pack_env(os.environ['CONDA_PREFIX'], env_filename)
+    package_create.pack_env(os.environ["CONDA_PREFIX"], env_filename)
 
     m = DaskVine(port=0)
     env = m.declare_poncho(env_filename, cache=True)


### PR DESCRIPTION
Enables and fixes the taskvine test that needs an environment tarball to run at a compute node.