### PR TITLE
fix: use ak.merge_union_of_records to generate input data format

### DIFF
--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -101,10 +101,8 @@ def slice_files(fileset: FilesetSpec, theslice: Any = slice(None)) -> FilesetSpe
 
 def _default_filter(name_and_spec):
     name, spec = name_and_spec
-    thesteps = spec["steps"]
-    return thesteps is not None and (
-        len(thesteps) > 1 or (thesteps[0][1] - thesteps[0][0]) > 0
-    )
+    num_entries = spec["num_entries"]
+    return num_entries is not None and num_entries > 0
 
 
 def filter_files(

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -355,26 +355,25 @@ def preprocess(
 
             for icontent, content in enumerate(union_form.contents):
                 if isinstance(content, awkward.forms.IndexedOptionForm):
-                    the_content = content.content
                     if (
-                        not isinstance(the_content, awkward.forms.NumpyForm)
-                        or the_content.primitive != "bool"
+                        not isinstance(content.content, awkward.forms.NumpyForm)
+                        or content.content.primitive != "bool"
                     ):
                         raise ValueError(
                             "IndexedOptionArrays can only contain NumpyArrays of "
                             "bools in mergers of flat-tuple-like schemas!"
                         )
                     parameters = (
-                        the_content.parameters.copy()
-                        if the_content.parameters is not None
+                        content.content.parameters.copy()
+                        if content.content.parameters is not None
                         else {}
                     )
-                    parameters["__allow_array_creation__"] = None
-                    union_form.contents[icontent] = awkward.forms.NumpyForm(
-                        the_content.primitive,
-                        the_content.inner_shape,
+                    # re-create IndexOptionForm with parameters of lower level array
+                    union_form.contents[icontent] = awkward.forms.IndexedOptionForm(
+                        content.index,
+                        content.content,
                         parameters=parameters,
-                        form_key=the_content.form_key,
+                        form_key=content.form_key,
                     )
 
             union_form_jsonstr = union_form.to_json()

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -189,12 +189,14 @@ class UprootFileSpec:
 @dataclass
 class CoffeaFileSpec(UprootFileSpec):
     steps: list[list[int]]
+    num_entries: int
     uuid: str
 
 
 @dataclass
 class CoffeaFileSpecOptional(CoffeaFileSpec):
     steps: list[list[int]] | None
+    num_entriees: int | None
     uuid: str | None
 
 

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -345,7 +345,7 @@ def preprocess(
                 union_array = new_array
             else:
                 union_array = awkward.merge_union_of_records(
-                    awkward.concatenate([union_array, new_array.length_zero_array()])
+                    awkward.concatenate([union_array, new_array])
                 )
         if union_array is not None:
             union_form_jsonstr = union_array.form.to_json()

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -340,15 +340,18 @@ def preprocess(
         union_array = None
         union_form_jsonstr = None
         while len(dataset_forms):
-            new_array = dataset_forms.pop().length_zero_array()
+            new_array = awkward.Array(dataset_forms.pop().length_zero_array())
             if union_array is None:
                 union_array = new_array
             else:
-                union_array = awkward.merge_union_of_records(
-                    awkward.concatenate([union_array, new_array])
+                union_array = awkward.to_packed(
+                    awkward.merge_union_of_records(
+                        awkward.concatenate([union_array, new_array]), axis=0
+                    )
                 )
+                union_array.layout.parameters.update(new_array.layout.parameters)
         if union_array is not None:
-            union_form_jsonstr = union_array.form.to_json()
+            union_form_jsonstr = union_array.layout.form.to_json()
 
         files_available = {
             item["file"]: {

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -345,7 +345,7 @@ def preprocess(
                 union_array = new_array
             else:
                 union_array = awkward.merge_union_of_records(
-                    awkward.concatenate([union_array, form.length_zero_array()])
+                    awkward.concatenate([union_array, new_array.length_zero_array()])
                 )
         if union_array is not None:
             union_form_jsonstr = union_array.form.to_json()

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -103,16 +103,9 @@ class _map_schema_uproot(_map_schema_base):
         branch_forms = {}
         for ifield, field in enumerate(form.fields):
             iform = form.contents[ifield].to_dict()
-            if len(iform["parameters"]) > 0:
-                branch_forms[field] = _lazify_form(
-                    iform, f"{field},!load", docstr=iform["parameters"]["__doc__"]
-                )
-            else:
-                branch_forms[field] = _lazify_form(
-                    iform,
-                    f"{field},!load",
-                    docstr=iform["content"]["parameters"]["__doc__"],
-                )
+            branch_forms[field] = _lazify_form(
+                iform, f"{field},!load", docstr=iform["parameters"]["__doc__"]
+            )
         lform = {
             "class": "RecordArray",
             "contents": [item for item in branch_forms.values()],

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -103,9 +103,16 @@ class _map_schema_uproot(_map_schema_base):
         branch_forms = {}
         for ifield, field in enumerate(form.fields):
             iform = form.contents[ifield].to_dict()
-            branch_forms[field] = _lazify_form(
-                iform, f"{field},!load", docstr=iform["parameters"]["__doc__"]
-            )
+            if len(iform["parameters"]) > 0:
+                branch_forms[field] = _lazify_form(
+                    iform, f"{field},!load", docstr=iform["parameters"]["__doc__"]
+                )
+            else:
+                branch_forms[field] = _lazify_form(
+                    iform,
+                    f"{field},!load",
+                    docstr=iform["content"]["parameters"]["__doc__"],
+                )
         lform = {
             "class": "RecordArray",
             "contents": [item for item in branch_forms.values()],

--- a/src/coffea/nanoevents/mapping/base.py
+++ b/src/coffea/nanoevents/mapping/base.py
@@ -56,11 +56,11 @@ class BaseSourceMapping(Mapping):
         self._cache[key] = source
 
     @abstractmethod
-    def get_column_handle(self, columnsource, name):
+    def get_column_handle(self, columnsource, name, allow_missing):
         pass
 
     @abstractmethod
-    def extract_column(self, columnhandle, start, stop, **kwargs):
+    def extract_column(self, columnhandle, start, stop, allow_missing, **kwargs):
         pass
 
     @classmethod
@@ -87,16 +87,21 @@ class BaseSourceMapping(Mapping):
             elif node == "!skip":
                 skip = True
                 continue
-            elif node == "!load":
+            elif node.startswith("!load"):
                 handle_name = stack.pop()
                 if self._access_log is not None:
                     self._access_log.append(handle_name)
+                allow_missing = node == "!loadallowmissing"
                 handle = self.get_column_handle(
-                    self._column_source(uuid, treepath), handle_name
+                    self._column_source(uuid, treepath), handle_name, allow_missing
                 )
                 stack.append(
                     self.extract_column(
-                        handle, start, stop, use_ak_forth=self._use_ak_forth
+                        handle,
+                        start,
+                        stop,
+                        allow_missing,
+                        use_ak_forth=self._use_ak_forth,
                     )
                 )
             elif node.startswith("!"):

--- a/src/coffea/nanoevents/mapping/uproot.py
+++ b/src/coffea/nanoevents/mapping/uproot.py
@@ -58,6 +58,7 @@ def _lazify_form(form, prefix, docstr=None):
                 "Only boolean NumpyArrays can be created dynamically if "
                 "missing in file!"
             )
+        assert prefix.endswith("!load")
         form["form_key"] = quote(prefix + "allowmissing,!index")
         form["content"] = _lazify_form(
             form["content"], prefix + "allowmissing,!content", docstr=docstr

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -122,6 +122,7 @@ _runnable_result = {
                     [28, 35],
                     [35, 40],
                 ],
+                "num_entries": 40,
                 "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
             }
         },
@@ -140,6 +141,7 @@ _runnable_result = {
                     [28, 35],
                     [35, 40],
                 ],
+                "num_entries": 40,
                 "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
             }
         },
@@ -161,6 +163,7 @@ _updated_result = {
                     [28, 35],
                     [35, 40],
                 ],
+                "num_entries": 40,
                 "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
             }
         },
@@ -179,11 +182,13 @@ _updated_result = {
                     [28, 35],
                     [35, 40],
                 ],
+                "num_entries": 40,
                 "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
             },
             "tests/samples/nano_dimuon_not_there.root": {
                 "object_path": "Events",
                 "steps": None,
+                "num_entries": None,
                 "uuid": None,
             },
         },
@@ -313,6 +318,7 @@ def test_filter_files():
                 "tests/samples/nano_dy.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "num_entries": 40,
                     "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
                 }
             },
@@ -324,6 +330,7 @@ def test_filter_files():
                 "tests/samples/nano_dimuon.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "num_entries": 40,
                     "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
                 }
             },
