### PR TITLE
feat: backport dataset_tools to coffea 0.7.x

### DIFF
--- a/binder/dataset_discovery.ipynb
+++ b/binder/dataset_discovery.ipynb
@@ -1,0 +1,1873 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c5754206-f41b-4e08-bc4d-496df85e8194",
+   "metadata": {},
+   "source": [
+    "# Dataset discovery tools\n",
+    "\n",
+    "This notebook shows some features to make the dataset discovery for CMS analysis easier. \n",
+    "The rucio sytem is queried to look for dataset and access to the list of all available file replicas.\n",
+    "\n",
+    "Users can exploit these tools at 2 different levels:\n",
+    "- low level: use the `rucio_utils` module directly to just query rucio\n",
+    "- high level: use the `DataDiscoveryCLI` class to simplify dataset query, replicas filters and uproot preprocessing with dask"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42242097-c04e-459e-9f3a-1d746df4e9dd",
+   "metadata": {},
+   "source": [
+    "## Using Rucio utils directly"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "09103c77-b8e6-4d61-920b-b1ff8fba8791",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from coffea.dataset_tools import rucio_utils\n",
+    "from coffea.dataset_tools.dataset_query import print_dataset_query\n",
+    "from rich.console import Console\n",
+    "from rich.table import Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d62b43cb-53c0-4e2d-b571-1a0683e34dc5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rucio.client.client.Client at 0x7f9bd2277fd0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client = rucio_utils.get_rucio_client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0359afc0-fc98-4aa8-acf4-288ef19ac7db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"/TTToSemiLeptonic_*_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9*/NANOAODSIM\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "659bee88-9fb0-4d1a-9544-a97372595f18",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['/TTToSemiLeptonic_TuneCP5CR1_erdON_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM',\n",
+       " '/TTToSemiLeptonic_TuneCP5CR2_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM',\n",
+       " '/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM',\n",
+       " '/TTToSemiLeptonic_TuneCP5_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-20UL18JMENano_106X_upgrade2018_realistic_v16_L1v1-v1/NANOAODSIM']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "outlist, outtree = rucio_utils.query_dataset(\n",
+    "                query,\n",
+    "                client=client,\n",
+    "                tree=True,\n",
+    "                scope=\"cms\",  \n",
+    "            )\n",
+    "\n",
+    "outlist[1:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bc2a454-4915-4366-9c02-2e389e9eb6fb",
+   "metadata": {},
+   "source": [
+    "Let's now pretty-print the results in a table using an utility function in the `dataset_query` module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4487d997-dc22-4a47-87df-4da14fa5b35a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">              Query: </span><span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold; font-style: italic\">/TTToSemiLeptonic_*_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9*/NANOAODSIM</span><span style=\"font-style: italic\">               </span>\n",
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┓\n",
+       "┃<span style=\"font-weight: bold\"> Name                              </span>┃<span style=\"font-weight: bold\"> Tag                                                                        </span>┃<span style=\"font-weight: bold\"></span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇┩\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_TuneCP5CR1_13Te… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(1)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NAN… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_TuneCP5CR1_erdO… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(2)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_TuneCP5CR2_13Te… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(3)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NAN… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_TuneCP5_13TeV-p… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(4)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN… </span>││\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                                   </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(5)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-20UL18JMENano_106X_upgrade2018_realistic_v… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                                   </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(6)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-PUForMUOVal_106X_upgrade2018_realistic_v16… </span>││\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">                                   </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(7)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-PUForTRK_TRK_106X_upgrade2018_realistic_v1… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                                   </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(8)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-PUForTRKv2_TRKv2_106X_upgrade2018_realisti… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_TuneCP5_erdON_1… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(9)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_TuneCP5down_13T… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(10)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_TuneCP5up_13TeV… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(11)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_Vcb_TuneCP5_13T… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(12)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_hdampDOWN_TuneC… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(13)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_hdampUP_TuneCP5… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(14)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_mtop166p5_TuneC… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(15)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_mtop169p5_TuneC… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(16)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_mtop171p5_TuneC… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(17)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_mtop173p5_TuneC… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(18)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_mtop175p5_TuneC… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(19)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_mtop178p5_TuneC… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(20)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_widthx0p55_Tune… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(21)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_widthx0p7_TuneC… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(22)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_widthx0p85_Tune… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(23)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_widthx1p15_Tune… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(24)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> TTToSemiLeptonic_widthx1p3_TuneC… </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf; font-weight: bold\">(25)</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"></span>│\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TTToSemiLeptonic_widthx1p45_Tune… </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">(26)</span><span style=\"color: #800080; text-decoration-color: #800080\"> RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA… </span>││\n",
+       "└───────────────────────────────────┴────────────────────────────────────────────────────────────────────────────┴┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m              Query: \u001b[0m\u001b[1;3;31m/TTToSemiLeptonic_*_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9*/NANOAODSIM\u001b[0m\u001b[3m               \u001b[0m\n",
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mName                             \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mTag                                                                       \u001b[0m\u001b[1m \u001b[0m┃┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇┩\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_TuneCP5CR1_13Te…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(1)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NAN…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_TuneCP5CR1_erdO…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(2)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_TuneCP5CR2_13Te…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(3)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NAN…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_TuneCP5_13TeV-p…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(4)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36m                                 \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(5)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-20UL18JMENano_106X_upgrade2018_realistic_v…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "│\u001b[36m \u001b[0m\u001b[36m                                 \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(6)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-PUForMUOVal_106X_upgrade2018_realistic_v16…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36m                                 \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(7)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-PUForTRK_TRK_106X_upgrade2018_realistic_v1…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "│\u001b[36m \u001b[0m\u001b[36m                                 \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(8)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-PUForTRKv2_TRKv2_106X_upgrade2018_realisti…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_TuneCP5_erdON_1…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(9)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NAN…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_TuneCP5down_13T…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(10)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_TuneCP5up_13TeV…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(11)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_Vcb_TuneCP5_13T…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(12)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_hdampDOWN_TuneC…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(13)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_hdampUP_TuneCP5…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(14)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_mtop166p5_TuneC…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(15)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_mtop169p5_TuneC…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(16)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_mtop171p5_TuneC…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(17)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_mtop173p5_TuneC…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(18)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_mtop175p5_TuneC…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(19)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_mtop178p5_TuneC…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(20)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_widthx0p55_Tune…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(21)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_widthx0p7_TuneC…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(22)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_widthx0p85_Tune…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(23)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_widthx1p15_Tune…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(24)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[2;36m \u001b[0m\u001b[2;36mTTToSemiLeptonic_widthx1p3_TuneC…\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[1;2;35m(25)\u001b[0m\u001b[2;35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[2;35m \u001b[0m││\n",
+       "├───────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┼┤\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTTToSemiLeptonic_widthx1p45_Tune…\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[1;35m(26)\u001b[0m\u001b[35m RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v1/NA…\u001b[0m\u001b[35m \u001b[0m││\n",
+       "└───────────────────────────────────┴────────────────────────────────────────────────────────────────────────────┴┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "console = Console()\n",
+    "print_dataset_query(query, outtree, console)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c213d5fc-6424-4cdf-8751-88ced7987a59",
+   "metadata": {},
+   "source": [
+    "### Dataset replicas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "961b4ad8-e3d6-49b1-a2ce-7cad49b46f06",
+   "metadata": {},
+   "source": [
+    "Let's select one dataset and look for available replicas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d08fd6ed-4b3a-4e9f-994a-d1bd529421a7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2/NANOAODSIM'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = outlist[0]\n",
+    "dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a605fb64-6e0b-4fbe-8807-84b9d75f2d53",
+   "metadata": {},
+   "source": [
+    "Using the option `mode='full'` in the function `rucio_utils.get_dataset_file_replicas()` one gets all the available replicas. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2d64069e-ea8f-48c2-bd33-43fc555f6ec8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    (\n",
+    "        outfiles,\n",
+    "        outsites,\n",
+    "        sites_counts,\n",
+    "    ) = rucio_utils.get_dataset_files_replicas(\n",
+    "        dataset,\n",
+    "        allowlist_sites=[],\n",
+    "        blocklist_sites=[],\n",
+    "        regex_sites=[],\n",
+    "        mode=\"full\",   # full or first. \"full\"==all the available replicas\n",
+    "        client=client,\n",
+    "    )\n",
+    "except Exception as e:\n",
+    "    print(f\"\\n[red bold] Exception: {e}[/]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3e4fc6c2-f378-40d2-a4ea-f265b6c18887",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_replicas(sites_counts):\n",
+    "    console.print(f\"[cyan]Sites availability for dataset: [red]{dataset}\")\n",
+    "    table = Table(title=\"Available replicas\")\n",
+    "    table.add_column(\"Index\", justify=\"center\")\n",
+    "    table.add_column(\"Site\", justify=\"left\", style=\"cyan\", no_wrap=True)\n",
+    "    table.add_column(\"Files\", style=\"magenta\", no_wrap=True)\n",
+    "    table.add_column(\"Availability\", justify=\"center\")\n",
+    "    table.row_styles = [\"dim\", \"none\"]\n",
+    "    Nfiles = len(outfiles)\n",
+    "    \n",
+    "    sorted_sites = dict(\n",
+    "        sorted(sites_counts.items(), key=lambda x: x[1], reverse=True)\n",
+    "    )\n",
+    "    for i, (site, stat) in enumerate(sorted_sites.items()):\n",
+    "        table.add_row(\n",
+    "            str(i), site, f\"{stat} / {Nfiles}\", f\"{stat*100/Nfiles:.1f}%\"\n",
+    "        )\n",
+    "    console.print(table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "79c68044-dc3b-4dd5-a0d3-c3f6ddd0bea1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/NANOAODSIM</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\n",
+       "\u001b[31m/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2\u001b[0m\n",
+       "\u001b[31m/\u001b[0m\u001b[31mNANOAODSIM\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                    Available replicas                    </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site                </span>┃<span style=\"font-weight: bold\"> Files     </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_DESY          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_DE_KIT_Disk      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   2   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_UK_RAL_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   3   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_RU_JINR_Disk     </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   4   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T3_CH_PSI           </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   5   │<span style=\"color: #008080; text-decoration-color: #008080\"> T3_KR_UOS           </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   6   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_US_FNAL_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 193 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    65.6%     </span>│\n",
+       "│   7   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Nebraska      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 99 / 294  </span>│    33.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   8   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_IT_CNAF_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 58 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    19.7%     </span>│\n",
+       "│   9   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Purdue        </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 53 / 294  </span>│    18.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  10   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BE_IIHE          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 50 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    17.0%     </span>│\n",
+       "│  11   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_MIT           </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 50 / 294  </span>│    17.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  12   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_ES_PIC_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 43 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    14.6%     </span>│\n",
+       "│  13   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Vanderbilt    </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 40 / 294  </span>│    13.6%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  14   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BR_SPRACE        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 39 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    13.3%     </span>│\n",
+       "│  15   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Florida       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 33 / 294  </span>│    11.2%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  16   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_IT_Legnaro       </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 28 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     9.5%     </span>│\n",
+       "│  17   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_UCSD          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 28 / 294  </span>│     9.5%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  18   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UA_KIPT          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 26 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     8.8%     </span>│\n",
+       "│  19   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Caltech       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 24 / 294  </span>│     8.2%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  20   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Wisconsin     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 22 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     7.5%     </span>│\n",
+       "│  21   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_TR_METU          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 18 / 294  </span>│     6.1%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  22   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_ES_CIEMAT        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 17 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     5.8%     </span>│\n",
+       "│  23   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_DE_RWTH          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 11 / 294  </span>│     3.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  24   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BR_UERJ          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 7 / 294   </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     2.4%     </span>│\n",
+       "│  25   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_UK_SGrid_Bristol </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 3 / 294   </span>│     1.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  26   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_ES_IFCA          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 2 / 294   </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     0.7%     </span>│\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                    Available replicas                    \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite               \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles    \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_DESY         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT1_DE_KIT_Disk     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  2  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_UK_RAL_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   3   │\u001b[36m \u001b[0m\u001b[36mT1_RU_JINR_Disk    \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  4  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT3_CH_PSI          \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   5   │\u001b[36m \u001b[0m\u001b[36mT3_KR_UOS          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  6  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_US_FNAL_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m193 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   65.6%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   7   │\u001b[36m \u001b[0m\u001b[36mT2_US_Nebraska     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m99 / 294 \u001b[0m\u001b[35m \u001b[0m│    33.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  8  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_IT_CNAF_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m58 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   19.7%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   9   │\u001b[36m \u001b[0m\u001b[36mT2_US_Purdue       \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m53 / 294 \u001b[0m\u001b[35m \u001b[0m│    18.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 10  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BE_IIHE         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m50 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   17.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  11   │\u001b[36m \u001b[0m\u001b[36mT2_US_MIT          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m50 / 294 \u001b[0m\u001b[35m \u001b[0m│    17.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 12  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_ES_PIC_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m43 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   14.6%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  13   │\u001b[36m \u001b[0m\u001b[36mT2_US_Vanderbilt   \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m40 / 294 \u001b[0m\u001b[35m \u001b[0m│    13.6%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 14  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BR_SPRACE       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m39 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   13.3%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  15   │\u001b[36m \u001b[0m\u001b[36mT2_US_Florida      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m33 / 294 \u001b[0m\u001b[35m \u001b[0m│    11.2%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 16  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_IT_Legnaro      \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m28 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    9.5%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  17   │\u001b[36m \u001b[0m\u001b[36mT2_US_UCSD         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m28 / 294 \u001b[0m\u001b[35m \u001b[0m│     9.5%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 18  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UA_KIPT         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m26 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    8.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  19   │\u001b[36m \u001b[0m\u001b[36mT2_US_Caltech      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m24 / 294 \u001b[0m\u001b[35m \u001b[0m│     8.2%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 20  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Wisconsin    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m22 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    7.5%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  21   │\u001b[36m \u001b[0m\u001b[36mT2_TR_METU         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m18 / 294 \u001b[0m\u001b[35m \u001b[0m│     6.1%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 22  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_ES_CIEMAT       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m17 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    5.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  23   │\u001b[36m \u001b[0m\u001b[36mT2_DE_RWTH         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m11 / 294 \u001b[0m\u001b[35m \u001b[0m│     3.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 24  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BR_UERJ         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m7 / 294  \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    2.4%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  25   │\u001b[36m \u001b[0m\u001b[36mT2_UK_SGrid_Bristol\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m3 / 294  \u001b[0m\u001b[35m \u001b[0m│     1.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 26  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_ES_IFCA         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m2 / 294  \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    0.7%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "print_replicas(sites_counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9544ceb-5949-4bd3-b997-14da4aa2d956",
+   "metadata": {},
+   "source": [
+    "### Filtering sites\n",
+    "Grid sites can be filtered in 3 different ways\n",
+    "- **allowlist**:  if this list of specified, only the sites in the list are considered. No blocklist and regex are considered\n",
+    "- **blocklist**: if this list is specified, those sites are excluded from the replicas\n",
+    "- **regex_sites**: regex filter the sites to be considered, on top of the blocklist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "1f6b586c-a8b7-40d8-a25a-b02e94f4a892",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/NANOAODSIM</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\n",
+       "\u001b[31m/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2\u001b[0m\n",
+       "\u001b[31m/\u001b[0m\u001b[31mNANOAODSIM\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                  Available replicas                  </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site            </span>┃<span style=\"font-weight: bold\"> Files     </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_DESY      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_US_FNAL_Disk </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 193 / 294 </span>│    65.6%     │\n",
+       "└───────┴─────────────────┴───────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                  Available replicas                  \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite           \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles    \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_DESY     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT1_US_FNAL_Disk\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m193 / 294\u001b[0m\u001b[35m \u001b[0m│    65.6%     │\n",
+       "└───────┴─────────────────┴───────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Example with allowlist\n",
+    "try:\n",
+    "    (\n",
+    "        outfiles,\n",
+    "        outsites,\n",
+    "        sites_counts,\n",
+    "    ) = rucio_utils.get_dataset_files_replicas(\n",
+    "        dataset,\n",
+    "        allowlist_sites=[\"T2_DE_DESY\", \"T1_US_FNAL_Disk\"],\n",
+    "        blocklist_sites=[],\n",
+    "        regex_sites=None,\n",
+    "        mode=\"full\",   # full or first. \"full\"==all the available replicas\n",
+    "        client=client,\n",
+    "    )\n",
+    "except Exception as e:\n",
+    "    print(f\"\\n[red bold] Exception: {e}[/]\")\n",
+    "\n",
+    "print_replicas(sites_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "12f7e403-67fe-42c0-a3ee-a668006b1836",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/NANOAODSIM</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\n",
+       "\u001b[31m/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2\u001b[0m\n",
+       "\u001b[31m/\u001b[0m\u001b[31mNANOAODSIM\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                    Available replicas                    </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site                </span>┃<span style=\"font-weight: bold\"> Files     </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_DE_KIT_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_UK_RAL_Disk      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   2   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_RU_JINR_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   3   │<span style=\"color: #008080; text-decoration-color: #008080\"> T3_KR_UOS           </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   4   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_US_FNAL_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 193 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    65.6%     </span>│\n",
+       "│   5   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Nebraska      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 99 / 294  </span>│    33.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   6   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_IT_CNAF_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 58 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    19.7%     </span>│\n",
+       "│   7   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Purdue        </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 53 / 294  </span>│    18.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   8   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BE_IIHE          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 50 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    17.0%     </span>│\n",
+       "│   9   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_MIT           </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 50 / 294  </span>│    17.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  10   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_ES_PIC_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 43 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    14.6%     </span>│\n",
+       "│  11   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Vanderbilt    </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 40 / 294  </span>│    13.6%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  12   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BR_SPRACE        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 39 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    13.3%     </span>│\n",
+       "│  13   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Florida       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 33 / 294  </span>│    11.2%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  14   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_IT_Legnaro       </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 28 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     9.5%     </span>│\n",
+       "│  15   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_UCSD          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 28 / 294  </span>│     9.5%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  16   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UA_KIPT          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 26 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     8.8%     </span>│\n",
+       "│  17   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Caltech       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 24 / 294  </span>│     8.2%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  18   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Wisconsin     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 22 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     7.5%     </span>│\n",
+       "│  19   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_TR_METU          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 18 / 294  </span>│     6.1%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  20   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_ES_CIEMAT        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 17 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     5.8%     </span>│\n",
+       "│  21   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_DE_RWTH          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 11 / 294  </span>│     3.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  22   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_BR_UERJ          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 7 / 294   </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     2.4%     </span>│\n",
+       "│  23   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_UK_SGrid_Bristol </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 3 / 294   </span>│     1.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  24   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_ES_IFCA          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 2 / 294   </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     0.7%     </span>│\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                    Available replicas                    \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite               \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles    \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_DE_KIT_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT1_UK_RAL_Disk     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  2  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_RU_JINR_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   3   │\u001b[36m \u001b[0m\u001b[36mT3_KR_UOS          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  4  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_US_FNAL_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m193 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   65.6%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   5   │\u001b[36m \u001b[0m\u001b[36mT2_US_Nebraska     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m99 / 294 \u001b[0m\u001b[35m \u001b[0m│    33.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  6  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_IT_CNAF_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m58 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   19.7%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   7   │\u001b[36m \u001b[0m\u001b[36mT2_US_Purdue       \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m53 / 294 \u001b[0m\u001b[35m \u001b[0m│    18.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  8  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BE_IIHE         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m50 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   17.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   9   │\u001b[36m \u001b[0m\u001b[36mT2_US_MIT          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m50 / 294 \u001b[0m\u001b[35m \u001b[0m│    17.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 10  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_ES_PIC_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m43 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   14.6%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  11   │\u001b[36m \u001b[0m\u001b[36mT2_US_Vanderbilt   \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m40 / 294 \u001b[0m\u001b[35m \u001b[0m│    13.6%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 12  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BR_SPRACE       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m39 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   13.3%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  13   │\u001b[36m \u001b[0m\u001b[36mT2_US_Florida      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m33 / 294 \u001b[0m\u001b[35m \u001b[0m│    11.2%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 14  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_IT_Legnaro      \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m28 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    9.5%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  15   │\u001b[36m \u001b[0m\u001b[36mT2_US_UCSD         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m28 / 294 \u001b[0m\u001b[35m \u001b[0m│     9.5%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 16  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UA_KIPT         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m26 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    8.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  17   │\u001b[36m \u001b[0m\u001b[36mT2_US_Caltech      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m24 / 294 \u001b[0m\u001b[35m \u001b[0m│     8.2%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 18  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Wisconsin    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m22 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    7.5%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  19   │\u001b[36m \u001b[0m\u001b[36mT2_TR_METU         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m18 / 294 \u001b[0m\u001b[35m \u001b[0m│     6.1%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 20  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_ES_CIEMAT       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m17 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    5.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  21   │\u001b[36m \u001b[0m\u001b[36mT2_DE_RWTH         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m11 / 294 \u001b[0m\u001b[35m \u001b[0m│     3.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 22  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_BR_UERJ         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m7 / 294  \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    2.4%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  23   │\u001b[36m \u001b[0m\u001b[36mT2_UK_SGrid_Bristol\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m3 / 294  \u001b[0m\u001b[35m \u001b[0m│     1.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 24  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_ES_IFCA         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m2 / 294  \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    0.7%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Example with blocklist\n",
+    "try:\n",
+    "    (\n",
+    "        outfiles,\n",
+    "        outsites,\n",
+    "        sites_counts,\n",
+    "    ) = rucio_utils.get_dataset_files_replicas(\n",
+    "        dataset,\n",
+    "        allowlist_sites=[],\n",
+    "        blocklist_sites=[\"T2_DE_DESY\", \"T3_CH_PSI\"],\n",
+    "        regex_sites=None,\n",
+    "        mode=\"full\",   # full or first. \"full\"==all the available replicas\n",
+    "        client=client,\n",
+    "    )\n",
+    "except Exception as e:\n",
+    "    print(f\"\\n[red bold] Exception: {e}[/]\")\n",
+    "\n",
+    "print_replicas(sites_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "f5dafcc2-c32e-4e33-9878-183a8e476b73",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2</span>\n",
+       "<span style=\"color: #800000; text-decoration-color: #800000\">/NANOAODSIM</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\n",
+       "\u001b[31m/TTToSemiLeptonic_TuneCP5CR1_13TeV-powheg-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realistic_v16_L1v1-v2\u001b[0m\n",
+       "\u001b[31m/\u001b[0m\u001b[31mNANOAODSIM\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                    Available replicas                    </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site                </span>┃<span style=\"font-weight: bold\"> Files     </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_DESY          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_DE_KIT_Disk      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   2   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_UK_RAL_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 294 / 294 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   3   │<span style=\"color: #008080; text-decoration-color: #008080\"> T3_CH_PSI           </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 294 / 294 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   4   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_IT_CNAF_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 58 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    19.7%     </span>│\n",
+       "│   5   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_BE_IIHE          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 50 / 294  </span>│    17.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   6   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_ES_PIC_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 43 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    14.6%     </span>│\n",
+       "│   7   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_IT_Legnaro       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 28 / 294  </span>│     9.5%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   8   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_ES_CIEMAT        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 17 / 294  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     5.8%     </span>│\n",
+       "│   9   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_DE_RWTH          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 11 / 294  </span>│     3.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  10   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UK_SGrid_Bristol </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 3 / 294   </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     1.0%     </span>│\n",
+       "│  11   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_ES_IFCA          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 2 / 294   </span>│     0.7%     │\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                    Available replicas                    \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite               \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles    \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_DESY         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT1_DE_KIT_Disk     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  2  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_UK_RAL_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m294 / 294\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   3   │\u001b[36m \u001b[0m\u001b[36mT3_CH_PSI          \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m294 / 294\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  4  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_IT_CNAF_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m58 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   19.7%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   5   │\u001b[36m \u001b[0m\u001b[36mT2_BE_IIHE         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m50 / 294 \u001b[0m\u001b[35m \u001b[0m│    17.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  6  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_ES_PIC_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m43 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   14.6%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   7   │\u001b[36m \u001b[0m\u001b[36mT2_IT_Legnaro      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m28 / 294 \u001b[0m\u001b[35m \u001b[0m│     9.5%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  8  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_ES_CIEMAT       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m17 / 294 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    5.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   9   │\u001b[36m \u001b[0m\u001b[36mT2_DE_RWTH         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m11 / 294 \u001b[0m\u001b[35m \u001b[0m│     3.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 10  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UK_SGrid_Bristol\u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m3 / 294  \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    1.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  11   │\u001b[36m \u001b[0m\u001b[36mT2_ES_IFCA         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m2 / 294  \u001b[0m\u001b[35m \u001b[0m│     0.7%     │\n",
+       "└───────┴─────────────────────┴───────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Example with regex\n",
+    "try:\n",
+    "    (\n",
+    "        outfiles,\n",
+    "        outsites,\n",
+    "        sites_counts,\n",
+    "    ) = rucio_utils.get_dataset_files_replicas(\n",
+    "        dataset,\n",
+    "        allowlist_sites=[],\n",
+    "        blocklist_sites=[],\n",
+    "        regex_sites= r\"T[123]_(FR|IT|BE|CH|DE|ES|UK)_\\w+\",\n",
+    "        mode=\"full\",   # full or first. \"full\"==all the available replicas\n",
+    "        client=client,\n",
+    "    )\n",
+    "except Exception as e:\n",
+    "    print(f\"\\n[red bold] Exception: {e}[/]\")\n",
+    "\n",
+    "print_replicas(sites_counts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b805dde-dd38-46a4-92ad-55ab2e4a4876",
+   "metadata": {},
+   "source": [
+    "## Using the DataDiscoveryCLI\n",
+    "Manipulating the dataset query and replicas is simplified by the `DataDiscoveryCLI` class in `dataset_query` module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "39846193-d6f2-4de5-ba42-a089d1b0786d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from coffea.dataset_tools import rucio_utils\n",
+    "from coffea.dataset_tools.dataset_query import print_dataset_query\n",
+    "from rich.console import Console\n",
+    "from rich.table import Table\n",
+    "from coffea.dataset_tools.dataset_query import DataDiscoveryCLI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eaba3e39-c95a-4282-83e2-3aadf748adca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_definition = {\n",
+    "    \"/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X*/NANOAODSIM\": {\"short_name\": \"ZJets\",\n",
+    "                                                                                                   \"metadata\": {\"xsec\": 100.0,\"isMC\":True}},\n",
+    "    \"/SingleMuon/Run2018C-UL20*_MiniAODv2_NanoAODv9_GT36*/NANOAOD\": {\"short_name\": \"SingleMuon\", \"metadata\": {\"isMC\":False}}\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecb84b02-b85f-4037-a08d-cce001bc35c7",
+   "metadata": {},
+   "source": [
+    "The dataset definition is passed to a `DataDiscoveryCLI` to automatically query rucio and get replicas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "716a6c0c-ea07-498a-a010-f9e7f87ba3a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">⠇</span> Querying rucio for replicas: <span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[32m⠇\u001b[0m Querying rucio for replicas: \u001b[1;31m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span><span style=\"color: #800000; text-decoration-color: #800000\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\u001b[31m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\u001b[31mNANOAOD\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                   Available replicas                   </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site                </span>┃<span style=\"font-weight: bold\"> Files   </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_DESY          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 67 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T3_KR_KISTI         </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 67 / 67 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   2   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_TW_NCHC          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 67 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   3   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_BE_IIHE          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 67 / 67 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   4   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Purdue        </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 67 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   5   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_ES_CIEMAT        </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 67 / 67 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   6   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T3_FR_IPNL          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 67 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   7   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_US_FNAL_Disk     </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 61 / 67 </span>│    91.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   8   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UK_London_IC     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 39 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    58.2%     </span>│\n",
+       "│   9   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_FR_CCIN2P3_Disk  </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 38 / 67 </span>│    56.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  10   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Caltech       </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 26 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    38.8%     </span>│\n",
+       "│  11   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_CH_CERN          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 25 / 67 </span>│    37.3%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  12   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_RWTH          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 22 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    32.8%     </span>│\n",
+       "│  13   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_IT_CNAF_Disk     </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 20 / 67 </span>│    29.9%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  14   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Wisconsin     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 16 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    23.9%     </span>│\n",
+       "│  15   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_US_Florida       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 16 / 67 </span>│    23.9%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  16   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_US_Nebraska      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 13 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    19.4%     </span>│\n",
+       "│  17   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_TR_METU          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 11 / 67 </span>│    16.4%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  18   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_DE_KIT_Disk      </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 11 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    16.4%     </span>│\n",
+       "│  19   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_UK_SGrid_RALPP   </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 6 / 67  </span>│     9.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  20   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_IT_Legnaro       </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 6 / 67  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     9.0%     </span>│\n",
+       "│  21   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_ES_IFCA          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 4 / 67  </span>│     6.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  22   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_FR_IPHC          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 2 / 67  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     3.0%     </span>│\n",
+       "│  23   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_UK_London_Brunel </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 1 / 67  </span>│     1.5%     │\n",
+       "└───────┴─────────────────────┴─────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                   Available replicas                   \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite               \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles  \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_DESY         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m67 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT3_KR_KISTI        \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m67 / 67\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  2  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_TW_NCHC         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m67 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   3   │\u001b[36m \u001b[0m\u001b[36mT2_BE_IIHE         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m67 / 67\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  4  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Purdue       \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m67 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   5   │\u001b[36m \u001b[0m\u001b[36mT2_ES_CIEMAT       \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m67 / 67\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  6  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT3_FR_IPNL         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m67 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   7   │\u001b[36m \u001b[0m\u001b[36mT1_US_FNAL_Disk    \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m61 / 67\u001b[0m\u001b[35m \u001b[0m│    91.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  8  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UK_London_IC    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m39 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   58.2%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   9   │\u001b[36m \u001b[0m\u001b[36mT1_FR_CCIN2P3_Disk \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m38 / 67\u001b[0m\u001b[35m \u001b[0m│    56.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 10  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Caltech      \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m26 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   38.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  11   │\u001b[36m \u001b[0m\u001b[36mT2_CH_CERN         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m25 / 67\u001b[0m\u001b[35m \u001b[0m│    37.3%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 12  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_RWTH         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m22 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   32.8%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  13   │\u001b[36m \u001b[0m\u001b[36mT1_IT_CNAF_Disk    \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m20 / 67\u001b[0m\u001b[35m \u001b[0m│    29.9%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 14  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Wisconsin    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m16 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   23.9%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  15   │\u001b[36m \u001b[0m\u001b[36mT2_US_Florida      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m16 / 67\u001b[0m\u001b[35m \u001b[0m│    23.9%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 16  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_US_Nebraska     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m13 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   19.4%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  17   │\u001b[36m \u001b[0m\u001b[36mT2_TR_METU         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m11 / 67\u001b[0m\u001b[35m \u001b[0m│    16.4%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 18  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_DE_KIT_Disk     \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m11 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   16.4%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  19   │\u001b[36m \u001b[0m\u001b[36mT2_UK_SGrid_RALPP  \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m6 / 67 \u001b[0m\u001b[35m \u001b[0m│     9.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 20  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_IT_Legnaro      \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m6 / 67 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    9.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  21   │\u001b[36m \u001b[0m\u001b[36mT2_ES_IFCA         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m4 / 67 \u001b[0m\u001b[35m \u001b[0m│     6.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 22  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_FR_IPHC         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m2 / 67 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    3.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  23   │\u001b[36m \u001b[0m\u001b[36mT2_UK_London_Brunel\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m1 / 67 \u001b[0m\u001b[35m \u001b[0m│     1.5%     │\n",
+       "└───────┴─────────────────────┴─────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Replicas for <span style=\"color: #008000; text-decoration-color: #008000\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_DE_DESY</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/0144EC47-BFA3-EA43-BF05-BD4248ED6031.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/2747DEFE-A247-1F42-B0EF-E7B7F1D3FCD6.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/2DA9130E-8423-304C-9902-1E42CD72E658.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/63047CC0-38C6-F74C-9A00-0DF9050F7CF1.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/8369B0EA-E4CC-AC4D-BD3F-0679B3310E09.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T3_KR_KISTI</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/0C9615C1-7EE6-CD44-8FC0-04F63B2C16FD.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/152C304A-97AD-1649-BCB6-3EA0CCD0DD33.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/1CEB718A-7DC1-C74A-A7BE-A3C8D9FA785A.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/51515E3C-C640-3A4C-A16C-DC267FD142BF.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/7DEA3718-B7BC-EE42-A8BE-11C62BB8536D.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/81CEA7BA-9E66-BC4F-A96F-32642D59B653.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/C4F476DA-3D00-334B-867C-7E12F94EE3AB.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_ES_CIEMAT</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/12FAE9F1-7139-924C-A8DE-9699A00FC994.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/1DD0FAC6-3087-E44E-ABCB-8AF812C1310D.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/3FE5B677-9AB3-0245-A1CF-4B320592F18F.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/74A75B73-E5B8-C942-BBC9-1DDDD7F752FB.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/8C8690F8-4FEE-1047-85F4-29E414B3D12C.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">/2520000/DA47C0B6-BCAB-C54C-A6BF-B0A64E88E3D4.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_FR_CCIN2P3_Disk</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/26FC8C40-EA29-804C-B17D-84FB1C6BC505.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/2D58C3FE-512A-1F48-9AEB-6F80379B8F4A.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/30A3A1AB-2F27-C84E-9437-6BB3881F6856.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/A350E2E4-705C-2C4D-9B11-3436056EEBE7.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_BE_IIHE</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">0000/365F32F6-F971-1B4D-8E9D-C0ACD74FFB03.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">0000/410C32AB-DEB5-404F-BC6B-92E8F560563F.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">0000/6809B5E3-6DE6-1541-AE4C-E1804C877EDE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">0000/78AC6A39-C303-EB44-9264-71819CC70FCC.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">0000/7CCCB2C3-F210-2C42-85DF-AA00293FACFB.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_US_Purdue</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/37312354-59AB-E44B-BC94-CF424D4B7DDB.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/42DC0F42-82E8-BE47-B04D-544B67274829.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/D7875684-9F26-084E-9B2B-5E9BB5D353E8.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/FAF0C67B-A8B4-8A4F-83B1-E43675CE9630.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">2520000/FE5EEFA5-C07A-5C44-B66D-5B31BE02C7D3.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_US_Wisconsin</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd.hep.wisc.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/39D52C69-2035-A24B-A413-40976993651D.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd.hep.wisc.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">-v1/2520000/FCAF4145-8E3F-2142-BDCB-5E276523B592.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_TW_NCHC</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/459261DD-4441-6047-9FF2-1EDE468452C9.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/6DDF448B-4605-5C41-9711-1C73EC5F01D3.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/7B14228A-5331-DF4E-B677-7B8AA281D460.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/7B181B92-AA2C-1E44-86FE-B074D359BBB3.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/8223C4A3-D4BD-6A4B-A513-54B6668C7122.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/A74EFE57-BAD2-C143-B8DC-817CE4F96FD7.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/AE014F55-84BE-E84E-B447-0B614070CD17.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/BCBF89A2-329C-744B-A38F-139EA8F94007.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/D8D41BBC-D514-D342-A514-CCF48575D184.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/F1B3977A-E777-EC4D-8FC7-981FE4ED5E0C.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_UK_London_IC</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/59DA0585-BD57-CE49-A15E-CDBAC5473EDE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/F16A9138-7563-E540-B6AD-8A8A688B3830.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/FE3D79A6-27D4-8948-A89B-2F966C5B29D4.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_US_FNAL_Disk</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/62789325-3C0B-FC4D-B578-B41A396399E4.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/6EAA5EDB-0DB3-6E40-87DC-7AB582295D29.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/A59D511A-A419-714F-8EE1-8B8BAFEC04D5.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/B78A9B75-3B32-CF4E-A144-375189CF48AE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/B9E9087C-255C-C24D-A733-FB9291DC7C3C.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/CDD2CDF9-72D0-4045-B28F-89002077FB89.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">Dv9_GT36-v1/2520000/ED95384D-9D3D-AE45-8425-C4C080E691C5.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_IT_CNAF_Disk</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">2520000/648ECD9C-8AAA-BB46-8683-C8987CCC73B9.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_US_Nebraska</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/69ABD79C-C684-8244-9F0D-153C6B8C2D9C.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/AB8DD69D-A522-D44C-BB9C-209623F7D41A.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">1/2520000/B3487FE0-B172-AD47-A13A-388C0A9BF93F.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_IT_Legnaro</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://t2-xrdcms.lnl.infn.it:7070///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">v1/2520000/B1B449CE-5952-8347-A9A7-35FE231D0C72.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T3_FR_IPNL</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/BA02D468-A8CE-4F49-884F-F836BB481AD5.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/BAAA6E00-7AC3-9947-9262-D9833D3A8B19.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/CBD43A1E-AE2F-0B4D-A642-29FB2E9EB33B.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/ECD4877E-707B-EA43-A38B-D1B700FBDE79.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/F09135D8-FCBE-AF40-BCE8-03A529C5C87F.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_DE_RWTH</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">_NanoAODv9_GT36-v1/2520000/D40D1285-B075-D446-B1BF-86A463EF6993.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_TR_METU</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://eymir.grid.metu.edu.tr//dpm/grid.metu.edu.tr/home/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">_MiniAODv2_NanoAODv9_GT36-v1/2520000/F34F4F00-3370-EF4D-AF44-39E474E6530F.root</span>\n",
+       "└── <span style=\"color: #008000; text-decoration-color: #008000\">T2_US_Florida</span>\n",
+       "    └── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsio2.rc.ufl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080\">520000/F6E44EA5-F4C6-E746-AD43-7A263F1E316E.root</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Replicas for \u001b[32m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD\u001b[0m\n",
+       "├── \u001b[32mT2_DE_DESY\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/0144EC47-BFA3-EA43-BF05-BD4248ED6031.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/2747DEFE-A247-1F42-B0EF-E7B7F1D3FCD6.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/2DA9130E-8423-304C-9902-1E42CD72E658.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/63047CC0-38C6-F74C-9A00-0DF9050F7CF1.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│       \u001b[36m36-v1/2520000/8369B0EA-E4CC-AC4D-BD3F-0679B3310E09.root\u001b[0m\n",
+       "├── \u001b[32mT3_KR_KISTI\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/0C9615C1-7EE6-CD44-8FC0-04F63B2C16FD.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/152C304A-97AD-1649-BCB6-3EA0CCD0DD33.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/1CEB718A-7DC1-C74A-A7BE-A3C8D9FA785A.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/51515E3C-C640-3A4C-A16C-DC267FD142BF.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/7DEA3718-B7BC-EE42-A8BE-11C62BB8536D.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/81CEA7BA-9E66-BC4F-A96F-32642D59B653.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://cms-xrdr.sdfarm.kr:1094//xrd//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│       \u001b[36m-v1/2520000/C4F476DA-3D00-334B-867C-7E12F94EE3AB.root\u001b[0m\n",
+       "├── \u001b[32mT2_ES_CIEMAT\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│   │   \u001b[36m/2520000/12FAE9F1-7139-924C-A8DE-9699A00FC994.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│   │   \u001b[36m/2520000/1DD0FAC6-3087-E44E-ABCB-8AF812C1310D.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│   │   \u001b[36m/2520000/3FE5B677-9AB3-0245-A1CF-4B320592F18F.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│   │   \u001b[36m/2520000/74A75B73-E5B8-C942-BBC9-1DDDD7F752FB.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│   │   \u001b[36m/2520000/8C8690F8-4FEE-1047-85F4-29E414B3D12C.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://gaexrdoor.ciemat.es:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1\u001b[0m\n",
+       "│       \u001b[36m/2520000/DA47C0B6-BCAB-C54C-A6BF-B0A64E88E3D4.root\u001b[0m\n",
+       "├── \u001b[32mT1_FR_CCIN2P3_Disk\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/26FC8C40-EA29-804C-B17D-84FB1C6BC505.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/2D58C3FE-512A-1F48-9AEB-6F80379B8F4A.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/30A3A1AB-2F27-C84E-9437-6BB3881F6856.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│       \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/A350E2E4-705C-2C4D-9B11-3436056EEBE7.root\u001b[0m\n",
+       "├── \u001b[32mT2_BE_IIHE\u001b[0m\n",
+       "│   ├── \u001b[36mroot://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252\u001b[0m\n",
+       "│   │   \u001b[36m0000/365F32F6-F971-1B4D-8E9D-C0ACD74FFB03.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252\u001b[0m\n",
+       "│   │   \u001b[36m0000/410C32AB-DEB5-404F-BC6B-92E8F560563F.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252\u001b[0m\n",
+       "│   │   \u001b[36m0000/6809B5E3-6DE6-1541-AE4C-E1804C877EDE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252\u001b[0m\n",
+       "│   │   \u001b[36m0000/78AC6A39-C303-EB44-9264-71819CC70FCC.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://maite.iihe.ac.be:1095//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/252\u001b[0m\n",
+       "│       \u001b[36m0000/7CCCB2C3-F210-2C42-85DF-AA00293FACFB.root\u001b[0m\n",
+       "├── \u001b[32mT2_US_Purdue\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/37312354-59AB-E44B-BC94-CF424D4B7DDB.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/42DC0F42-82E8-BE47-B04D-544B67274829.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/D7875684-9F26-084E-9B2B-5E9BB5D353E8.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/FAF0C67B-A8B4-8A4F-83B1-E43675CE9630.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://eos.cms.rcac.purdue.edu///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│       \u001b[36m2520000/FE5EEFA5-C07A-5C44-B66D-5B31BE02C7D3.root\u001b[0m\n",
+       "├── \u001b[32mT2_US_Wisconsin\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsxrootd.hep.wisc.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│   │   \u001b[36m-v1/2520000/39D52C69-2035-A24B-A413-40976993651D.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://cmsxrootd.hep.wisc.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36\u001b[0m\n",
+       "│       \u001b[36m-v1/2520000/FCAF4145-8E3F-2142-BDCB-5E276523B592.root\u001b[0m\n",
+       "├── \u001b[32mT2_TW_NCHC\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/459261DD-4441-6047-9FF2-1EDE468452C9.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/6DDF448B-4605-5C41-9711-1C73EC5F01D3.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/7B14228A-5331-DF4E-B677-7B8AA281D460.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/7B181B92-AA2C-1E44-86FE-B074D359BBB3.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/8223C4A3-D4BD-6A4B-A513-54B6668C7122.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/A74EFE57-BAD2-C143-B8DC-817CE4F96FD7.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/AE014F55-84BE-E84E-B447-0B614070CD17.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/BCBF89A2-329C-744B-A38F-139EA8F94007.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/D8D41BBC-D514-D342-A514-CCF48575D184.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://se01.grid.nchc.org.tw//cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│       \u001b[36m1/2520000/F1B3977A-E777-EC4D-8FC7-981FE4ED5E0C.root\u001b[0m\n",
+       "├── \u001b[32mT2_UK_London_IC\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/59DA0585-BD57-CE49-A15E-CDBAC5473EDE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/F16A9138-7563-E540-B6AD-8A8A688B3830.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│       \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/FE3D79A6-27D4-8948-A89B-2F966C5B29D4.root\u001b[0m\n",
+       "├── \u001b[32mT1_US_FNAL_Disk\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/62789325-3C0B-FC4D-B578-B41A396399E4.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/6EAA5EDB-0DB3-6E40-87DC-7AB582295D29.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/A59D511A-A419-714F-8EE1-8B8BAFEC04D5.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/B78A9B75-3B32-CF4E-A144-375189CF48AE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/B9E9087C-255C-C24D-A733-FB9291DC7C3C.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│   │   \u001b[36mDv9_GT36-v1/2520000/CDD2CDF9-72D0-4045-B28F-89002077FB89.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://cmsdcadisk.fnal.gov//dcache/uscmsdisk/store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAO\u001b[0m\n",
+       "│       \u001b[36mDv9_GT36-v1/2520000/ED95384D-9D3D-AE45-8425-C4C080E691C5.root\u001b[0m\n",
+       "├── \u001b[32mT1_IT_CNAF_Disk\u001b[0m\n",
+       "│   └── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│       \u001b[36m2520000/648ECD9C-8AAA-BB46-8683-C8987CCC73B9.root\u001b[0m\n",
+       "├── \u001b[32mT2_US_Nebraska\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/69ABD79C-C684-8244-9F0D-153C6B8C2D9C.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│   │   \u001b[36m1/2520000/AB8DD69D-A522-D44C-BB9C-209623F7D41A.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://xrootd-local.unl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v\u001b[0m\n",
+       "│       \u001b[36m1/2520000/B3487FE0-B172-AD47-A13A-388C0A9BF93F.root\u001b[0m\n",
+       "├── \u001b[32mT2_IT_Legnaro\u001b[0m\n",
+       "│   └── \u001b[36mroot://t2-xrdcms.lnl.infn.it:7070///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-\u001b[0m\n",
+       "│       \u001b[36mv1/2520000/B1B449CE-5952-8347-A9A7-35FE231D0C72.root\u001b[0m\n",
+       "├── \u001b[32mT3_FR_IPNL\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/BA02D468-A8CE-4F49-884F-F836BB481AD5.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/BAAA6E00-7AC3-9947-9262-D9833D3A8B19.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/CBD43A1E-AE2F-0B4D-A642-29FB2E9EB33B.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/ECD4877E-707B-EA43-A38B-D1B700FBDE79.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│       \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/F09135D8-FCBE-AF40-BCE8-03A529C5C87F.root\u001b[0m\n",
+       "├── \u001b[32mT2_DE_RWTH\u001b[0m\n",
+       "│   └── \u001b[36mroot://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2\u001b[0m\n",
+       "│       \u001b[36m_NanoAODv9_GT36-v1/2520000/D40D1285-B075-D446-B1BF-86A463EF6993.root\u001b[0m\n",
+       "├── \u001b[32mT2_TR_METU\u001b[0m\n",
+       "│   └── \u001b[36mroot://eymir.grid.metu.edu.tr//dpm/grid.metu.edu.tr/home/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018\u001b[0m\n",
+       "│       \u001b[36m_MiniAODv2_NanoAODv9_GT36-v1/2520000/F34F4F00-3370-EF4D-AF44-39E474E6530F.root\u001b[0m\n",
+       "└── \u001b[32mT2_US_Florida\u001b[0m\n",
+       "    └── \u001b[36mroot://cmsio2.rc.ufl.edu:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "        \u001b[36m520000/F6E44EA5-F4C6-E746-AD43-7A263F1E316E.root\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Selected datasets:</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSelected datasets:\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                                                 Selected datasets                                                 </span>\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃<span style=\"font-weight: bold\"> … </span>┃<span style=\"font-weight: bold\"> Dataset                                                                                                   </span>┃<span style=\"font-weight: bold\"></span>┃<span style=\"font-weight: bold\"></span>┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 1 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti… </span>│││\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 2 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                           </span>│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                                                 Selected datasets                                                 \u001b[0m\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1m…\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mDataset                                                                                                  \u001b[0m\u001b[1m \u001b[0m┃┃┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36m1\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti…\u001b[0m\u001b[35m \u001b[0m│││\n",
+       "│\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                          \u001b[0m\u001b[35m \u001b[0m│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ddc = DataDiscoveryCLI()\n",
+    "ddc.load_dataset_definition(dataset_definition, \n",
+    "                           query_results_strategy=\"all\",\n",
+    "                           replicas_strategy=\"round-robin\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db7798eb-eb9f-47e5-9239-92cdea20600f",
+   "metadata": {},
+   "source": [
+    "### Filtering sites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd57fe7b-0642-48b8-9f9f-cd209e50d867",
+   "metadata": {},
+   "source": [
+    "Sites filtering works in a very similar way for `DataDiscoveryCLI`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "d85ca119-0a56-4c67-bb21-ebbca8164728",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">⠇</span> Querying rucio for replicas: <span style=\"color: #800000; text-decoration-color: #800000; font-weight: bold\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[32m⠇\u001b[0m Querying rucio for replicas: \u001b[1;31m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Sites availability for dataset: </span><span style=\"color: #800000; text-decoration-color: #800000\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSites availability for dataset: \u001b[0m\u001b[31m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\u001b[31mNANOAOD\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                   Available replicas                   </span>\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"font-weight: bold\"> Index </span>┃<span style=\"font-weight: bold\"> Site                </span>┃<span style=\"font-weight: bold\"> Files   </span>┃<span style=\"font-weight: bold\"> Availability </span>┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   0   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_DE_DESY          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 67 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    100.0%    </span>│\n",
+       "│   1   │<span style=\"color: #008080; text-decoration-color: #008080\"> T3_FR_IPNL          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 67 / 67 </span>│    100.0%    │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   2   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UK_London_IC     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 39 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    58.2%     </span>│\n",
+       "│   3   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_FR_CCIN2P3_Disk  </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 38 / 67 </span>│    56.7%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   4   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_CH_CERN          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 25 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    37.3%     </span>│\n",
+       "│   5   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_DE_RWTH          </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 22 / 67 </span>│    32.8%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   6   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T1_IT_CNAF_Disk     </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 20 / 67 </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">    29.9%     </span>│\n",
+       "│   7   │<span style=\"color: #008080; text-decoration-color: #008080\"> T1_DE_KIT_Disk      </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 11 / 67 </span>│    16.4%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">   8   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_UK_SGrid_RALPP   </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 6 / 67  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     9.0%     </span>│\n",
+       "│   9   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_IT_Legnaro       </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 6 / 67  </span>│     9.0%     │\n",
+       "│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">  10   </span>│<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\"> T2_FR_IPHC          </span>│<span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\"> 2 / 67  </span>│<span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">     3.0%     </span>│\n",
+       "│  11   │<span style=\"color: #008080; text-decoration-color: #008080\"> T2_UK_London_Brunel </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> 1 / 67  </span>│     1.5%     │\n",
+       "└───────┴─────────────────────┴─────────┴──────────────┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                   Available replicas                   \u001b[0m\n",
+       "┏━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1mIndex\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mSite               \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mFiles  \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mAvailability\u001b[0m\u001b[1m \u001b[0m┃\n",
+       "┡━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━┩\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  0  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_DE_DESY         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m67 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   100.0%   \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   1   │\u001b[36m \u001b[0m\u001b[36mT3_FR_IPNL         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m67 / 67\u001b[0m\u001b[35m \u001b[0m│    100.0%    │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  2  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UK_London_IC    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m39 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   58.2%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   3   │\u001b[36m \u001b[0m\u001b[36mT1_FR_CCIN2P3_Disk \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m38 / 67\u001b[0m\u001b[35m \u001b[0m│    56.7%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  4  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_CH_CERN         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m25 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   37.3%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   5   │\u001b[36m \u001b[0m\u001b[36mT2_DE_RWTH         \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m22 / 67\u001b[0m\u001b[35m \u001b[0m│    32.8%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  6  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT1_IT_CNAF_Disk    \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m20 / 67\u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m   29.9%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   7   │\u001b[36m \u001b[0m\u001b[36mT1_DE_KIT_Disk     \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m11 / 67\u001b[0m\u001b[35m \u001b[0m│    16.4%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m  8  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_UK_SGrid_RALPP  \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m6 / 67 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    9.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│   9   │\u001b[36m \u001b[0m\u001b[36mT2_IT_Legnaro      \u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m6 / 67 \u001b[0m\u001b[35m \u001b[0m│     9.0%     │\n",
+       "│\u001b[2m \u001b[0m\u001b[2m 10  \u001b[0m\u001b[2m \u001b[0m│\u001b[2;36m \u001b[0m\u001b[2;36mT2_FR_IPHC         \u001b[0m\u001b[2;36m \u001b[0m│\u001b[2;35m \u001b[0m\u001b[2;35m2 / 67 \u001b[0m\u001b[2;35m \u001b[0m│\u001b[2m \u001b[0m\u001b[2m    3.0%    \u001b[0m\u001b[2m \u001b[0m│\n",
+       "│  11   │\u001b[36m \u001b[0m\u001b[36mT2_UK_London_Brunel\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m1 / 67 \u001b[0m\u001b[35m \u001b[0m│     1.5%     │\n",
+       "└───────┴─────────────────────┴─────────┴──────────────┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Replicas for <span style=\"color: #008000; text-decoration-color: #008000\">/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_CH_CERN</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/0144EC47-BFA3-EA43-BF05-BD4248ED6031.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/1DD0FAC6-3087-E44E-ABCB-8AF812C1310D.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/2747DEFE-A247-1F42-B0EF-E7B7F1D3FCD6.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/2DA9130E-8423-304C-9902-1E42CD72E658.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/39D52C69-2035-A24B-A413-40976993651D.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/69ABD79C-C684-8244-9F0D-153C6B8C2D9C.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">520000/7CCCB2C3-F210-2C42-85DF-AA00293FACFB.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">520000/F34F4F00-3370-EF4D-AF44-39E474E6530F.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T3_FR_IPNL</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/0C9615C1-7EE6-CD44-8FC0-04F63B2C16FD.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/30A3A1AB-2F27-C84E-9437-6BB3881F6856.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/410C32AB-DEB5-404F-BC6B-92E8F560563F.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/42DC0F42-82E8-BE47-B04D-544B67274829.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/62789325-3C0B-FC4D-B578-B41A396399E4.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/6809B5E3-6DE6-1541-AE4C-E1804C877EDE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/78AC6A39-C303-EB44-9264-71819CC70FCC.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/A350E2E4-705C-2C4D-9B11-3436056EEBE7.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/FCAF4145-8E3F-2142-BDCB-5E276523B592.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">Dv2_NanoAODv9_GT36-v1/2520000/FE3D79A6-27D4-8948-A89B-2F966C5B29D4.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_UK_London_IC</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/12FAE9F1-7139-924C-A8DE-9699A00FC994.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/63047CC0-38C6-F74C-9A00-0DF9050F7CF1.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/8369B0EA-E4CC-AC4D-BD3F-0679B3310E09.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/AE014F55-84BE-E84E-B447-0B614070CD17.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/F16A9138-7563-E540-B6AD-8A8A688B3830.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">OD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/FAF0C67B-A8B4-8A4F-83B1-E43675CE9630.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_FR_CCIN2P3_Disk</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/152C304A-97AD-1649-BCB6-3EA0CCD0DD33.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/37312354-59AB-E44B-BC94-CF424D4B7DDB.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/7B14228A-5331-DF4E-B677-7B8AA281D460.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/7B181B92-AA2C-1E44-86FE-B074D359BBB3.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/C4F476DA-3D00-334B-867C-7E12F94EE3AB.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/D8D41BBC-D514-D342-A514-CCF48575D184.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">18_MiniAODv2_NanoAODv9_GT36-v1/2520000/FE5EEFA5-C07A-5C44-B66D-5B31BE02C7D3.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_FR_IPHC</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://sbgdcache.in2p3.fr///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/25200</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">00/1CEB718A-7DC1-C74A-A7BE-A3C8D9FA785A.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_DE_DESY</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/26FC8C40-EA29-804C-B17D-84FB1C6BC505.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/2D58C3FE-512A-1F48-9AEB-6F80379B8F4A.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/459261DD-4441-6047-9FF2-1EDE468452C9.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/51515E3C-C640-3A4C-A16C-DC267FD142BF.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/648ECD9C-8AAA-BB46-8683-C8987CCC73B9.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/74A75B73-E5B8-C942-BBC9-1DDDD7F752FB.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/81CEA7BA-9E66-BC4F-A96F-32642D59B653.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/8223C4A3-D4BD-6A4B-A513-54B6668C7122.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/8C8690F8-4FEE-1047-85F4-29E414B3D12C.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/B78A9B75-3B32-CF4E-A144-375189CF48AE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/BAAA6E00-7AC3-9947-9262-D9833D3A8B19.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/BCBF89A2-329C-744B-A38F-139EA8F94007.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/CBD43A1E-AE2F-0B4D-A642-29FB2E9EB33B.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/D40D1285-B075-D446-B1BF-86A463EF6993.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/DA47C0B6-BCAB-C54C-A6BF-B0A64E88E3D4.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/ECD4877E-707B-EA43-A38B-D1B700FBDE79.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/ED95384D-9D3D-AE45-8425-C4C080E691C5.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">36-v1/2520000/F1B3977A-E777-EC4D-8FC7-981FE4ED5E0C.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_DE_KIT_Disk</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">9_GT36-v1/2520000/365F32F6-F971-1B4D-8E9D-C0ACD74FFB03.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">9_GT36-v1/2520000/3FE5B677-9AB3-0245-A1CF-4B320592F18F.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">9_GT36-v1/2520000/6DDF448B-4605-5C41-9711-1C73EC5F01D3.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">9_GT36-v1/2520000/6EAA5EDB-0DB3-6E40-87DC-7AB582295D29.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">9_GT36-v1/2520000/7DEA3718-B7BC-EE42-A8BE-11C62BB8536D.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T2_DE_RWTH</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">_NanoAODv9_GT36-v1/2520000/59DA0585-BD57-CE49-A15E-CDBAC5473EDE.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">_NanoAODv9_GT36-v1/2520000/A59D511A-A419-714F-8EE1-8B8BAFEC04D5.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">_NanoAODv9_GT36-v1/2520000/B9E9087C-255C-C24D-A733-FB9291DC7C3C.root</span>\n",
+       "├── <span style=\"color: #008000; text-decoration-color: #008000\">T1_IT_CNAF_Disk</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/A74EFE57-BAD2-C143-B8DC-817CE4F96FD7.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/AB8DD69D-A522-D44C-BB9C-209623F7D41A.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/B3487FE0-B172-AD47-A13A-388C0A9BF93F.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/CDD2CDF9-72D0-4045-B28F-89002077FB89.root</span>\n",
+       "│   ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│   │   <span style=\"color: #008080; text-decoration-color: #008080\">2520000/D7875684-9F26-084E-9B2B-5E9BB5D353E8.root</span>\n",
+       "│   └── <span style=\"color: #008080; text-decoration-color: #008080\">root://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/</span>\n",
+       "│       <span style=\"color: #008080; text-decoration-color: #008080\">2520000/F09135D8-FCBE-AF40-BCE8-03A529C5C87F.root</span>\n",
+       "└── <span style=\"color: #008000; text-decoration-color: #008000\">T2_UK_SGrid_RALPP</span>\n",
+       "    ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini</span>\n",
+       "    │   <span style=\"color: #008080; text-decoration-color: #008080\">AODv2_NanoAODv9_GT36-v1/2520000/B1B449CE-5952-8347-A9A7-35FE231D0C72.root</span>\n",
+       "    ├── <span style=\"color: #008080; text-decoration-color: #008080\">root://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini</span>\n",
+       "    │   <span style=\"color: #008080; text-decoration-color: #008080\">AODv2_NanoAODv9_GT36-v1/2520000/BA02D468-A8CE-4F49-884F-F836BB481AD5.root</span>\n",
+       "    └── <span style=\"color: #008080; text-decoration-color: #008080\">root://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini</span>\n",
+       "        <span style=\"color: #008080; text-decoration-color: #008080\">AODv2_NanoAODv9_GT36-v1/2520000/F6E44EA5-F4C6-E746-AD43-7A263F1E316E.root</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Replicas for \u001b[32m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD\u001b[0m\n",
+       "├── \u001b[32mT2_CH_CERN\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/0144EC47-BFA3-EA43-BF05-BD4248ED6031.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/1DD0FAC6-3087-E44E-ABCB-8AF812C1310D.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/2747DEFE-A247-1F42-B0EF-E7B7F1D3FCD6.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/2DA9130E-8423-304C-9902-1E42CD72E658.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/39D52C69-2035-A24B-A413-40976993651D.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/69ABD79C-C684-8244-9F0D-153C6B8C2D9C.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│   │   \u001b[36m520000/7CCCB2C3-F210-2C42-85DF-AA00293FACFB.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://eoscms.cern.ch//eos/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2\u001b[0m\n",
+       "│       \u001b[36m520000/F34F4F00-3370-EF4D-AF44-39E474E6530F.root\u001b[0m\n",
+       "├── \u001b[32mT3_FR_IPNL\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/0C9615C1-7EE6-CD44-8FC0-04F63B2C16FD.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/30A3A1AB-2F27-C84E-9437-6BB3881F6856.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/410C32AB-DEB5-404F-BC6B-92E8F560563F.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/42DC0F42-82E8-BE47-B04D-544B67274829.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/62789325-3C0B-FC4D-B578-B41A396399E4.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/6809B5E3-6DE6-1541-AE4C-E1804C877EDE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/78AC6A39-C303-EB44-9264-71819CC70FCC.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/A350E2E4-705C-2C4D-9B11-3436056EEBE7.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│   │   \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/FCAF4145-8E3F-2142-BDCB-5E276523B592.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://lyogrid06.in2p3.fr//dpm/in2p3.fr/home/cms/data//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAO\u001b[0m\n",
+       "│       \u001b[36mDv2_NanoAODv9_GT36-v1/2520000/FE3D79A6-27D4-8948-A89B-2F966C5B29D4.root\u001b[0m\n",
+       "├── \u001b[32mT2_UK_London_IC\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/12FAE9F1-7139-924C-A8DE-9699A00FC994.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/63047CC0-38C6-F74C-9A00-0DF9050F7CF1.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/8369B0EA-E4CC-AC4D-BD3F-0679B3310E09.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/AE014F55-84BE-E84E-B447-0B614070CD17.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│   │   \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/F16A9138-7563-E540-B6AD-8A8A688B3830.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://gfe02.grid.hep.ph.ic.ac.uk:1094//pnfs/hep.ph.ic.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOA\u001b[0m\n",
+       "│       \u001b[36mOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/2520000/FAF0C67B-A8B4-8A4F-83B1-E43675CE9630.root\u001b[0m\n",
+       "├── \u001b[32mT1_FR_CCIN2P3_Disk\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/152C304A-97AD-1649-BCB6-3EA0CCD0DD33.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/37312354-59AB-E44B-BC94-CF424D4B7DDB.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/7B14228A-5331-DF4E-B677-7B8AA281D460.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/7B181B92-AA2C-1E44-86FE-B074D359BBB3.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/C4F476DA-3D00-334B-867C-7E12F94EE3AB.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│   │   \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/D8D41BBC-D514-D342-A514-CCF48575D184.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://ccxrdcms.in2p3.fr:1094/pnfs/in2p3.fr/data/cms/disk/data//store/data/Run2018C/SingleMuon/NANOAOD/UL20\u001b[0m\n",
+       "│       \u001b[36m18_MiniAODv2_NanoAODv9_GT36-v1/2520000/FE5EEFA5-C07A-5C44-B66D-5B31BE02C7D3.root\u001b[0m\n",
+       "├── \u001b[32mT2_FR_IPHC\u001b[0m\n",
+       "│   └── \u001b[36mroot://sbgdcache.in2p3.fr///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/25200\u001b[0m\n",
+       "│       \u001b[36m00/1CEB718A-7DC1-C74A-A7BE-A3C8D9FA785A.root\u001b[0m\n",
+       "├── \u001b[32mT2_DE_DESY\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/26FC8C40-EA29-804C-B17D-84FB1C6BC505.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/2D58C3FE-512A-1F48-9AEB-6F80379B8F4A.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/459261DD-4441-6047-9FF2-1EDE468452C9.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/51515E3C-C640-3A4C-A16C-DC267FD142BF.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/648ECD9C-8AAA-BB46-8683-C8987CCC73B9.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/74A75B73-E5B8-C942-BBC9-1DDDD7F752FB.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/81CEA7BA-9E66-BC4F-A96F-32642D59B653.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/8223C4A3-D4BD-6A4B-A513-54B6668C7122.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/8C8690F8-4FEE-1047-85F4-29E414B3D12C.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/B78A9B75-3B32-CF4E-A144-375189CF48AE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/BAAA6E00-7AC3-9947-9262-D9833D3A8B19.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/BCBF89A2-329C-744B-A38F-139EA8F94007.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/CBD43A1E-AE2F-0B4D-A642-29FB2E9EB33B.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/D40D1285-B075-D446-B1BF-86A463EF6993.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/DA47C0B6-BCAB-C54C-A6BF-B0A64E88E3D4.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/ECD4877E-707B-EA43-A38B-D1B700FBDE79.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│   │   \u001b[36m36-v1/2520000/ED95384D-9D3D-AE45-8425-C4C080E691C5.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://dcache-cms-xrootd.desy.de:1094//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT\u001b[0m\n",
+       "│       \u001b[36m36-v1/2520000/F1B3977A-E777-EC4D-8FC7-981FE4ED5E0C.root\u001b[0m\n",
+       "├── \u001b[32mT1_DE_KIT_Disk\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv\u001b[0m\n",
+       "│   │   \u001b[36m9_GT36-v1/2520000/365F32F6-F971-1B4D-8E9D-C0ACD74FFB03.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv\u001b[0m\n",
+       "│   │   \u001b[36m9_GT36-v1/2520000/3FE5B677-9AB3-0245-A1CF-4B320592F18F.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv\u001b[0m\n",
+       "│   │   \u001b[36m9_GT36-v1/2520000/6DDF448B-4605-5C41-9711-1C73EC5F01D3.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv\u001b[0m\n",
+       "│   │   \u001b[36m9_GT36-v1/2520000/6EAA5EDB-0DB3-6E40-87DC-7AB582295D29.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://cmsxrootd-kit-disk.gridka.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv\u001b[0m\n",
+       "│       \u001b[36m9_GT36-v1/2520000/7DEA3718-B7BC-EE42-A8BE-11C62BB8536D.root\u001b[0m\n",
+       "├── \u001b[32mT2_DE_RWTH\u001b[0m\n",
+       "│   ├── \u001b[36mroot://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2\u001b[0m\n",
+       "│   │   \u001b[36m_NanoAODv9_GT36-v1/2520000/59DA0585-BD57-CE49-A15E-CDBAC5473EDE.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2\u001b[0m\n",
+       "│   │   \u001b[36m_NanoAODv9_GT36-v1/2520000/A59D511A-A419-714F-8EE1-8B8BAFEC04D5.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://grid-cms-xrootd.physik.rwth-aachen.de:1094///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2\u001b[0m\n",
+       "│       \u001b[36m_NanoAODv9_GT36-v1/2520000/B9E9087C-255C-C24D-A733-FB9291DC7C3C.root\u001b[0m\n",
+       "├── \u001b[32mT1_IT_CNAF_Disk\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/A74EFE57-BAD2-C143-B8DC-817CE4F96FD7.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/AB8DD69D-A522-D44C-BB9C-209623F7D41A.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/B3487FE0-B172-AD47-A13A-388C0A9BF93F.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/CDD2CDF9-72D0-4045-B28F-89002077FB89.root\u001b[0m\n",
+       "│   ├── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│   │   \u001b[36m2520000/D7875684-9F26-084E-9B2B-5E9BB5D353E8.root\u001b[0m\n",
+       "│   └── \u001b[36mroot://xrootd-cms.infn.it:1194///store/data/Run2018C/SingleMuon/NANOAOD/UL2018_MiniAODv2_NanoAODv9_GT36-v1/\u001b[0m\n",
+       "│       \u001b[36m2520000/F09135D8-FCBE-AF40-BCE8-03A529C5C87F.root\u001b[0m\n",
+       "└── \u001b[32mT2_UK_SGrid_RALPP\u001b[0m\n",
+       "    ├── \u001b[36mroot://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini\u001b[0m\n",
+       "    │   \u001b[36mAODv2_NanoAODv9_GT36-v1/2520000/B1B449CE-5952-8347-A9A7-35FE231D0C72.root\u001b[0m\n",
+       "    ├── \u001b[36mroot://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini\u001b[0m\n",
+       "    │   \u001b[36mAODv2_NanoAODv9_GT36-v1/2520000/BA02D468-A8CE-4F49-884F-F836BB481AD5.root\u001b[0m\n",
+       "    └── \u001b[36mroot://mover.pp.rl.ac.uk:1094/pnfs/pp.rl.ac.uk/data/cms//store/data/Run2018C/SingleMuon/NANOAOD/UL2018_Mini\u001b[0m\n",
+       "        \u001b[36mAODv2_NanoAODv9_GT36-v1/2520000/F6E44EA5-F4C6-E746-AD43-7A263F1E316E.root\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Selected datasets:</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSelected datasets:\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                                                 Selected datasets                                                 </span>\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃<span style=\"font-weight: bold\"> … </span>┃<span style=\"font-weight: bold\"> Dataset                                                                                                   </span>┃<span style=\"font-weight: bold\"></span>┃<span style=\"font-weight: bold\"></span>┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 1 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti… </span>│││\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 2 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                           </span>│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                                                 Selected datasets                                                 \u001b[0m\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1m…\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mDataset                                                                                                  \u001b[0m\u001b[1m \u001b[0m┃┃┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36m1\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti…\u001b[0m\u001b[35m \u001b[0m│││\n",
+       "│\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                          \u001b[0m\u001b[35m \u001b[0m│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ddc = DataDiscoveryCLI()\n",
+    "ddc.do_regex_sites(r\"T[123]_(CH|IT|UK|FR|DE)_\\w+\")\n",
+    "ddc.load_dataset_definition(dataset_definition, \n",
+    "                           query_results_strategy=\"all\",\n",
+    "                           replicas_strategy=\"round-robin\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "dd9ca4ea-039d-4ebb-bbf2-79092ba6e7d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080\">Selected datasets:</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[36mSelected datasets:\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                                                 Selected datasets                                                 </span>\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃<span style=\"font-weight: bold\"> … </span>┃<span style=\"font-weight: bold\"> Dataset                                                                                                   </span>┃<span style=\"font-weight: bold\"></span>┃<span style=\"font-weight: bold\"></span>┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 1 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti… </span>│││\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> 2 </span>│<span style=\"color: #800080; text-decoration-color: #800080\"> /SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                           </span>│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[3m                                                 Selected datasets                                                 \u001b[0m\n",
+       "┏━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳┳┓\n",
+       "┃\u001b[1m \u001b[0m\u001b[1m…\u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mDataset                                                                                                  \u001b[0m\u001b[1m \u001b[0m┃┃┃\n",
+       "┡━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇╇┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36m1\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18NanoAODv9-106X_upgrade2018_realisti…\u001b[0m\u001b[35m \u001b[0m│││\n",
+       "│\u001b[36m \u001b[0m\u001b[36m2\u001b[0m\u001b[36m \u001b[0m│\u001b[35m \u001b[0m\u001b[35m/SingleMuon/Run2018C-UL2018_MiniAODv2_NanoAODv9_GT36-v1/NANOAOD                                          \u001b[0m\u001b[35m \u001b[0m│││\n",
+       "└───┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴┴┘\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ddc.do_list_selected()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6ffbefb-8276-4733-aedb-cc12898f4ed8",
+   "metadata": {},
+   "source": [
+    "### Save the replicas metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b0e3e4b8-34d4-4558-988a-edacd1df9b37",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">File replicas_info.json saved!</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[32mFile replicas_info.json saved!\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ddc.do_save(\"replicas_info.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9f6a70b-0194-4b00-ab79-4fdb0b4fa0cf",
+   "metadata": {},
+   "source": [
+    "## DataDiscoveryCLI from shell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7237fc9e-50b8-4cc4-9c51-9674fbf4358a",
+   "metadata": {},
+   "source": [
+    "The DataDiscoveryCLI can be used directly from CLI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "2c075f2e-a06e-4c97-b5b6-6a6806571a9a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "usage: dataset_query.py [-h] [--cli] [-d DATASET_DEFINITION] [-o OUTPUT]\n",
+      "                        [-fo FILESET_OUTPUT] [-p] [--step-size STEP_SIZE]\n",
+      "                        [--dask-cluster DASK_CLUSTER]\n",
+      "                        [-as ALLOW_SITES [ALLOW_SITES ...]]\n",
+      "                        [-bs BLOCK_SITES [BLOCK_SITES ...]] [-rs REGEX_SITES]\n",
+      "                        [--query-results-strategy QUERY_RESULTS_STRATEGY]\n",
+      "                        [--replicas-strategy REPLICAS_STRATEGY]\n",
+      "\n",
+      "options:\n",
+      "  -h, --help            show this help message and exit\n",
+      "  --cli                 Start the dataset discovery CLI\n",
+      "  -d DATASET_DEFINITION, --dataset-definition DATASET_DEFINITION\n",
+      "                        Dataset definition file\n",
+      "  -o OUTPUT, --output OUTPUT\n",
+      "                        Output name for dataset discovery output (no fileset\n",
+      "                        preprocessing)\n",
+      "  -fo FILESET_OUTPUT, --fileset-output FILESET_OUTPUT\n",
+      "                        Output name for fileset\n",
+      "  -p, --preprocess      Preprocess with dask\n",
+      "  --step-size STEP_SIZE\n",
+      "                        Step size for preprocessing\n",
+      "  --dask-cluster DASK_CLUSTER\n",
+      "                        Dask cluster url\n",
+      "  -as ALLOW_SITES [ALLOW_SITES ...], --allow-sites ALLOW_SITES [ALLOW_SITES ...]\n",
+      "                        List of sites to be allowlisted\n",
+      "  -bs BLOCK_SITES [BLOCK_SITES ...], --block-sites BLOCK_SITES [BLOCK_SITES ...]\n",
+      "                        List of sites to be blocklisted\n",
+      "  -rs REGEX_SITES, --regex-sites REGEX_SITES\n",
+      "                        Regex string to be used to filter the sites\n",
+      "  --query-results-strategy QUERY_RESULTS_STRATEGY\n",
+      "                        Mode for query results selection: [all|manual]\n",
+      "  --replicas-strategy REPLICAS_STRATEGY\n",
+      "                        Mode for selecting replicas for datasets:\n",
+      "                        [manual|round-robin|choose]\n"
+     ]
+    }
+   ],
+   "source": [
+    "!python -m coffea.dataset_tools.dataset_query --help"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e93cb24c-44ed-43f1-8aae-0f6b03c88de0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m coffea.dataset_tools.dataset_query --cli  -d dataset_definition.json"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/coffea/dataset_tools/dataset_query.py
+++ b/coffea/dataset_tools/dataset_query.py
@@ -413,7 +413,7 @@ Some basic commands:
         self.final_output = {}
         for fileset, files in self.replica_results.items():
             self.final_output[fileset] = {
-                "files": {f: "Events" for f in files},
+                "files": files,
                 "metadata": self.replica_results_metadata[fileset],
             }
         return self.final_output

--- a/coffea/dataset_tools/dataset_query.py
+++ b/coffea/dataset_tools/dataset_query.py
@@ -1,0 +1,642 @@
+import argparse
+import gzip
+import json
+import os
+import random
+from collections import defaultdict
+from typing import List
+
+import yaml
+from rich import print
+from rich.console import Console
+from rich.prompt import Confirm, IntPrompt, Prompt
+from rich.table import Table
+from rich.tree import Tree
+
+from . import rucio_utils
+
+
+def print_dataset_query(query, dataset_list, console, selected=[]):
+    table = Table(title=f"Query: [bold red]{query}")
+    table.add_column("Name", justify="left", style="cyan", no_wrap=True)
+    table.add_column("Tag", style="magenta", no_wrap=True)
+    table.add_column("Selected", justify="center")
+    table.row_styles = ["dim", "none"]
+    j = 1
+    for name, conds in dataset_list.items():
+        ic = 0
+        ncond = len(conds)
+        for c, tiers in conds.items():
+            dataset = f"/{name}/{c}/{tiers[0]}"
+            sel = dataset in selected
+            if ic == 0:
+                table.add_row(
+                    name,
+                    f"[bold]({j})[/bold] {c}/{'-'.join(tiers)}",
+                    "[green bold]Y" if sel else "[red]N",
+                    end_section=ic == ncond - 1,
+                )
+            else:
+                table.add_row(
+                    "",
+                    f"[bold]({j})[/bold] {c}/{'-'.join(tiers)}",
+                    "[green bold]Y" if sel else "[red]N",
+                    end_section=ic == ncond - 1,
+                )
+            ic += 1
+            j += 1
+
+    console.print(table)
+
+
+def get_indices_query(input_str: str, maxN: int) -> List[int]:
+    tokens = input_str.strip().split(" ")
+    final_tokens = []
+    for t in tokens:
+        if t.isdigit():
+            if int(t) > maxN:
+                print(
+                    f"[red bold]Requested index {t} larger than available elements {maxN}"
+                )
+                return False
+            final_tokens.append(int(t) - 1)  # index 0
+        elif "-" in t:
+            rng = t.split("-")
+            try:
+                for i in range(
+                    int(rng[0]), int(rng[1]) + 1
+                ):  # including the last index
+                    if i > maxN:
+                        print(
+                            f"[red bold]Requested index {t} larger than available elements {maxN}"
+                        )
+                        return False
+                    final_tokens.append(i - 1)
+            except Exception:
+                print(
+                    "[red]Error! Bad formatting for selection string. Use e.g. 1 4 5-9"
+                )
+                return False
+        elif t == "all":
+            final_tokens = list(range(0, maxN))
+        else:
+            print("[red]Error! Bad formatting for selection string. Use e.g. 1 4 5-9")
+            return False
+    return final_tokens
+
+
+class DataDiscoveryCLI:
+    def __init__(self):
+        self.console = Console()
+        self.rucio_client = None
+        self.selected_datasets = []
+        self.selected_datasets_metadata = []
+        self.last_query = ""
+        self.last_query_tree = None
+        self.last_query_list = None
+        self.sites_allowlist = None
+        self.sites_blocklist = None
+        self.sites_regex = None
+        self.last_replicas_results = None
+        self.final_output = None
+
+        self.replica_results = defaultdict(list)
+        self.replica_results_metadata = {}
+        self.replica_results_bysite = {}
+
+        self.commands = [
+            "help",
+            "login",
+            "query",
+            "query-results",
+            "select",
+            "list-selected",
+            "replicas",
+            "list-replicas",
+            "save",
+            "allow-sites",
+            "block-sites",
+            "regex-sites",
+            "sites-filters",
+            "quit",
+        ]
+
+    def start_cli(self):
+        while True:
+            command = Prompt.ask(">", choices=self.commands)
+            if command == "help":
+                print(
+                    r"""[bold yellow]Welcome to the datasets discovery coffea CLI![/bold yellow]
+Use this CLI tool to query the CMS datasets and to select interactively the grid sites to use for reading the files in your analysis.
+Some basic commands:
+  - [bold cyan]query[/]: Look for datasets with * wildcards (like in DAS)
+  - [bold cyan]select[/]: Select datasets to process further from query results
+  - [bold cyan]replicas[/]: Query rucio to look for files replica and then select the preferred sites
+  - [bold cyan]query-results[/]: List the results of the last dataset query
+  - [bold cyan]list-selected[/]: Print a list of the selected datasets
+  - [bold cyan]list-replicas[/]: Print the selected files replicas for the selected dataset
+  - [bold cyan]sites-filters[/]: show the active sites filters and ask to clear them
+  - [bold cyan]allow-sites[/]: Restrict the grid sites available for replicas query only to the requested list
+  - [bold cyan]block-sites[/]: Exclude grid sites from the available sites for replicas query
+  - [bold cyan]regex-sites[/]: Select sites with a regex for replica queries: e.g.  "T[123]_(FR|IT|BE|CH|DE)_\w+"
+  - [bold cyan]save[/]: Save the replicas query results to file (json or yaml) for further processing
+  - [bold cyan]help[/]: Print this help message
+            """
+                )
+            elif command == "login":
+                self.do_login()
+            elif command == "quit":
+                print("Bye!")
+                break
+            elif command == "query":
+                self.do_query()
+            elif command == "query-results":
+                self.do_query_results()
+            elif command == "select":
+                self.do_select()
+            elif command == "list-selected":
+                self.do_list_selected()
+            elif command == "replicas":
+                self.do_replicas()
+            elif command == "list-replicas":
+                self.do_list_replicas()
+            elif command == "save":
+                self.do_save()
+            elif command == "allow-sites":
+                self.do_allowlist_sites()
+            elif command == "block-sites":
+                self.do_blocklist_sites()
+            elif command == "regex-sites":
+                self.do_regex_sites()
+            elif command == "sites-filters":
+                self.do_sites_filters()
+            else:
+                break
+
+    def do_login(self, proxy=None):
+        """Login to the rucio client. Optionally a specific proxy file can be passed to the command.
+        If the proxy file is not specified, `voms-proxy-info` is used"""
+        if proxy:
+            self.rucio_client = rucio_utils.get_rucio_client(proxy)
+        else:
+            self.rucio_client = rucio_utils.get_rucio_client()
+        print(self.rucio_client)
+
+    def do_whoami(self):
+        # Your code here
+        if not self.rucio_client:
+            print("First [bold]login (L)[/] to the rucio server")
+            return
+        print(self.rucio_client.whoami())
+
+    def do_query(self, query=None):
+        # Your code here
+        if query is None:
+            query = Prompt.ask(
+                "[yellow bold]Query for[/]",
+            )
+        with self.console.status(f"Querying rucio for: [bold red]{query}[/]"):
+            outlist, outtree = rucio_utils.query_dataset(
+                query,
+                client=self.rucio_client,
+                tree=True,
+                scope="cms",  # TODO configure scope
+            )
+            # Now let's print the results as a tree
+            print_dataset_query(query, outtree, self.console, self.selected_datasets)
+            self.last_query = query
+            self.last_query_list = outlist
+            self.last_query_tree = outtree
+        print("Use the command [bold red]select[/] to selected the datasets")
+
+    def do_query_results(self):
+        if self.last_query_list:
+            print_dataset_query(
+                self.last_query,
+                self.last_query_tree,
+                self.console,
+                self.selected_datasets,
+            )
+        else:
+            print("First [bold red]query (Q)[/] for a dataset")
+
+    def do_select(self, selection=None, metadata=None):
+        """Selected the datasets from the list of query results. Input a list of indices
+        also with range 4-6 or "all"."""
+        if not self.last_query_list:
+            print("First [bold red]query (Q)[/] for a dataset")
+            return
+
+        if selection is None:
+            selection = Prompt.ask(
+                "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+            )
+        final_tokens = get_indices_query(selection, len(self.last_query_list))
+        if not final_tokens:
+            return
+
+        Nresults = len(self.last_query_list)
+        print("[cyan]Selected datasets:")
+
+        for s in final_tokens:
+            if s < Nresults:
+                self.selected_datasets.append(self.last_query_list[s])
+                if metadata:
+                    self.selected_datasets_metadata.append(metadata)
+                else:
+                    self.selected_datasets_metadata.append({})
+                print(f"- ({s+1}) {self.last_query_list[s]}")
+            else:
+                print(
+                    f"[red]The requested dataset is not in the list. Please insert a position <={Nresults}"
+                )
+
+    def do_list_selected(self):
+        print("[cyan]Selected datasets:")
+        table = Table(title="Selected datasets")
+        table.add_column("Index", justify="left", style="cyan", no_wrap=True)
+        table.add_column("Dataset", style="magenta", no_wrap=True)
+        table.add_column("Replicas selected", justify="center")
+        table.add_column("N. of files", justify="center")
+        for i, ds in enumerate(self.selected_datasets):
+            table.add_row(
+                str(i + 1),
+                ds,
+                "[green bold]Y" if ds in self.replica_results else "[red]N",
+                (
+                    str(len(self.replica_results[ds]))
+                    if ds in self.replica_results
+                    else "-"
+                ),
+            )
+        self.console.print(table)
+
+    def do_replicas(self, mode=None, selection=None):
+        """Query Rucio for replicas.
+        mode: - None:  ask the user about the mode
+              - round-robin (take files randomly from available sites),
+              - choose: ask the user to choose from a list of sites
+              - first: take the first site from the rucio query
+        selection: list of indices or 'all' to select all the selected datasets for replicas query
+        """
+        if selection is None:
+            selection = Prompt.ask(
+                "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+            )
+        indices = get_indices_query(selection, len(self.selected_datasets))
+        if not indices:
+            return
+        datasets = [
+            (self.selected_datasets[ind], self.selected_datasets_metadata[ind])
+            for ind in indices
+        ]
+
+        for dataset, dataset_metadata in datasets:
+            with self.console.status(
+                f"Querying rucio for replicas: [bold red]{dataset}[/]"
+            ):
+                try:
+                    (
+                        outfiles,
+                        outsites,
+                        sites_counts,
+                    ) = rucio_utils.get_dataset_files_replicas(
+                        dataset,
+                        allowlist_sites=self.sites_allowlist,
+                        blocklist_sites=self.sites_blocklist,
+                        regex_sites=self.sites_regex,
+                        mode="full",
+                        client=self.rucio_client,
+                    )
+                except Exception as e:
+                    print(f"\n[red bold] Exception: {e}[/]")
+                    return
+                self.last_replicas_results = (outfiles, outsites, sites_counts)
+
+            print(f"[cyan]Sites availability for dataset: [red]{dataset}")
+            table = Table(title="Available replicas")
+            table.add_column("Index", justify="center")
+            table.add_column("Site", justify="left", style="cyan", no_wrap=True)
+            table.add_column("Files", style="magenta", no_wrap=True)
+            table.add_column("Availability", justify="center")
+            table.row_styles = ["dim", "none"]
+            Nfiles = len(outfiles)
+
+            sorted_sites = dict(
+                sorted(sites_counts.items(), key=lambda x: x[1], reverse=True)
+            )
+            for i, (site, stat) in enumerate(sorted_sites.items()):
+                table.add_row(
+                    str(i), site, f"{stat} / {Nfiles}", f"{stat*100/Nfiles:.1f}%"
+                )
+
+            self.console.print(table)
+            if mode is None:
+                mode = Prompt.ask(
+                    "Select sites",
+                    choices=["round-robin", "choose", "first", "quit"],
+                    default="round-robin",
+                )
+
+            files_by_site = defaultdict(list)
+
+            if mode == "choose":
+                ind = list(
+                    map(
+                        int,
+                        Prompt.ask("Enter list of sites index to be used").split(" "),
+                    )
+                )
+                sites_to_use = [list(sorted_sites.keys())[i] for i in ind]
+                print(f"Filtering replicas with [green]: {' '.join(sites_to_use)}")
+
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    random.shuffle(sites_to_use)
+                    found = False
+                    # loop on shuffled selected sites until one is found
+                    for site in sites_to_use:
+                        try:
+                            iS = sites.index(site)
+                            output.append(files[iS])
+                            files_by_site[sites[iS]].append(files[iS])
+                            found = True
+                            break  # keep only one replica
+                        except ValueError:
+                            # if the index is not found just go to the next site
+                            pass
+
+                    if not found:
+                        print(
+                            f"[bold red]No replica found compatible with sites selection for file #{ifile}. The available sites are:"
+                        )
+                        for f, s in zip(files, sites):
+                            print(f"\t- [green]{s} [cyan]{f}")
+                        return
+
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "round-robin":
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    # selecting randomly from the sites
+                    iS = random.randint(0, len(sites) - 1)
+                    output.append(files[iS])
+                    files_by_site[sites[iS]].append(files[iS])
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "first":
+                output = []
+                for ifile, (files, sites) in enumerate(zip(outfiles, outsites)):
+                    output.append(files[0])
+                    files_by_site[sites[0]].append(files[0])
+                self.replica_results[dataset] = output
+                self.replica_results_metadata[dataset] = dataset_metadata
+
+            elif mode == "quit":
+                print("[orange]Doing nothing...")
+                return
+
+            self.replica_results_bysite[dataset] = files_by_site
+
+            # Now let's print the results
+            tree = Tree(label=f"[bold orange]Replicas for [green]{dataset}")
+            for site, files in files_by_site.items():
+                T = tree.add(f"[green]{site}")
+                for f in files:
+                    T.add(f"[cyan]{f}")
+            self.console.print(tree)
+
+        # Building an uproot compatible output
+        self.final_output = {}
+        for fileset, files in self.replica_results.items():
+            self.final_output[fileset] = {
+                "files": {f: "Events" for f in files},
+                "metadata": self.replica_results_metadata[fileset],
+            }
+        return self.final_output
+
+    @property
+    def as_dict(self):
+        return self.final_output
+
+    def do_allowlist_sites(self, sites=None):
+        if sites is None:
+            sites = Prompt.ask(
+                "[yellow]Restrict the available sites to (comma-separated list)"
+            ).split(",")
+        if self.sites_allowlist is None:
+            self.sites_allowlist = sites
+        else:
+            self.sites_allowlist += sites
+        print("[green]Allowlisted sites:")
+        for s in self.sites_allowlist:
+            print(f"- {s}")
+
+    def do_blocklist_sites(self, sites=None):
+        if sites is None:
+            sites = Prompt.ask(
+                "[yellow]Exclude the sites (comma-separated list)"
+            ).split(",")
+        if self.sites_blocklist is None:
+            self.sites_blocklist = sites
+        else:
+            self.sites_blocklist += sites
+        print("[red]Blocklisted sites:")
+        for s in self.sites_blocklist:
+            print(f"- {s}")
+
+    def do_regex_sites(self, regex=None):
+        if regex is None:
+            regex = Prompt.ask("[yellow]Regex to restrict the available sites")
+        if len(regex):
+            self.sites_regex = rf"{regex}"
+            print(f"New sites regex: [cyan]{self.sites_regex}")
+
+    def do_sites_filters(self, ask_clear=True):
+        print("[green bold]Allow-listed sites:")
+        if self.sites_allowlist:
+            for s in self.sites_allowlist:
+                print(f"- {s}")
+
+        print("[bold red]Block-listed sites:")
+        if self.sites_blocklist:
+            for s in self.sites_blocklist:
+                print(f"- {s}")
+
+        print(f"[bold cyan]Sites regex: [italics]{self.sites_regex}")
+
+        if ask_clear:
+            if Confirm.ask("Clear sites restrinction?", default=False):
+                self.sites_allowlist = None
+                self.sites_blocklist = None
+                self.sites_regex = None
+                print("[bold green]Sites filters cleared")
+
+    def do_list_replicas(self):
+        selection = Prompt.ask(
+            "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
+        )
+        indices = get_indices_query(selection, len(self.selected_datasets))
+        datasets = [self.selected_datasets[ind] for ind in indices]
+
+        for dataset in datasets:
+            if dataset not in self.replica_results:
+                print(
+                    f"[red bold]No replica info for dataset {dataset}. You need to selected the replicas with [cyan] replicas [/cyan] command[/]"
+                )
+                return
+            tree = Tree(label=f"[bold orange]Replicas for [/][green]{dataset}[/]")
+            for site, files in self.replica_results_bysite[dataset].items():
+                T = tree.add(f"[green]{site}")
+                for f in files:
+                    T.add(f"[cyan]{f}")
+
+            self.console.print(tree)
+
+    def do_save(self, filename=None):
+        """Save the replica information in yaml format"""
+        if not filename:
+            filename = Prompt.ask(
+                "[yellow bold]Output file name (.yaml or .json)", default="output.json"
+            )
+        format = os.path.splitext(filename)[1]
+        if not format:
+            raise Exception("[red] Please use a .json or .yaml filename for the output")
+        with open(filename, "w") as file:
+            if format == ".yaml":
+                yaml.dump(self.final_output, file, default_flow_style=False)
+            elif format == ".json":
+                json.dump(self.final_output, file, indent=2)
+        print(f"[green]File {filename} saved!")
+
+    def load_dataset_definition(
+        self,
+        dataset_definition,
+        query_results_strategy="all",
+        replicas_strategy="round-robin",
+    ):
+        """
+        Initialize the DataDiscoverCLI by querying a set of datasets defined in `dataset_definitions`
+        and selected results and replicas following the options.
+
+        - query_results_strategy:  "all" or "manual" to be prompt for selection
+        - replicas_strategy:
+            - "round-robin": select randomly from the available sites for each file
+            - "choose": filter the sites with a list of indices for all the files
+            - "first": take the first result returned by rucio
+            - "manual": to be prompt for manual decision dataset by dataset
+        """
+        for dataset_query, dataset_meta in dataset_definition.items():
+            print(f"\nProcessing query: {dataset_query}")
+            # Adding queries
+            self.do_query(dataset_query)
+            # Now selecting the results depending on the interactive mode or not.
+            # Metadata are passed to the selection function to associated them with the selected dataset.
+            if query_results_strategy not in ["all", "manual"]:
+                raise ValueError(
+                    "Invalid query-results-strategy option: please choose between: manual|all"
+                )
+            elif query_results_strategy == "manual":
+                self.do_select(selection=None, metadata=dataset_meta)
+            else:
+                self.do_select(selection="all", metadata=dataset_meta)
+
+        # Now list all
+        self.do_list_selected()
+
+        # selecting replicas
+        self.do_sites_filters(ask_clear=False)
+        print("Getting replicas")
+        if replicas_strategy == "manual":
+            out_replicas = self.do_replicas(mode=None, selection="all")
+        else:
+            if replicas_strategy not in ["round-robin", "choose", "first"]:
+                raise ValueError(
+                    "Invalid replicas-strategy: please choose between manual|round-robin|choose|first"
+                )
+            out_replicas = self.do_replicas(mode=replicas_strategy, selection="all")
+        # Now list all
+        self.do_list_selected()
+        return out_replicas
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cli", help="Start the dataset discovery CLI", action="store_true"
+    )
+    parser.add_argument(
+        "-d",
+        "--dataset-definition",
+        help="Dataset definition file",
+        type=str,
+        required=False,
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output name for dataset discovery output (no fileset preprocessing)",
+        type=str,
+        required=False,
+        default="output_dataset.json",
+    )
+    parser.add_argument(
+        "-as",
+        "--allow-sites",
+        help="List of sites to be allowlisted",
+        nargs="+",
+        type=str,
+    )
+    parser.add_argument(
+        "-bs",
+        "--block-sites",
+        help="List of sites to be blocklisted",
+        nargs="+",
+        type=str,
+    )
+    parser.add_argument(
+        "-rs",
+        "--regex-sites",
+        help="Regex string to be used to filter the sites",
+        type=str,
+    )
+    parser.add_argument(
+        "--query-results-strategy",
+        help="Mode for query results selection: [all|manual]",
+        type=str,
+        default="all",
+    )
+    parser.add_argument(
+        "--replicas-strategy",
+        help="Mode for selecting replicas for datasets: [manual|round-robin|first|choose]",
+        default="round-robin",
+        required=False,
+    )
+    args = parser.parse_args()
+
+    cli = DataDiscoveryCLI()
+
+    if args.allow_sites:
+        cli.sites_allowlist = args.allow_sites
+    if args.block_sites:
+        cli.sites_blocklist = args.block_sites
+    if args.regex_sites:
+        cli.sites_regex = args.regex_sites
+
+    if args.dataset_definition:
+        with open(args.dataset_definition) as file:
+            dd = json.load(file)
+        cli.load_dataset_definition(
+            dd,
+            query_results_strategy=args.query_results_strategy,
+            replicas_strategy=args.replicas_strategy,
+        )
+        # Save
+        if args.output:
+            cli.do_save(filename=args.output)
+
+    if args.cli:
+        cli.start_cli()

--- a/coffea/dataset_tools/rucio_utils.py
+++ b/coffea/dataset_tools/rucio_utils.py
@@ -1,0 +1,313 @@
+# import getpass
+import json
+import os
+import re
+import subprocess
+from collections import defaultdict
+
+from rucio.client import Client
+
+# Rucio needs the default configuration --> taken from CMS cvmfs defaults
+if "RUCIO_HOME" not in os.environ:
+    os.environ["RUCIO_HOME"] = "/cvmfs/cms.cern.ch/rucio/current"
+
+
+def get_proxy_path() -> str:
+    """
+    Checks if the VOMS proxy exists and if it is valid
+    for at least 1 hour.
+    If it exists, returns the path of it"""
+    try:
+        subprocess.run("voms-proxy-info -exists -hours 1", shell=True, check=True)
+    except subprocess.CalledProcessError:
+        raise Exception(
+            "VOMS proxy expirend or non-existing: please run `voms-proxy-init -voms cms -rfc --valid 168:0`"
+        )
+
+    # Now get the path of the certificate
+    proxy = subprocess.check_output(
+        "voms-proxy-info -path", shell=True, text=True
+    ).strip()
+    return proxy
+
+
+def get_rucio_client(proxy=None) -> Client:
+    """
+    Open a client to the CMS rucio server using x509 proxy.
+
+    Parameters
+    ----------
+        proxy : str, optional
+            Use the provided proxy file if given, if not use `voms-proxy-info` to get the current active one.
+
+    Returns
+    -------
+        nativeClient: rucio.Client
+            Rucio client
+    """
+    try:
+        if not proxy:
+            proxy = get_proxy_path()
+        nativeClient = Client()
+        return nativeClient
+
+    except Exception as e:
+        print("Wrong Rucio configuration, impossible to create client")
+        raise e
+
+
+def get_xrootd_sites_map():
+    """
+    The mapping between RSE (sites) and the xrootd prefix rules is read
+    from `/cvmfs/cms/cern.ch/SITECONF/*site*/storage.json`.
+
+    This function returns the list of xrootd prefix rules for each site.
+    """
+    sites_xrootd_access = defaultdict(dict)
+    # TODO Do not rely on local sites_map cache. Just reload it?
+    if not os.path.exists(".sites_map.json"):
+        print("Loading SITECONF info")
+        sites = [
+            (s, "/cvmfs/cms.cern.ch/SITECONF/" + s + "/storage.json")
+            for s in os.listdir("/cvmfs/cms.cern.ch/SITECONF/")
+            if s.startswith("T")
+        ]
+        for site_name, conf in sites:
+            if not os.path.exists(conf):
+                continue
+            try:
+                data = json.load(open(conf))
+            except Exception:
+                continue
+            for site in data:
+                if site["type"] != "DISK":
+                    continue
+                if site["rse"] is None:
+                    continue
+                for proc in site["protocols"]:
+                    if proc["protocol"] == "XRootD":
+                        if proc["access"] not in ["global-ro", "global-rw"]:
+                            continue
+                        if "prefix" not in proc:
+                            if "rules" in proc:
+                                for rule in proc["rules"]:
+                                    sites_xrootd_access[site["rse"]][
+                                        rule["lfn"]
+                                    ] = rule["pfn"]
+                        else:
+                            sites_xrootd_access[site["rse"]] = proc["prefix"]
+        json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
+
+    return json.load(open(".sites_map.json"))
+
+
+def _get_pfn_for_site(path, rules):
+    """
+    Utility function that converts the file path to a valid pfn matching
+    the file path with the site rules (regexes).
+    """
+    if isinstance(rules, dict):
+        for rule, pfn in rules.items():
+            if m := re.match(rule, path):
+                grs = m.groups()
+                for i in range(len(grs)):
+                    pfn = pfn.replace(f"${i+1}", grs[i])
+                return pfn
+    else:
+        return rules + "/" + path
+
+
+def get_dataset_files_replicas(
+    dataset,
+    allowlist_sites=None,
+    blocklist_sites=None,
+    regex_sites=None,
+    mode="full",
+    partial_allowed=False,
+    client=None,
+    scope="cms",
+):
+    """
+    This function queries the Rucio server to get information about the location
+    of all the replicas of the files in a CMS dataset.
+
+    The sites can be filtered in 3 different ways:
+    - `allowlist_sites`: list of sites to select from. If the file is not found there, raise an Exception.
+    - `blocklist_sites`: list of sites to avoid. If the file has no left site, raise an Exception
+    - `regex_sites`: regex expression to restrict the list of sites.
+
+    The fileset returned by the function is controlled by the `mode` parameter:
+    - "full": returns the full set of replicas and sites (passing the filtering parameters)
+    - "first": returns the first replica found for each file
+    - "best": to be implemented (ServiceX..)
+    - "roundrobin": try to distribute the replicas over different sites
+
+    Parameters
+    ----------
+
+        dataset: str
+        allowlist_sites: list
+        blocklist_sites: list
+        regex_sites: list
+        mode:  str, default "full"
+        client: rucio Client, optional
+        partial_allowed: bool, default False
+        scope:  rucio scope, "cms"
+
+    Returns
+    -------
+        files: list
+           depending on the `mode` option.
+           - If `mode=="full"`, returns the complete list of replicas for each file in the dataset
+           - If `mode=="first"`, returns only the first replica for each file.
+
+        sites: list
+           depending on the `mode` option.
+           - If `mode=="full"`, returns the list of sites where the file replica is available for each file in the dataset
+           - If `mode=="first"`, returns a list of sites for the first replica of each file.
+
+        sites_counts: dict
+           Metadata counting the coverage of the dataset by site
+
+    """
+    sites_xrootd_prefix = get_xrootd_sites_map()
+    client = client if client else get_rucio_client()
+    outsites = []
+    outfiles = []
+    for filedata in client.list_replicas([{"scope": scope, "name": dataset}]):
+        outfile = []
+        outsite = []
+        rses = filedata["rses"]
+        found = False
+        if allowlist_sites:
+            for site in allowlist_sites:
+                if site in rses:
+                    # Check actual availability
+                    meta = filedata["pfns"][rses[site][0]]
+                    if (
+                        meta["type"] != "DISK"
+                        or meta["volatile"]
+                        or filedata["states"][site] != "AVAILABLE"
+                        or site not in sites_xrootd_prefix
+                    ):
+                        continue
+                    outfile.append(
+                        _get_pfn_for_site(filedata["name"], sites_xrootd_prefix[site])
+                    )
+                    outsite.append(site)
+                    found = True
+
+            if not found and not partial_allowed:
+                raise Exception(
+                    f"No SITE available in the allowlist for file {filedata['name']}"
+                )
+        else:
+            possible_sites = list(rses.keys())
+            if blocklist_sites:
+                possible_sites = list(
+                    filter(lambda key: key not in blocklist_sites, possible_sites)
+                )
+
+            if len(possible_sites) == 0 and not partial_allowed:
+                raise Exception(f"No SITE available for file {filedata['name']}")
+
+            # now check for regex
+            for site in possible_sites:
+                if regex_sites:
+                    if re.search(regex_sites, site):
+                        # Check actual availability
+                        meta = filedata["pfns"][rses[site][0]]
+                        if (
+                            meta["type"] != "DISK"
+                            or meta["volatile"]
+                            or filedata["states"][site] != "AVAILABLE"
+                            or site not in sites_xrootd_prefix
+                        ):
+                            continue
+                        outfile.append(
+                            _get_pfn_for_site(
+                                filedata["name"], sites_xrootd_prefix[site]
+                            )
+                        )
+                        outsite.append(site)
+                        found = True
+                else:
+                    # Just take the first one
+                    # Check actual availability
+                    meta = filedata["pfns"][rses[site][0]]
+                    if (
+                        meta["type"] != "DISK"
+                        or meta["volatile"]
+                        or filedata["states"][site] != "AVAILABLE"
+                        or site not in sites_xrootd_prefix
+                    ):
+                        continue
+                    outfile.append(
+                        _get_pfn_for_site(filedata["name"], sites_xrootd_prefix[site])
+                    )
+                    outsite.append(site)
+                    found = True
+
+        if not found and not partial_allowed:
+            raise Exception(f"No SITE available for file {filedata['name']}")
+        else:
+            if mode == "full":
+                outfiles.append(outfile)
+                outsites.append(outsite)
+            elif mode == "first":
+                outfiles.append(outfile[0])
+                outsites.append(outsite[0])
+            else:
+                raise NotImplementedError(f"Mode {mode} not yet implemented!")
+
+    # Computing replicas by site:
+    sites_counts = defaultdict(int)
+    if mode == "full":
+        for sites_by_file in outsites:
+            for site in sites_by_file:
+                sites_counts[site] += 1
+    elif mode == "first":
+        for site_by_file in outsites:
+            sites_counts[site] += 1
+
+    return outfiles, outsites, sites_counts
+
+
+def query_dataset(
+    query: str, client=None, tree: bool = False, datatype="container", scope="cms"
+):
+    """
+    This function uses the rucio client to query for containers or datasets.
+
+    Parameters
+    ---------
+        query: str = query to filter datasets / containers with the rucio list_dids functions
+        client: rucio client
+        tree: bool = if True return the results splitting the dataset name in parts parts
+        datatype: "container/dataset":  rucio terminology. "Container"==CMS dataset. "Dataset" == CMS block.
+        scope: "cms". Rucio instance
+
+    Returns
+    -------
+       list of containers/datasets
+
+       if tree==True, returns the list of dataset and also a dictionary decomposing the datasets
+       names in the 1st command part and a list of available 2nd parts.
+
+    """
+    client = client if client else get_rucio_client()
+    out = list(
+        client.list_dids(
+            scope=scope, filters={"name": query, "type": datatype}, long=False
+        )
+    )
+    if tree:
+        outdict = {}
+        for dataset in out:
+            split = dataset[1:].split("/")
+            if split[0] not in outdict:
+                outdict[split[0]] = defaultdict(list)
+            outdict[split[0]][split[1]].append(split[2])
+        return out, outdict
+    else:
+        return out

--- a/coffea/version.py
+++ b/coffea/version.py
@@ -30,7 +30,7 @@
 
 import re
 
-__version__ = "0.7.21"
+__version__ = "0.7.23"
 version = __version__
 version_info = tuple(re.split(r"[-\.]", __version__))
 

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,10 @@ EXTRAS_REQUIRE["dev"] = [
     "pyinstrument",
     "ipython",
 ]
+EXTRAS_REQUIRE["rucio"] = [
+    "rucio-clients>=32;python_version>'3.8'",
+    "rucio-clients<32;python_version<'3.9'",
+]
 
 setup(
     name="coffea",

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ EXTRAS_REQUIRE["dev"] = [
 EXTRAS_REQUIRE["rucio"] = [
     "rucio-clients>=32;python_version>'3.8'",
     "rucio-clients<32;python_version<'3.9'",
+    "pyyaml",
 ]
 
 setup(


### PR DESCRIPTION
This PR aims to backport @valsdav's dataset tools to coffea 0.7.x.
The preprocessing part has to be removed since that is tied to coffea 202x.