### PR TITLE
ci: Add GitHub artifact attestations to package distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: [test, test-vine]
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -199,6 +203,12 @@ jobs:
     - name: Build package for PyPI
       run: |
         pipx run hatch build -t sdist -t wheel
+    - name: Verify the distribution
+      run: pipx run twine check --strict dist/*
+    - name: Generate artifact attestation for sdist and wheel
+      uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.1.2
+      with:
+        subject-path: "dist/coffea-*"
     - name: Publish package to PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.14
       with:


### PR DESCRIPTION
* Add generation of GitHub artifact attestations to built sdist and wheel before upload. c.f.:
   - https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
   - https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

Verification of artifact attestations can be done via the `gh attestation verify` CLI API, added in [v2.49.0](https://github.com/cli/cli/releases/tag/v2.49.0).