### PR TITLE
fix: allow importing `ml_tools` modules without `xgboost`

### DIFF
--- a/src/coffea/ml_tools/xgboost_wrapper.py
+++ b/src/coffea/ml_tools/xgboost_wrapper.py
@@ -32,7 +32,7 @@ class xgboost_wrapper(numpy_call_wrapper, nonserializable_attribute):
         nonserializable_attribute.__init__(self, ["xgbooster"])
         self.xgboost_file = fname
 
-    def _create_xgbooster(self) -> xgboost.Booster:
+    def _create_xgbooster(self) -> "xgboost.Booster":
         # Automatic detection of compressed model file
         return xgboost.Booster(model_file=self.xgboost_file)
 


### PR DESCRIPTION
The error right now -
```py
In [1]: from coffea.ml_tools.torch_wrapper import torch_wrapper
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Cell In[1], line 1
----> 1 from coffea.ml_tools.torch_wrapper import torch_wrapper

File ~\Saransh_softwares\OpenSource\Python\coffea\src\coffea\ml_tools\__init__.py:11
      9 from coffea.ml_tools.torch_wrapper import torch_wrapper
     10 from coffea.ml_tools.triton_wrapper import triton_wrapper
---> 11 from coffea.ml_tools.xgboost_wrapper import xgboost_wrapper
     13 __all__ = [
     14     "numpy_call_wrapper",
     15     "torch_wrapper",
     16     "triton_wrapper",
     17     "xgboost_wrapper",
     18 ]

File ~\Saransh_softwares\OpenSource\Python\coffea\src\coffea\ml_tools\xgboost_wrapper.py:15
     11 except (ImportError, ModuleNotFoundError) as err:
     12     _xgboost_import_error = err
---> 15 class xgboost_wrapper(numpy_call_wrapper, nonserializable_attribute):
     16     """
     17     Very simple wrapper for xgbooster inference. The xgboost.Booster object is
     18     nonserializable, so the users should pass in the xgboost model file.
     19     """
     21     def __init__(self, fname):

File ~\Saransh_softwares\OpenSource\Python\coffea\src\coffea\ml_tools\xgboost_wrapper.py:35, in xgboost_wrapper()
     32     nonserializable_attribute.__init__(self, ["xgbooster"])
     33     self.xgboost_file = fname
---> 35 def _create_xgbooster(self) -> xgboost.Booster:
     36     # Automatic detection of compressed model file
     37     return xgboost.Booster(model_file=self.xgboost_file)
     39 def validate_numpy_input(
     40     self,
     41     data: numpy.ndarray,
     42     dmat_args: Optional[Dict] = None,
     43     predict_args: Optional[Dict] = None,
     44 ):

NameError: name 'xgboost' is not defined
```

The tests for `ml_tools.torch_wrapper` fail too if `xgboost` is not installed. 