### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,39 +60,45 @@ jobs:
       run: |
         echo "INSTALL_EXTRAS='[dev,parsl,dask,servicex]'" >> $GITHUB_ENV
 
+    - name: Install uv
+      run: python -m pip install --upgrade uv
+
     - name: Install dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip setuptools wheel
         # mltool installs
+        # c.f. https://github.com/astral-sh/uv/issues/3437
         python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-        python -m pip install xgboost
-        python -m pip install 'tritonclient[grpc,http]!=2.41.0'
+        uv pip install --system xgboost
+        uv pip install --system 'tritonclient[grpc,http]!=2.41.0'
         # install checked out coffea
-        python -m pip install -q -e '.[dev,parsl,dask,spark]' --upgrade --upgrade-strategy eager
-        python -m pip list
+        uv pip install --system -q '.[dev,parsl,dask,spark]' --upgrade
+        uv pip list --system
         java -version
     - name: Install dependencies (MacOS)
       if: matrix.os == 'macOS-latest'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip setuptools wheel
         # mltool installs
+        # c.f. https://github.com/astral-sh/uv/issues/3437
         python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-        python -m pip install xgboost
+        uv pip install --system xgboost
         # install checked out coffea
-        python -m pip install -q -e '.[dev,dask,spark]' --upgrade --upgrade-strategy eager
-        python -m pip list
+        uv pip install --system -q '.[dev,dask,spark]' --upgrade
+        uv pip list --system
         java -version
     - name: Install dependencies (Windows)
       if: matrix.os == 'windows-latest'
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        uv pip install --system --upgrade pip setuptools wheel
         # mltool installs
+        # c.f. https://github.com/astral-sh/uv/issues/3437
         python -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-        python -m pip install xgboost
+        uv pip install --system xgboost
         # install checked out coffea
-        python -m pip install -q -e '.[dev,dask]' --upgrade --upgrade-strategy eager
-        python -m pip list
+        uv pip install --system -q '.[dev,dask]' --upgrade
+        uv pip list --system
         java -version
 
     - name: Start triton server with example model
@@ -146,10 +152,10 @@ jobs:
     - name: Construct conda environment
       shell: bash -l {0}
       run: |
-        conda create --yes --prefix ./coffea-conda-test-env -c conda-forge python=${{ matrix.python-version }} ndcctools
+        conda create --yes --prefix ./coffea-conda-test-env -c conda-forge python=${{ matrix.python-version }} ndcctools uv
         conda activate ./coffea-conda-test-env
-        python -m pip install .
-        python -m pip install pytest
+        uv pip install --system .
+        uv pip install --system pytest
     - name: Test with pytest
       run: |
         conda run --prefix ./coffea-conda-test-env pytest tests/test_taskvine.py
@@ -192,7 +198,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Build package for PyPI
       run: |
-        python -m pip install pip hatch --upgrade
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade hatch
         python -m hatch build -t sdist -t wheel
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Build package for PyPI
       run: |
-        python -m pip install --upgrade uv
-        uv pip install --system --upgrade hatch
-        python -m hatch build -t sdist -t wheel
+        pipx run hatch build -t sdist -t wheel
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.14
       with:


### PR DESCRIPTION
* Use 'uv pip' for all calls to 'pip install' and 'pip uninstall' in CI workflows.
   - c.f. https://github.com/astral-sh/uv/
* Fall back to 'python -m pip' for issue with alternative package index.
   - c.f. https://github.com/astral-sh/uv/issues/3437
* Use '--upgrade' as '--upgrade' uses '--resolution highest' by default, which is similar to the 'eager' upgrade strategy in pip.