### PR TITLE
feat: Request all arrays from uproot at once inside dask task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward>=2.6.3",
-  "uproot>=5.3.0",
+  "uproot!=5.3.3,>=5.3.0",
   "dask[array]>=2024.3.0;python_version>'3.8'",
   "dask[array]>=2023.4.0;python_version<'3.9'",
   "dask-awkward>=2024.3.0",

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -88,6 +88,7 @@ class _TranslatedMapping:
 
 class _OnlySliceableAs:
     """A workaround for how PreloadedSourceMapping works"""
+
     def __init__(self, array, expected_slice):
         self._array = array
         self._expected_slice = expected_slice
@@ -163,8 +164,7 @@ class _map_schema_uproot(_map_schema_base):
             how=dict,
         )
         source_arrays = {
-            k: _OnlySliceableAs(v, slice(start, stop))
-            for k, v in arrays.items()
+            k: _OnlySliceableAs(v, slice(start, stop)) for k, v in arrays.items()
         }
         mapping = PreloadedSourceMapping(
             PreloadedOpener(uuidpfn), start, stop, access_log=None

--- a/src/coffea/nanoevents/transforms.py
+++ b/src/coffea/nanoevents/transforms.py
@@ -477,7 +477,8 @@ def nestedindex(stack):
 
 def item(stack):
     field = stack.pop()
-    stack.append(stack.pop()[field])
+    array = stack.pop()
+    stack.append(array[field])
 
 
 def eventindex(stack):


### PR DESCRIPTION
So we can do more IO optimizations inside uproot's source (e.g. coalesced reads, more concurrent decompression)

FYI @jpivarski  while working on this I found that uproot 5.3.3 broke `test_nanoevents_delphes.py` and `test_nanoevents_treemaker.py`.
https://github.com/scikit-hep/uproot5/compare/v5.3.2...v5.3.3 doesn't suggest anything obvious