### PR TITLE
feat: preprocess returns [[0, 0]] for empty ttrees, add filter_files tool

### DIFF
--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -1,5 +1,6 @@
 from coffea.dataset_tools.apply_processor import apply_to_dataset, apply_to_fileset
 from coffea.dataset_tools.manipulations import (
+    filter_files,
     get_failed_steps_for_dataset,
     get_failed_steps_for_fileset,
     max_chunks,
@@ -15,6 +16,7 @@ __all__ = [
     "apply_to_fileset",
     "max_chunks",
     "slice_chunks",
+    "filter_files",
     "max_files",
     "slice_files",
     "get_failed_steps_for_dataset",

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -112,6 +112,9 @@ def get_steps(
             out_uuid = file_uuid
             out_steps = out.tolist()
 
+        if out_steps is not None and len(out_steps) == 0:
+            out_steps = [[0, 0]]
+
         array.append(
             {
                 "file": arg.file,
@@ -129,7 +132,7 @@ def get_steps(
                 {
                     "file": "junk",
                     "object_path": "junk",
-                    "steps": [[]],
+                    "steps": [[0, 0]],
                     "uuid": "junk",
                     "form": "junk",
                     "form_hash_md5": "junk",

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -5,6 +5,7 @@ from distributed import Client
 
 from coffea.dataset_tools import (
     apply_to_fileset,
+    filter_files,
     get_failed_steps_for_fileset,
     max_chunks,
     max_files,
@@ -282,6 +283,35 @@ def test_preprocess_failed_file():
             files_per_batch=10,
             skip_bad_files=False,
         )
+
+
+def test_filter_files():
+    filtered_files = filter_files(_updated_result)
+
+    assert filtered_files == {
+        "ZJets": {
+            "files": {
+                "tests/samples/nano_dy.root": {
+                    "object_path": "Events",
+                    "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
+                }
+            },
+            "metadata": None,
+            "form": None,
+        },
+        "Data": {
+            "files": {
+                "tests/samples/nano_dimuon.root": {
+                    "object_path": "Events",
+                    "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
+                }
+            },
+            "metadata": None,
+            "form": None,
+        },
+    }
 
 
 def test_max_files():


### PR DESCRIPTION
- preprocess now returns steps of length zero for empty ttrees
- a new filter_files tool is included to remove these trees (and anything else the user specifies)

@kmohrman 