### PR TITLE
fix: make dask layer name shorthands easier to read

### DIFF
--- a/src/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/src/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -434,6 +434,6 @@ class CorrectedJetsFactory:
             _AwkwardRewrapFn(gfunc=rewrap_recordarray),
             out,
             jets,
-            label="corrected-jets",
+            label="corrected_jets",
             meta=out_meta,
         )

--- a/src/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/src/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -224,7 +224,7 @@ class FactorizedJetCorrector:
                 corrections.append(
                     func(
                         *fargs,
-                        dask_label=f"{self._campaign}-{self._dataera}-{self._datatype}-{self._levels[i]}-{self._jettype}",
+                        dask_label=f"{self._campaign}_{self._dataera}_{self._datatype}_{self._levels[i]}_{self._jettype}",
                     )
                 )
             else:

--- a/src/coffea/jetmet_tools/JetCorrectionUncertainty.py
+++ b/src/coffea/jetmet_tools/JetCorrectionUncertainty.py
@@ -168,7 +168,7 @@ class JetCorrectionUncertainty:
                 uncs.append(
                     func(
                         *args,
-                        dask_label=f"{self._campaign}-{self._dataera}-{self._datatype}-{self._levels[i]}-{self._jettype}",
+                        dask_label=f"{self._campaign}_{self._dataera}_{self._datatype}_{self._levels[i]}_{self._jettype}",
                     )
                 )
             else:

--- a/src/coffea/jetmet_tools/JetResolution.py
+++ b/src/coffea/jetmet_tools/JetResolution.py
@@ -159,7 +159,7 @@ class JetResolution:
                 resos.append(
                     func(
                         *args,
-                        dask_label=f"{self._campaign}-{self._dataera}-{self._datatype}-{self._levels[i]}-{self._jettype}",
+                        dask_label=f"{self._campaign}_{self._dataera}_{self._datatype}_{self._levels[i]}_{self._jettype}",
                     )
                 )
             else:

--- a/src/coffea/jetmet_tools/JetResolutionScaleFactor.py
+++ b/src/coffea/jetmet_tools/JetResolutionScaleFactor.py
@@ -155,7 +155,7 @@ class JetResolutionScaleFactor:
                 sfs.append(
                     func(
                         *args,
-                        dask_label=f"{self._campaign}-{self._dataera}-{self._datatype}-{self._levels[i]}-{self._jettype}",
+                        dask_label=f"{self._campaign}_{self._dataera}_{self._datatype}_{self._levels[i]}_{self._jettype}",
                     )
                 )
             else:

--- a/src/coffea/ml_tools/helper.py
+++ b/src/coffea/ml_tools/helper.py
@@ -358,7 +358,7 @@ class numpy_call_wrapper(abc.ABC):
             wrap,
             self._delayed_wrapper,
             *packed_args,
-            label=f"numpy_call_{self.__class__.__name__}_",
+            label=f"numpy_call_{self.__class__.__name__}",
             meta=wrap_meta,
         )
         arr = unpack_ret_array(arr)

--- a/src/coffea/nanoevents/methods/base.py
+++ b/src/coffea/nanoevents/methods/base.py
@@ -236,7 +236,7 @@ class NanoCollection:
         return dask_array.map_partitions(
             _ClassMethodFn("_apply_global_index"),
             index,
-            label="_apply_global_index",
+            label="apply_global_index",
         )
 
     @dask_method(no_dispatch=True)

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -95,7 +95,7 @@ def _get_target_offsets(load_column, event_index):
     ):
         # wrap in map_partitions if dask arrays
         return dask_awkward.map_partitions(
-            _get_target_offsets, load_column, event_index
+            _get_target_offsets, load_column, event_index, label="get_target_offsets"
         )
 
     offsets = load_column.layout.offsets.data


### PR DESCRIPTION
Mostly removing leading `_` in a few names or changing `-` to `_`.