### PR TITLE
fix: better empty files filter

### DIFF
--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -103,7 +103,7 @@ def _default_filter(name_and_spec):
     name, spec = name_and_spec
     thesteps = spec["steps"]
     return thesteps is not None and (
-        len(thesteps) > 1 or (thesteps[0][1] - thesteps[0][0]) != 0
+        len(thesteps) > 1 or (thesteps[0][1] - thesteps[0][0]) > 0
     )
 
 


### PR DESCRIPTION
Use `> 0` rather than `!= 0` in case we encounter steps that are somehow backwards.