### PR TITLE
build: Disallow uproots with known form manipulation issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dependencies = [
   "awkward>=2.6.3",
-  "uproot!=5.3.3,>=5.3.0",
+  "uproot>=5.3.0,!=5.3.3,!=5.3.4,!=5.3.5",
   "dask[array]>=2024.3.0;python_version>'3.8'",
   "dask[array]>=2023.4.0;python_version<'3.9'",
   "dask-awkward>=2024.3.0",


### PR DESCRIPTION
* This will be fixed in uproot v5.3.6 given https://github.com/scikit-hep/uproot5/pull/1209#pullrequestreview-2044483928, but will remedy installation issues for Issue https://github.com/CoffeaTeam/coffea/issues/1080.