### PR TITLE
fix: Do not add trailing slash in xrootd urls

### DIFF
--- a/src/coffea/dataset_tools/dataset_query.py
+++ b/src/coffea/dataset_tools/dataset_query.py
@@ -352,7 +352,9 @@ Some basic commands:
                 ind = list(
                     map(
                         int,
-                        Prompt.ask("Enter list of sites index to be used", default="0").split(" "),
+                        Prompt.ask(
+                            "Enter list of sites index to be used", default="0"
+                        ).split(" "),
                     )
                 )
                 sites_to_use = [list(sorted_sites.keys())[i] for i in ind]

--- a/src/coffea/dataset_tools/dataset_query.py
+++ b/src/coffea/dataset_tools/dataset_query.py
@@ -352,7 +352,7 @@ Some basic commands:
                 ind = list(
                     map(
                         int,
-                        Prompt.ask("Enter list of sites index to be used").split(" "),
+                        Prompt.ask("Enter list of sites index to be used", default="0").split(" "),
                     )
                 )
                 sites_to_use = [list(sorted_sites.keys())[i] for i in ind]

--- a/src/coffea/dataset_tools/rucio_utils.py
+++ b/src/coffea/dataset_tools/rucio_utils.py
@@ -2,8 +2,8 @@
 import json
 import os
 import re
-import time
 import subprocess
+import time
 from collections import defaultdict
 
 from rucio.client import Client
@@ -100,9 +100,9 @@ def get_xrootd_sites_map():
                         if "prefix" not in proc:
                             if "rules" in proc:
                                 for rule in proc["rules"]:
-                                    sites_xrootd_access[site["rse"]][
-                                        rule["lfn"]
-                                    ] = rule["pfn"]
+                                    sites_xrootd_access[site["rse"]][rule["lfn"]] = (
+                                        rule["pfn"]
+                                    )
                         else:
                             sites_xrootd_access[site["rse"]] = proc["prefix"]
 

--- a/src/coffea/dataset_tools/rucio_utils.py
+++ b/src/coffea/dataset_tools/rucio_utils.py
@@ -125,7 +125,7 @@ def _get_pfn_for_site(path, rules):
                 return pfn
     else:
         # not adding any slash as the path usually starts with it
-        return rules + path
+        return rules + "/" + path.removeprefix("/")
 
 
 def get_dataset_files_replicas(

--- a/src/coffea/dataset_tools/rucio_utils.py
+++ b/src/coffea/dataset_tools/rucio_utils.py
@@ -2,6 +2,7 @@
 import json
 import os
 import re
+import time
 import subprocess
 from collections import defaultdict
 
@@ -64,8 +65,16 @@ def get_xrootd_sites_map():
     This function returns the list of xrootd prefix rules for each site.
     """
     sites_xrootd_access = defaultdict(dict)
-    # TODO Do not rely on local sites_map cache. Just reload it?
-    if not os.path.exists(".sites_map.json"):
+    # Check if the cache file has been modified in the last 10 minutes
+    cache_valid = False
+    if os.path.exists(".sites_map.json"):
+        file_time = os.path.getmtime(".sites_map.json")
+        current_time = time.time()
+        ten_minutes_ago = current_time - 600
+        if file_time > ten_minutes_ago:
+            cache_valid = True
+
+    if not os.path.exists(".sites_map.json") or not cache_valid:
         print("Loading SITECONF info")
         sites = [
             (s, "/cvmfs/cms.cern.ch/SITECONF/" + s + "/storage.json")
@@ -91,11 +100,12 @@ def get_xrootd_sites_map():
                         if "prefix" not in proc:
                             if "rules" in proc:
                                 for rule in proc["rules"]:
-                                    sites_xrootd_access[site["rse"]][rule["lfn"]] = (
-                                        rule["pfn"]
-                                    )
+                                    sites_xrootd_access[site["rse"]][
+                                        rule["lfn"]
+                                    ] = rule["pfn"]
                         else:
                             sites_xrootd_access[site["rse"]] = proc["prefix"]
+
         json.dump(sites_xrootd_access, open(".sites_map.json", "w"))
 
     return json.load(open(".sites_map.json"))
@@ -114,7 +124,8 @@ def _get_pfn_for_site(path, rules):
                     pfn = pfn.replace(f"${i+1}", grs[i])
                 return pfn
     else:
-        return rules + "/" + path
+        # not adding any slash as the path usually starts with it
+        return rules + path
 
 
 def get_dataset_files_replicas(


### PR DESCRIPTION
Now the sites map cache file is invalidated after 10 mins to avoid stale information. 

Fixes #1053 