### PR TITLE
feat: calculate analysis task graphs in parallel via dask.delayed

### DIFF
--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -1,4 +1,9 @@
-from coffea.dataset_tools.apply_processor import apply_to_dataset, apply_to_fileset
+from coffea.dataset_tools.apply_processor import (
+    apply_to_dataset,
+    apply_to_fileset,
+    load_taskgraph,
+    save_taskgraph,
+)
 from coffea.dataset_tools.manipulations import (
     filter_files,
     get_failed_steps_for_dataset,
@@ -14,6 +19,8 @@ __all__ = [
     "preprocess",
     "apply_to_dataset",
     "apply_to_fileset",
+    "save_taskgraph",
+    "load_taskgraph",
     "max_chunks",
     "slice_chunks",
     "filter_files",

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -86,7 +86,11 @@ def apply_to_dataset(
     metadata: dict[Hashable, Any] = {},
     uproot_options: dict[str, Any] = {},
     parallelize_with_dask: bool = False,
-) -> DaskOutputType | tuple[DaskOutputType, dask_awkward.Array]:
+) -> (
+    DaskOutputType
+    | tuple[DaskOutputType, dask_awkward.Array]
+    | tuple[dask_awkward.Array, DaskOutputType, dask_awkward.Array]
+):
     """
     Apply the supplied function or processor to the supplied dataset.
     Parameters
@@ -103,6 +107,8 @@ def apply_to_dataset(
             Options to pass to uproot. Pass at least {"allow_read_errors_with_report": True} to turn on file access reports.
         parallelize_with_dask: bool, default False
             Create dask.delayed objects that will return the the computable dask collections for the analysis when computed.
+        return_events: bool, default True
+            Return the created events object, or not.
 
     Returns
     -------
@@ -165,7 +171,16 @@ def apply_to_fileset(
     uproot_options: dict[str, Any] = {},
     parallelize_with_dask: bool = False,
     scheduler: Callable | str | None = None,
-) -> dict[str, DaskOutputType] | tuple[dict[str, DaskOutputType], dask_awkward.Array]:
+    return_events: bool = False,
+) -> (
+    dict[str, DaskOutputType]
+    | tuple[dict[str, DaskOutputType], dict[str, dask_awkward.Array]]
+    | tuple[
+        dict[str, dask_awkward.Array],
+        dict[str, DaskOutputType],
+        dict[str, dask_awkward.Array],
+    ]
+):
     """
     Apply the supplied function or processor to the supplied fileset (set of datasets).
     Parameters
@@ -242,8 +257,8 @@ def apply_to_fileset(
             out[name] = out[name][0]
 
     if len(report) > 0:
-        return events, out, report
-    return events, out
+        return (events, out, report) if return_events else (out, report)
+    return (events, out) if return_events else out
 
 
 def save_taskgraph(filename, events, *data_products, optimize_graph=False):

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -139,26 +139,25 @@ def apply_to_dataset(
     out = None
     if parallelize_with_dask:
         (wired_events,) = _pack_meta_to_wire(events)
-        out = dask.delayed(
-            lambda: lz4.frame.compress(
-                cloudpickle.dumps(
-                    partial(_apply_analysis_wire, analysis, wired_events)()
-                ),
-                compression_level=6,
-            )
-        )()
+        out = (
+            dask.delayed(
+                lambda: lz4.frame.compress(
+                    cloudpickle.dumps(
+                        partial(_apply_analysis_wire, analysis, wired_events)()
+                    ),
+                    compression_level=6,
+                )
+            )(),
+        )
         dask.base.function_cache.clear()
     else:
         out = analysis(events)
+        if not isinstance(out, tuple):
+            out = (out,)
 
     if report is not None:
-<<<<<<< HEAD
-        return out, report
-    return (out,)
-=======
         return events, out, report
     return events, out
->>>>>>> aae802b3 (provide interface for serializing taskgraphs to/from disk)
 
 
 def apply_to_fileset(

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -153,7 +153,8 @@ def apply_to_dataset(
                 compression_level=6,
             )
         )()
-        dask.base.function_cache.clear()
+        if hasattr(dask.base, "function_cache"):
+            dask.base.function_cache.clear()
     else:
         out = analysis(events)
         if not isinstance(out, tuple):

--- a/src/coffea/lumi_tools/lumi_tools.py
+++ b/src/coffea/lumi_tools/lumi_tools.py
@@ -170,10 +170,12 @@ class LumiMask:
         """
 
         def apply(runs, lumis):
+            backend = awkward.backend(runs)
             # fill numba typed dict
             _masks = Dict.empty(key_type=types.uint32, value_type=types.uint32[:])
-            for k, v in self._masks.items():
-                _masks[k] = v
+            if backend != "typetracer":
+                for k, v in self._masks.items():
+                    _masks[k] = v
 
             runs_orig = runs
             if isinstance(runs, awkward.highlevel.Array):
@@ -185,10 +187,11 @@ class LumiMask:
                     awkward.typetracer.length_zero_if_typetracer(lumis)
                 )
             mask_out = numpy.zeros(dtype="bool", shape=runs.shape)
-            LumiMask._apply_run_lumi_mask_kernel(_masks, runs, lumis, mask_out)
+            if backend != "typetracer":
+                LumiMask._apply_run_lumi_mask_kernel(_masks, runs, lumis, mask_out)
             if isinstance(runs_orig, awkward.Array):
                 mask_out = awkward.Array(mask_out)
-            if awkward.backend(runs_orig) == "typetracer":
+            if backend == "typetracer":
                 mask_out = awkward.Array(
                     mask_out.layout.to_typetracer(forget_length=True)
                 )

--- a/src/coffea/ml_tools/xgboost_wrapper.py
+++ b/src/coffea/ml_tools/xgboost_wrapper.py
@@ -29,8 +29,10 @@ class xgboost_wrapper(numpy_call_wrapper, nonserializable_attribute):
             )
             raise _xgboost_import_error
 
-        nonserializable_attribute.__init__(self, ["xgbooster"])
+        nonserializable_attribute.__init__(self, [])
+
         self.xgboost_file = fname
+        self.xgbooster = self._create_xgbooster()
 
     def _create_xgbooster(self) -> xgboost.Booster:
         # Automatic detection of compressed model file

--- a/src/coffea/processor/test_items/NanoEventsProcessor.py
+++ b/src/coffea/processor/test_items/NanoEventsProcessor.py
@@ -69,6 +69,9 @@ class NanoEventsProcessor(processor.ProcessorABC):
         # print(dimuon["0"].behavior)
         dimuon = dimuon["0"] + dimuon["1"]
 
+        if "GenPart" in events.fields:
+            _ = events.GenPart.parent.pt
+
         output["pt"].fill(dataset=dataset, pt=dak.flatten(muon_pt))
         output["mass"].fill(dataset=dataset, mass=dak.flatten(dimuon.mass))
         output["cutflow"]["%s_pt" % dataset] = dak.sum(dak.num(events.Muon, axis=1))

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -36,21 +36,20 @@ import cloudpickle
 import lz4.frame
 
 
-def load(filename):
+def load(filename, mode="rb"):
     """Load a coffea file from disk"""
-    with lz4.frame.open(filename) as fin:
+    with lz4.frame.open(filename, mode) as fin:
         output = cloudpickle.load(fin)
     return output
 
 
-def save(output, filename):
+def save(output, filename, mode="wb"):
     """Save a coffea object or collection thereof to disk
 
     This function can accept any picklable object.  Suggested suffix: ``.coffea``
     """
-    with lz4.frame.open(filename, "wb") as fout:
-        thepickle = cloudpickle.dumps(output)
-        fout.write(thepickle)
+    with lz4.frame.open(filename, mode) as fout:
+        cloudpickle.dump(output, fout)
 
 
 def _hex(string):

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -7,9 +7,11 @@ from coffea.dataset_tools import (
     apply_to_fileset,
     filter_files,
     get_failed_steps_for_fileset,
+    load_taskgraph,
     max_chunks,
     max_files,
     preprocess,
+    save_taskgraph,
     slice_chunks,
     slice_files,
 )
@@ -290,7 +292,7 @@ def test_apply_to_fileset(proc_and_schema, delayed_taskgraph_calc):
     proc, schemaclass = proc_and_schema
 
     with Client() as _:
-        to_compute = apply_to_fileset(
+        _, to_compute = apply_to_fileset(
             proc(),
             _runnable_result,
             schemaclass=schemaclass,
@@ -303,7 +305,7 @@ def test_apply_to_fileset(proc_and_schema, delayed_taskgraph_calc):
         assert out["Data"]["cutflow"]["Data_pt"] == 84
         assert out["Data"]["cutflow"]["Data_mass"] == 66
 
-        to_compute = apply_to_fileset(
+        _, to_compute = apply_to_fileset(
             proc(),
             max_chunks(_runnable_result, 1),
             schemaclass=schemaclass,
@@ -328,7 +330,7 @@ def test_apply_to_fileset_hinted_form():
             save_form=True,
         )
 
-        to_compute = apply_to_fileset(
+        _, to_compute = apply_to_fileset(
             NanoEventsProcessor(),
             dataset_runnable,
             schemaclass=NanoAODSchema,
@@ -542,14 +544,14 @@ def test_slice_chunks():
 @pytest.mark.parametrize("delayed_taskgraph_calc", [True, False])
 def test_recover_failed_chunks(delayed_taskgraph_calc):
     with Client() as _:
-        to_compute = apply_to_fileset(
+        _, to_compute, reports = apply_to_fileset(
             NanoEventsProcessor(),
             _starting_fileset_with_steps,
             schemaclass=NanoAODSchema,
             uproot_options={"allow_read_errors_with_report": True},
             parallelize_with_dask=delayed_taskgraph_calc,
         )
-        out, reports = dask.compute(*to_compute)
+        out, reports = dask.compute(to_compute, reports)
 
     failed_fset = get_failed_steps_for_fileset(_starting_fileset_with_steps, reports)
     assert failed_fset == {
@@ -571,3 +573,50 @@ def test_recover_failed_chunks(delayed_taskgraph_calc):
             }
         }
     }
+
+
+@pytest.mark.parametrize(
+    "proc_and_schema",
+    [(NanoTestProcessor, BaseSchema), (NanoEventsProcessor, NanoAODSchema)],
+)
+@pytest.mark.parametrize(
+    "with_report",
+    [True, False],
+)
+def test_task_graph_serialization(proc_and_schema, with_report):
+    proc, schemaclass = proc_and_schema
+
+    with Client() as _:
+        output = apply_to_fileset(
+            proc(),
+            _runnable_result,
+            schemaclass=schemaclass,
+            parallelize_with_dask=False,
+            uproot_options={"allow_read_errors_with_report": with_report},
+        )
+
+        events = output[0]
+        to_compute = output[1:]
+
+        save_taskgraph(
+            "./test_task_graph_serialization.hlg",
+            events,
+            to_compute,
+            optimize_graph=False,
+        )
+
+        _, to_compute_serdes, is_optimized = load_taskgraph(
+            "./test_task_graph_serialization.hlg"
+        )
+
+        print(to_compute_serdes)
+
+        if len(to_compute_serdes) > 1:
+            (out, _) = dask.compute(*to_compute_serdes)
+        else:
+            (out,) = dask.compute(*to_compute_serdes)
+
+        assert out["ZJets"]["cutflow"]["ZJets_pt"] == 18
+        assert out["ZJets"]["cutflow"]["ZJets_mass"] == 6
+        assert out["Data"]["cutflow"]["Data_pt"] == 84
+        assert out["Data"]["cutflow"]["Data_mass"] == 66

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -216,6 +216,7 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
         _my_analysis_output_2,
         _runnable_result,
         uproot_options={"allow_read_errors_with_report": allow_read_errors_with_report},
+        return_events=True,
     )
 
     if allow_read_errors_with_report:
@@ -253,6 +254,7 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
         _my_analysis_output_3,
         _runnable_result,
         uproot_options={"allow_read_errors_with_report": allow_read_errors_with_report},
+        return_events=True,
     )
 
     if allow_read_errors_with_report:
@@ -301,6 +303,7 @@ def test_apply_to_fileset(proc_and_schema, delayed_taskgraph_calc):
             _runnable_result,
             schemaclass=schemaclass,
             parallelize_with_dask=delayed_taskgraph_calc,
+            return_events=True,
         )
         out = dask.compute(to_compute)[0]
 
@@ -314,6 +317,7 @@ def test_apply_to_fileset(proc_and_schema, delayed_taskgraph_calc):
             max_chunks(_runnable_result, 1),
             schemaclass=schemaclass,
             parallelize_with_dask=delayed_taskgraph_calc,
+            return_events=True,
         )
         out = dask.compute(to_compute)[0]
 
@@ -338,6 +342,7 @@ def test_apply_to_fileset_hinted_form():
             NanoEventsProcessor(),
             dataset_runnable,
             schemaclass=NanoAODSchema,
+            return_events=True,
         )
         out = dask.compute(to_compute)[0]
 
@@ -554,6 +559,7 @@ def test_recover_failed_chunks(delayed_taskgraph_calc):
             schemaclass=NanoAODSchema,
             uproot_options={"allow_read_errors_with_report": True},
             parallelize_with_dask=delayed_taskgraph_calc,
+            return_events=True,
         )
         out, reports = dask.compute(to_compute, reports)
 
@@ -597,6 +603,7 @@ def test_task_graph_serialization(proc_and_schema, with_report):
             schemaclass=schemaclass,
             parallelize_with_dask=False,
             uproot_options={"allow_read_errors_with_report": with_report},
+            return_events=True,
         )
 
         events = output[0]

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -220,8 +220,8 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
 
     if allow_read_errors_with_report:
         assert isinstance(out, tuple)
-        assert len(out) == 2
-        out, report = out
+        assert len(out) == 3
+        _, out, report = out
         assert isinstance(out, dict)
         assert isinstance(report, dict)
         assert out.keys() == {"ZJets", "Data"}
@@ -236,8 +236,10 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
         assert isinstance(report["ZJets"], dask_awkward.Array)
         assert isinstance(report["Data"], dask_awkward.Array)
     else:
-        assert isinstance(out, dict)
+        assert isinstance(out, tuple)
         assert len(out) == 2
+        _, out = out
+        assert isinstance(out, dict)
         assert out.keys() == {"ZJets", "Data"}
         assert isinstance(out["ZJets"], tuple)
         assert isinstance(out["Data"], tuple)
@@ -255,8 +257,8 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
 
     if allow_read_errors_with_report:
         assert isinstance(out, tuple)
-        assert len(out) == 2
-        out, report = out
+        assert len(out) == 3
+        _, out, report = out
         assert isinstance(out, dict)
         assert isinstance(report, dict)
         assert out.keys() == {"ZJets", "Data"}
@@ -271,8 +273,10 @@ def test_tuple_data_manipulation_output(allow_read_errors_with_report):
         assert isinstance(report["ZJets"], dask_awkward.Array)
         assert isinstance(report["Data"], dask_awkward.Array)
     else:
-        assert isinstance(out, dict)
+        assert isinstance(out, tuple)
         assert len(out) == 2
+        _, out = out
+        assert isinstance(out, dict)
         assert out.keys() == {"ZJets", "Data"}
         assert isinstance(out["ZJets"], tuple)
         assert isinstance(out["Data"], tuple)


### PR DESCRIPTION
This is a workaround for the large amount of time it can take to calculate all the task graphs for a large and mature analysis.