### PR TITLE
feat: use tree reduction to aggregate files in preprocessing

### DIFF
--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -322,7 +322,7 @@ def preprocess(
 
         split_every = 8
 
-        files_trl_label = f"{name}"
+        files_trl_label = f"preprocess-{name}"
         files_trl_token = dask.base.tokenize(dak_norm_files, concat_fn, split_every)
         files_trl_name = f"{files_trl_label}-{files_trl_token}"
         files_trl_tree_node_name = f"{files_trl_label}-tree-node-{files_trl_token}"


### PR DESCRIPTION
Preprocessing used to fail with `RecursionError` when enough files were included (#1078). Following helpful advice from @lgray, this applies the exact same method as https://github.com/dask-contrib/dask-awkward/pull/479 to resolve the problem by using a tree reduction strategy.

This seems to have worked as a rather clean copy/paste with no real changes apart from the paths to all the imported objects and functions. Perhaps that is not so surprising given that the approach is generic, but it did make me slightly suspicious at first. I did not find anything wrong with it myself so far. I was also testing with `sys.setrecursionlimit(200)` to more quickly hit the error. I don't _think_ that this is an issue, but wanted to mention it to be sure.

I am not very familiar with the internals here and only have a rough understanding of everything happening. In addition, my test case is running distributed on a facility (which works since the relevant code only is needed on the head node). I can confirm that these changes do resolve the issue in my test setup, but a critical look / other tests would be very welcome.

resolves #1078