@@ -342,6 +349,7 @@ def test_max_files():
                 "tests/samples/nano_dy.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "num_entries": 40,
                     "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
                 }
             },
@@ -353,6 +361,7 @@ def test_max_files():
                 "tests/samples/nano_dimuon.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21], [21, 28], [28, 35], [35, 40]],
+                    "num_entries": 40,
                     "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
                 }
             },
@@ -372,6 +381,7 @@ def test_slice_files():
                 "tests/samples/nano_dimuon_not_there.root": {
                     "object_path": "Events",
                     "steps": None,
+                    "num_entries": None,
                     "uuid": None,
                 }
             },
@@ -390,6 +400,7 @@ def test_max_chunks():
                 "tests/samples/nano_dy.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21]],
+                    "num_entries": 40,
                     "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
                 }
             },
@@ -401,6 +412,7 @@ def test_max_chunks():
                 "tests/samples/nano_dimuon.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [7, 14], [14, 21]],
+                    "num_entries": 40,
                     "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
                 }
             },
@@ -419,6 +431,7 @@ def test_slice_chunks():
                 "tests/samples/nano_dy.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [14, 21], [28, 35]],
+                    "num_entries": 40,
                     "uuid": "a9490124-3648-11ea-89e9-f5b55c90beef",
                 }
             },
@@ -430,6 +443,7 @@ def test_slice_chunks():
                 "tests/samples/nano_dimuon.root": {
                     "object_path": "Events",
                     "steps": [[0, 7], [14, 21], [28, 35]],
+                    "num_entries": 40,
                     "uuid": "a210a3f8-3648-11ea-a29f-f5b55c90beef",
                 }
             },


### PR DESCRIPTION
Fixes #1014

~~May not need to merge if current pre-processing scheme already functions for this task.~~

As it is right now this PR uses ak.merge_union_of_records to tag fields that are not shared across files in a dataset.
When a file is parsed, if a given key is not available in that file a buffer is generated as an array of `None` using an IndexedOptionArray and the expected length of the step in that form key.

The *only* kind of arrays that are supported by this workaround at present are flat arrays of booleans. The user may choose with `ak.fill_none` the default behavior for the boolean to match their needs.

If any other kind of array is encountered the file is considered not openable as nanoevents and emits errors either in preprocessing or within nanoevents itself.