### PR TITLE
fix: add zero photon charge and fix their cutBased id

### DIFF
--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -292,12 +292,25 @@ _set_repr_name("Tau")
 class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     """NanoAOD photon object"""
 
-    LOOSE = 0
-    "cutBasedBitmap bit position"
-    MEDIUM = 1
-    "cutBasedBitmap bit position"
-    TIGHT = 2
-    "cutBasedBitmap bit position"
+    @classmethod
+    def _initialize_cutbased(cls, fields):
+        """Initialize cut-based selection values based on the fields"""
+        if "cutBased" in fields:
+            cls.FAIL = 0
+            """cutBased selection minimum value"""
+            cls.LOOSE = 1
+            """cutBased selection minimum value"""
+            cls.MEDIUM = 2
+            """cutBased selection minimum value"""
+            cls.TIGHT = 3
+            """cutBased selection minimum value"""
+        else:
+            cls.LOOSE = 0
+            """cutBased bit position"""
+            cls.MEDIUM = 1
+            """cutBased bit position"""
+            cls.TIGHT = 2
+            """cutBased bit position"""
 
     @property
     def mass(self):
@@ -310,22 +323,25 @@ class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
     @property
     def isLoose(self):
         """Returns a boolean array marking loose cut-based photons"""
+        self._initialize_cutbased(self.fields)
         if "cutBased" in self.fields:
-            return (self.cutBased & (1 << self.LOOSE)) != 0
+            return self.cutBased >= self.LOOSE
         return (self.cutBasedBitmap & (1 << self.LOOSE)) != 0
 
     @property
     def isMedium(self):
         """Returns a boolean array marking medium cut-based photons"""
+        self._initialize_cutbased(self.fields)
         if "cutBased" in self.fields:
-            return (self.cutBased & (1 << self.MEDIUM)) != 0
+            return self.cutBased >= self.MEDIUM
         return (self.cutBasedBitmap & (1 << self.MEDIUM)) != 0
 
     @property
     def isTight(self):
         """Returns a boolean array marking tight cut-based photons"""
+        self._initialize_cutbased(self.fields)
         if "cutBased" in self.fields:
-            return (self.cutBased & (1 << self.TIGHT)) != 0
+            return self.cutBased >= self.TIGHT
         return (self.cutBasedBitmap & (1 << self.TIGHT)) != 0
 
     @dask_property

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -304,6 +304,10 @@ class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
         return 0.0 * self.pt
 
     @property
+    def charge(self):
+        return 0.0 * self.pt
+
+    @property
     def isLoose(self):
         """Returns a boolean array marking loose cut-based photons"""
         return (self.cutBasedBitmap & (1 << self.LOOSE)) != 0

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -292,25 +292,14 @@ _set_repr_name("Tau")
 class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     """NanoAOD photon object"""
 
-    @classmethod
-    def _initialize_cutbased(cls, fields):
-        """Initialize cut-based selection values based on the fields"""
-        if "cutBased" in fields:
-            cls.FAIL = 0
-            """cutBased selection minimum value"""
-            cls.LOOSE = 1
-            """cutBased selection minimum value"""
-            cls.MEDIUM = 2
-            """cutBased selection minimum value"""
-            cls.TIGHT = 3
-            """cutBased selection minimum value"""
-        else:
-            cls.LOOSE = 0
-            """cutBased bit position"""
-            cls.MEDIUM = 1
-            """cutBased bit position"""
-            cls.TIGHT = 2
-            """cutBased bit position"""
+    FAIL = 0
+    "cutBased selection minimum value"
+    LOOSE = 1
+    "cutBased selection minimum value"
+    MEDIUM = 2
+    "cutBased selection minimum value"
+    TIGHT = 3
+    "cutBased selection minimum value"
 
     @property
     def mass(self):
@@ -323,26 +312,26 @@ class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
     @property
     def isLoose(self):
         """Returns a boolean array marking loose cut-based photons"""
-        self._initialize_cutbased(self.fields)
+        # For NanoAOD v9+ the cutBasedBitmap was changed to a cutBased integer
         if "cutBased" in self.fields:
             return self.cutBased >= self.LOOSE
-        return (self.cutBasedBitmap & (1 << self.LOOSE)) != 0
+        return (self.cutBasedBitmap & (1 << (self.LOOSE - 1))) != 0
 
     @property
     def isMedium(self):
         """Returns a boolean array marking medium cut-based photons"""
-        self._initialize_cutbased(self.fields)
+        # For NanoAOD v9+ the cutBasedBitmap was changed to a cutBased integer
         if "cutBased" in self.fields:
             return self.cutBased >= self.MEDIUM
-        return (self.cutBasedBitmap & (1 << self.MEDIUM)) != 0
+        return (self.cutBasedBitmap & (1 << (self.MEDIUM - 1))) != 0
 
     @property
     def isTight(self):
         """Returns a boolean array marking tight cut-based photons"""
-        self._initialize_cutbased(self.fields)
+        # For NanoAOD v9+ the cutBasedBitmap was changed to a cutBased integer
         if "cutBased" in self.fields:
             return self.cutBased >= self.TIGHT
-        return (self.cutBasedBitmap & (1 << self.TIGHT)) != 0
+        return (self.cutBasedBitmap & (1 << (self.TIGHT - 1))) != 0
 
     @dask_property
     def matched_electron(self):

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -310,16 +310,22 @@ class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
     @property
     def isLoose(self):
         """Returns a boolean array marking loose cut-based photons"""
