### PR TITLE
feat: deprecate coffea.nanoevents.methods.vector

### DIFF
--- a/src/coffea/__init__.py
+++ b/src/coffea/__init__.py
@@ -31,7 +31,4 @@ from . import _version
 
 __version__ = _version.__version__
 
-# control severity for utils.deprecate
-deprecations_as_errors = False
-
 __all__ = ["deprecations_as_errors"]

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -56,7 +56,7 @@ from coffea.util import deprecate
 _cst = pytz.timezone("US/Central")
 _depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
 deprecate(
-    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Consider using that package!",
+    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Nanoevents schemas internal to coffea will be migrated. Otherwise please consider using that package!",
     version="2024.7.0",
     date=str(_depttime),
     category=FutureWarning,

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -42,20 +42,21 @@ A small example::
     assert np.allclose(np.array(abs(2*vec + vec4) / abs(vec)), 3)
 
 """
-from datetime import datetime
 import numbers
+from datetime import datetime
 
 import awkward
-from coffea.util import deprecate
 import numba
 import numpy
-from dask_awkward import dask_method
 import pytz
+from dask_awkward import dask_method
 
+from coffea.util import deprecate
 
 _cst = pytz.timezone("US/Central")
 _depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
 deprecate(ModuleNotFoundError, version="2024.7.0", date=str(_depttime))
+
 
 @numba.vectorize(
     [

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -56,8 +56,8 @@ from coffea.util import deprecate
 _cst = pytz.timezone("US/Central")
 _depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
 deprecate(
-    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Consider using that package!", 
-    version="2024.7.0", 
+    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Consider using that package!",
+    version="2024.7.0",
     date=str(_depttime),
     category=FutureWarning,
 )

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -42,13 +42,20 @@ A small example::
     assert np.allclose(np.array(abs(2*vec + vec4) / abs(vec)), 3)
 
 """
+from datetime import datetime
 import numbers
 
 import awkward
+from coffea.util import deprecate
 import numba
 import numpy
 from dask_awkward import dask_method
+import pytz
 
+
+_cst = pytz.timezone("US/Central")
+_depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
+deprecate(ModuleNotFoundError, version="2024.7.0", date=str(_depttime))
 
 @numba.vectorize(
     [

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -55,7 +55,12 @@ from coffea.util import deprecate
 
 _cst = pytz.timezone("US/Central")
 _depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
-deprecate(ModuleNotFoundError, version="2024.7.0", date=str(_depttime))
+deprecate(
+    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Consider using that package!", 
+    version="2024.7.0", 
+    date=str(_depttime),
+    category=FutureWarning,
+)
 
 
 @numba.vectorize(

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -56,7 +56,11 @@ from coffea.util import deprecate
 _cst = pytz.timezone("US/Central")
 _depttime = _cst.localize(datetime(2024, 6, 30, 11, 59, 59))
 deprecate(
-    "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. Nanoevents schemas internal to coffea will be migrated. Otherwise please consider using that package!",
+    (
+        "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. "
+        "Nanoevents schemas internal to coffea will be migrated. "
+        "Otherwise please consider using that package!"
+    ),
     version="2024.7.0",
     date=str(_depttime),
     category=FutureWarning,

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -23,8 +23,6 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
-import coffea
-
 ak = awkward
 dak = dask_awkward
 np = numpy

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -181,7 +181,7 @@ def deprecate(
     warning = f"""In version {version}{date}, this will be {will_be}.
 To raise these warnings as errors (and get stack traces to find out where they're called), run
     import warnings
-    warnings.filterwarnings("error", module="awkward.*")
+    warnings.filterwarnings("error", module="coffea.*")
 after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::coffea.*")` in pytest.
 Issue: {message}."""
     warnings.warn(warning, category, stacklevel=stacklevel + 1)

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -166,22 +166,27 @@ def rich_bar():
     )
 
 
-# lifted from awkward - https://github.com/scikit-hep/awkward-1.0/blob/5fe31a916bf30df6c2ea10d4094f6f1aefcf3d0c/src/awkward/_util.py#L47-L61 # noqa
+# lifted from awkward - https://github.com/scikit-hep/awkward/blob/2b80da6b60bd5f0437b66f266387f1ab4bf98fe1/src/awkward/_errors.py#L421 # noqa
 # drive our deprecations-as-errors as with awkward
-def deprecate(exception, version, date=None):
-    if coffea.deprecations_as_errors:
-        raise exception
+def deprecate(
+    message,
+    version,
+    date=None,
+    will_be="an error",
+    category=DeprecationWarning,
+    stacklevel=2,
+):
+    if date is None:
+        date = ""
     else:
-        if date is None:
-            date = ""
-        else:
-            date = " (target date: " + date + ")"
-        message = """In coffea version {}{}, this will be an error.
-(Set coffea.deprecations_as_errors = True to get a stack trace now.)
-{}: {}""".format(
-            version, date, type(exception).__name__, str(exception)
-        )
-        warnings.warn(message, FutureWarning)
+        date = " (target date: " + date + ")"
+    warning = f"""In version {version}{date}, this will be {will_be}.
+To raise these warnings as errors (and get stack traces to find out where they're called), run
+    import warnings
+    warnings.filterwarnings("error", module="awkward.*")
+after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::coffea.*")` in pytest.
+Issue: {message}."""
+    warnings.warn(warning, category, stacklevel=stacklevel + 1)
 
 
 # re-nest a record array into a ListArray

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -182,7 +182,7 @@ def deprecate(
 To raise these warnings as errors (and get stack traces to find out where they're called), run
     import warnings
     warnings.filterwarnings("error", module="coffea.*")
-after the first `import awkward` or use `@pytest.mark.filterwarnings("error:::coffea.*")` in pytest.
+after the first `import coffea` or use `@pytest.mark.filterwarnings("error:::coffea.*")` in pytest.
 Issue: {message}."""
     warnings.warn(warning, category, stacklevel=stacklevel + 1)
 


### PR DESCRIPTION
Since we are looking into changing nanoevents to use https://github.com/scikit-hep/vector, see #991,  and it seems very possible, we are deprecating nanoevents.methods.vector very much in advance.