### PR TITLE
backport: backport low pt electrons to 0.7

### DIFF
--- a/coffea/nanoevents/methods/nanoaod.py
+++ b/coffea/nanoevents/methods/nanoaod.py
@@ -180,6 +180,26 @@ _set_repr_name("Electron")
 
 
 @awkward.mixin_class(behavior)
+class LowPtElectron(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
+    """NanoAOD low-pt electron object"""
+
+    @property
+    def matched_gen(self):
+        return self._events().GenPart._apply_global_index(self.genPartIdxG)
+
+    @property
+    def matched_electron(self):
+        return self._events().Electron._apply_global_index(self.electronIdxG)
+
+    @property
+    def matched_photon(self):
+        return self._events().Photon._apply_global_index(self.photonIdxG)
+
+
+_set_repr_name("LowPtElectron")
+
+
+@awkward.mixin_class(behavior)
 class Muon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     """NanoAOD muon object"""
 
@@ -501,6 +521,7 @@ __all__ = [
     "GenParticle",
     "GenVisTau",
     "Electron",
+    "LowPtElectron",
     "Muon",
     "Tau",
     "Photon",

--- a/coffea/nanoevents/schemas/nanoaod.py
+++ b/coffea/nanoevents/schemas/nanoaod.py
@@ -57,6 +57,7 @@ class NanoAODSchema(BaseSchema):
         "SubJet": "PtEtaPhiMCollection",
         # Candidate: lorentz + charge
         "Electron": "Electron",
+        "LowPtElectron": "LowPtElectron",
         "Muon": "Muon",
         "Photon": "Photon",
         "FsrPhoton": "FsrPhoton",
@@ -75,6 +76,9 @@ class NanoAODSchema(BaseSchema):
         "Electron_genPartIdx": "GenPart",
         "Electron_jetIdx": "Jet",
         "Electron_photonIdx": "Photon",
+        "LowPtElectron_electronIdx": "Electron",
+        "LowPtElectron_genPartIdx": "GenPart",
+        "LowPtElectron_photonIdx": "Photon",
         "FatJet_genJetAK8Idx": "GenJetAK8",
         "FatJet_subJetIdx1": "SubJet",
         "FatJet_subJetIdx2": "SubJet",


### PR DESCRIPTION
Backport of https://github.com/CoffeaTeam/coffea/pull/1121 to `coffea 0.7.x`.
The same validation:
```python
In [1]: from coffea.nanoevents import NanoEventsFactory

In [2]: events = NanoEventsFactory.from_root("root://eoscms.cern.ch:1094//eos/cms//store/mc/Run3Winter24NanoAOD/DYJetsToLL_M-50_TuneCP5_13p6TeV-madgraphMLM-pythia8/NANOAODSIM/NoPU_Pilot_133X_mcRun3_2024_realistic_v6-v2/50000/976308db-41c9-4b50-b297-d2577ef22e4b.root").events()

In [3]: events.LowPtElectron
Out[3]: <LowPtElectronArray [[], [LowPtElectron, ... [], []] type='1941 * var * lowPtEle...'>

In [4]: events.LowPtElectron.matched_gen
Out[4]: <GenParticleArray [[], [GenParticle, ... [], []] type='1941 * var * ?genParticle'>

In [5]: events.LowPtElectron.matched_electron
Out[5]: <ElectronArray [[], [Electron, Electron, ... [], []] type='1941 * var * ?electron'>

In [6]: events.LowPtElectron.matched_photon
Out[6]: <PhotonArray [[], [None, None], ... None], [], []] type='1941 * var * ?photon'>

In [7]: events.LowPtElectron.metric_table(events.Electron)
Out[7]: <Array [[], [[2.77, 0], [0, ... [4.2]], [], []] type='1941 * var * var * float32'>

```