### PR TITLE
fix(docs): Update dataset_discovery.ipynb

### DIFF
--- a/binder/dataset_discovery.ipynb
+++ b/binder/dataset_discovery.ipynb
@@ -20,7 +20,7 @@
    "id": "42242097-c04e-459e-9f3a-1d746df4e9dd",
    "metadata": {},
    "source": [
-    "# Using Rucio utils directly"
+    "## Using Rucio utils directly"
    ]
   },
   {
@@ -727,7 +727,7 @@
    "id": "0b805dde-dd38-46a4-92ad-55ab2e4a4876",
    "metadata": {},
    "source": [
-    "# Using the DataDiscoveryCLI\n",
+    "## Using the DataDiscoveryCLI\n",
     "Manipulating the dataset query and replicas is simplified by the `DataDiscoveryCLI` class in `dataset_query` module."
    ]
   },


### PR DESCRIPTION
The headings for the sub-sections of this notebook are the same level as the overall heading, which breaks the index in the rendered docs:
<img width="306" alt="Screenshot 2024-01-22 at 3 24 19 PM" src="https://github.com/CoffeaTeam/coffea/assets/6587412/4ca0b0ca-07cf-4ce2-9956-6123b4d8c2f1">

This should fix it