### PR TITLE
fix: form_hash_md5 is not needed in FilesetSpec

### DIFF
--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -172,7 +172,6 @@ class DatasetSpec:
     files: dict[str, CoffeaFileSpec]
     metadata: dict[Hashable, Any] | None
     form: str | None
-    form_hash_md5: str | None
 
 
 @dataclass


### PR DESCRIPTION
It's just used to tell if there are unique forms in `get_steps`.