+        if "cutBased" in self.fields:
+            return (self.cutBased & (1 << self.LOOSE)) != 0
         return (self.cutBasedBitmap & (1 << self.LOOSE)) != 0
 
     @property
     def isMedium(self):
         """Returns a boolean array marking medium cut-based photons"""
+        if "cutBased" in self.fields:
+            return (self.cutBased & (1 << self.MEDIUM)) != 0
         return (self.cutBasedBitmap & (1 << self.MEDIUM)) != 0
 
     @property
     def isTight(self):
         """Returns a boolean array marking tight cut-based photons"""
+        if "cutBased" in self.fields:
+            return (self.cutBased & (1 << self.TIGHT)) != 0
         return (self.cutBasedBitmap & (1 << self.TIGHT)) != 0
 
     @dask_property

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -606,6 +606,17 @@ def test_photon_zero_mass_charge(optimization_enabled):
             delayed=True,
         ).events()
 
+        np.testing.assert_allclose(ak.flatten(eagerevents.Photon.mass), 0.0, atol=1e-5)
+        np.testing.assert_allclose(
+            ak.flatten(daskevents.Photon.mass).compute(), 0.0, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            ak.flatten(eagerevents.Photon.charge), 0.0, atol=1e-5
+        )
+        np.testing.assert_allclose(
+            ak.flatten(daskevents.Photon.charge).compute(), 0.0, atol=1e-5
+        )
+
         eagerdiphotonevents = eagerevents[ak.num(eagerevents.Photon) == 2]
         daskdiphotonevents = daskevents[ak.num(daskevents.Photon) == 2]
         eagerdiphotons = ak.zip(

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -633,4 +633,24 @@ def test_photon_zero_mass_charge(optimization_enabled):
         )
         eagerdiphotons["mass"] = (eagerdiphotons.tag + eagerdiphotons.probe).mass
         daskdiphotons["mass"] = (daskdiphotons.tag + daskdiphotons.probe).mass
+        eagermll = np.sqrt(
+            2
+            * eagerdiphotons.tag.pt
+            * eagerdiphotons.probe.pt
+            * (
+                np.cosh(eagerdiphotons.tag.eta - eagerdiphotons.probe.eta)
+                - np.cos(eagerdiphotons.tag.phi - eagerdiphotons.probe.phi)
+            )
+        )
+        daskmll = np.sqrt(
+            2
+            * daskdiphotons.tag.pt
+            * daskdiphotons.probe.pt
+            * (
+                np.cosh(daskdiphotons.tag.eta - daskdiphotons.probe.eta)
+                - np.cos(daskdiphotons.tag.phi - daskdiphotons.probe.phi)
+            )
+        )
+        assert_eq(eagerdiphotons.mass, eagermll)
+        assert_eq(daskdiphotons.mass, daskmll)
         assert_eq(eagerdiphotons.mass, daskdiphotons.mass)

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -586,3 +586,40 @@ def test_dask_metric_table_and_nearest(optimization_enabled):
         )
         assert_eq(out_eager_thresh, out_dask_thresh)
         assert_eq(metric_eager_thresh, metric_dask_thresh)
+
+
+@pytest.mark.parametrize("optimization_enabled", [True, False])
+def test_photon_zero_mass_charge(optimization_enabled):
+    import dask
+    from dask_awkward.lib.testutils import assert_eq
+
+    from coffea.nanoevents import NanoEventsFactory
+
+    with dask.config.set({"awkward.optimization.enabled": optimization_enabled}):
+        eagerevents = NanoEventsFactory.from_root(
+            {"tests/samples/nano_dy.root": "Events"},
+            delayed=False,
+        ).events()
+
+        daskevents = NanoEventsFactory.from_root(
+            {"tests/samples/nano_dy.root": "Events"},
+            delayed=True,
+        ).events()
+
+        eagerdiphotonevents = eagerevents[ak.num(eagerevents.Photon) == 2]
+        daskdiphotonevents = daskevents[ak.num(daskevents.Photon) == 2]
+        eagerdiphotons = ak.zip(
+            {
+                "tag": eagerdiphotonevents.Photon[:, 0],
+                "probe": eagerdiphotonevents.Photon[:, 1],
+            }
+        )
+        daskdiphotons = ak.zip(
+            {
+                "tag": daskdiphotonevents.Photon[:, 0],
+                "probe": daskdiphotonevents.Photon[:, 1],
+            }
+        )
+        eagerdiphotons["mass"] = (eagerdiphotons.tag + eagerdiphotons.probe).mass
+        daskdiphotons["mass"] = (daskdiphotons.tag + daskdiphotons.probe).mass
+        assert_eq(eagerdiphotons.mass, daskdiphotons.mass)


### PR DESCRIPTION
This adds a zero Photon charge like we do with mass so that operations like diphoton invariant mass `(photon1 + photon2).mass` don't run into
```
AttributeError: no field named 'charge'

This error occurred while calling

    numpy.add.__call__(
        <PhotonArray-typetracer [...] type='## * Photon[seediEtaOriX: int8[...'>
        <PhotonArray-typetracer [...] type='## * Photon[seediEtaOriX: int8[...'>
    )
```

Also fixes the cutBased ID of photons since it was changed in later NanoAOD versions and it is not caught by tests.