### PR TITLE
fix!: improve user interface for preprocess

### DIFF
--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -35,7 +35,7 @@ def get_steps(
     ----------
         normed_files: awkward.Array | dask_awkward.Array
             The list of normalized file descriptions to process for steps.
-        step_sizes: int | None, default None
+        step_size: int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
         align_clusters: bool, default False
             Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in
@@ -263,7 +263,7 @@ def preprocess(
     ----------
         fileset: FilesetSpecOptional
             The set of datasets whose files will be preprocessed.
-        step_sizes: int | None, default None
+        step_size: int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
         align_clusters: bool, default False
             Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -5,6 +5,7 @@ import hashlib
 import math
 import warnings
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, Callable, Dict, Hashable
 
 import awkward
@@ -14,7 +15,7 @@ import numpy
 import uproot
 from uproot._util import no_filter
 
-from coffea.util import compress_form, decompress_form
+from coffea.util import _remove_not_interpretable, compress_form, decompress_form
 
 
 def get_steps(
@@ -81,7 +82,7 @@ def get_steps(
                 recursive=True,
                 filter_name=no_filter,
                 filter_typename=no_filter,
-                filter_branch=no_filter,
+                filter_branch=partial(_remove_not_interpretable, emit_warning=False),
                 full_paths=False,
             )
             form_str = uproot._dask._get_ttree_form(

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -253,7 +253,6 @@ def preprocess(
     file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
     save_form: bool = False,
     scheduler: None | Callable | str = None,
-    split_every: int = 8,
     uproot_options: dict = {},
     step_size_safety_factor: float = 0.5,
 ) -> tuple[FilesetSpec, FilesetSpecOptional]:
@@ -280,8 +279,6 @@ def preprocess(
             Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
         scheduler: None | Callable | str, default None
             Specifies the scheduler that dask should use to execute the preprocessing task graph.
-        split_every: int, default 8
-            How many inputs for each tree reduce step, controls parallelism vs. memory use.
         uproot_options: dict, default {}
             Options to pass to get_steps for opening files with uproot.
         step_size_safety_factor: float, default 0.5

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -22,37 +22,9 @@ from coffea.nanoevents.mapping import (
 )
 from coffea.nanoevents.schemas import BaseSchema, NanoAODSchema
 from coffea.nanoevents.util import key_to_tuple, quote, tuple_to_key, unquote
+from coffea.util import _remove_not_interpretable
 
 _offsets_label = quote(",!offsets")
-
-
-def _remove_not_interpretable(branch):
-    if isinstance(
-        branch.interpretation, uproot.interpretation.identify.uproot.AsGrouped
-    ):
-        for name, interpretation in branch.interpretation.subbranches.items():
-            if isinstance(
-                interpretation, uproot.interpretation.identify.UnknownInterpretation
-            ):
-                warnings.warn(
-                    f"Skipping {branch.name} as it is not interpretable by Uproot"
-                )
-                return False
-    if isinstance(
-        branch.interpretation, uproot.interpretation.identify.UnknownInterpretation
-    ):
-        warnings.warn(f"Skipping {branch.name} as it is not interpretable by Uproot")
-        return False
-
-    try:
-        _ = branch.interpretation.awkward_form(None)
-    except uproot.interpretation.objects.CannotBeAwkward:
-        warnings.warn(
-            f"Skipping {branch.name} as it is it cannot be represented as an Awkward array"
-        )
-        return False
-    else:
-        return True
 
 
 def _key_formatter(prefix, form_key, form, attribute):

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -17,6 +17,22 @@ from coffea.nanoevents import BaseSchema, NanoAODSchema
 from coffea.processor.test_items import NanoEventsProcessor, NanoTestProcessor
 from coffea.util import decompress_form
 
+_starting_fileset_list = {
+    "ZJets": ["tests/samples/nano_dy.root:Events"],
+    "Data": [
+        "tests/samples/nano_dimuon.root:Events",
+        "tests/samples/nano_dimuon_not_there.root:Events",
+    ],
+}
+
+_starting_fileset_dict = {
+    "ZJets": {"tests/samples/nano_dy.root": "Events"},
+    "Data": {
+        "tests/samples/nano_dimuon.root": "Events",
+        "tests/samples/nano_dimuon_not_there.root": "Events",
+    },
+}
+
 _starting_fileset = {
     "ZJets": {
         "files": {
@@ -214,7 +230,7 @@ def test_apply_to_fileset_hinted_form():
     with Client() as _:
         dataset_runnable, dataset_updated = preprocess(
             _starting_fileset,
-            maybe_step_size=7,
+            step_size=7,
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=True,
@@ -234,11 +250,14 @@ def test_apply_to_fileset_hinted_form():
         assert out["Data"]["cutflow"]["Data_mass"] == 66
 
 
-def test_preprocess():
+@pytest.mark.parametrize(
+    "the_fileset", [_starting_fileset_list, _starting_fileset_dict, _starting_fileset]
+)
+def test_preprocess(the_fileset):
     with Client() as _:
         dataset_runnable, dataset_updated = preprocess(
-            _starting_fileset,
-            maybe_step_size=7,
+            the_fileset,
+            step_size=7,
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=True,
@@ -254,7 +273,7 @@ def test_preprocess_calculate_form():
 
         dataset_runnable, dataset_updated = preprocess(
             starting_fileset,
-            maybe_step_size=7,
+            step_size=7,
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=True,
@@ -278,7 +297,7 @@ def test_preprocess_failed_file():
 
         dataset_runnable, dataset_updated = preprocess(
             starting_fileset,
-            maybe_step_size=7,
+            step_size=7,
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=False,


### PR DESCRIPTION
This PR changes the names of some arguments to preprocess so it breaks that interface a little.

In particular:
`maybe_step_size` -> `step_size`
`recalculate_seen_steps` -> `recalculate_steps`

you can also now pass `uproot_options` to the eventual `uproot.open` that happens during `preprocess`.

It also allows preprocess to take lists of strings and simple dicts of file info as inputs.

@nsmith- 