### PR TITLE
chore: cleanup VCS versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 .idea
 .servicex
 dask-worker-space/
+
+# VCS versioning
+src/coffea/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,15 +111,9 @@ dev = [
 #[project.entry-points."dask.sizeof"]
 #coffea = "coffea.sizeof:register"
 
-[tool.hatch.version]
-source = "vcs"
-path = "src/coffea/__init__.py"
-
-[tool.hatch.build.hooks.vcs]
-version-file = "src/coffea/version.py"
-
-[tool.setuptools_scm]
-write_to = "src/coffea/_version.py"
+[tool.hatch]
+version.source = "vcs"
+build.hooks.vcs.version-file = "src/coffea/_version.py"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/coffea/__init__.py
+++ b/src/coffea/__init__.py
@@ -27,9 +27,9 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from . import version
+from . import _version
 
-__version__ = version.__version__
+__version__ = _version.__version__
 
 # control severity for utils.deprecate
 deprecations_as_errors = False

--- a/src/coffea/version.pyi
+++ b/src/coffea/version.pyi
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+version: str
+version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]


### PR DESCRIPTION
Ran into a few developer issues while installing locally and decided to inspect `pyproject.toml` -

- `hatch-vcs` uses `setuptools_scm` underneath, so it is not required to list down `setuptools_scm`'s config in `pyproject.toml` (this was redundant anyways, given that the `hatch-vcs` config was given preference)
- The path of the version file is automatically picked up by `hatch-vcs`
- The version file (`_version.py`) should not be tracked by version control
- `setuptools_scm` suggests using the name `_version.py` and not `version.py`
- `version.pyi` defines the structure of the version (this is optional and can be removed, but it is always nice to have one)

I hope these things were not intentional.