### PR TITLE
fix: Add dataset discovery tools to coffea.dataset_tools's __all__ and to docs

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -25,7 +25,7 @@ class WeightStatistics:
     """
     Container for statistics about the weight, including the sum of squared weights
     and number of entries.
-    
+
     Parameters
     ----------
         sumw: float
@@ -39,6 +39,7 @@ class WeightStatistics:
         n: int
             The number of entries
     """
+
     def __init__(self, sumw=0.0, sumw2=0.0, minw=numpy.inf, maxw=-numpy.inf, n=0):
         self.sumw = sumw
         self.sumw2 = sumw2
@@ -54,7 +55,7 @@ class WeightStatistics:
 
     def add(self, other):
         """Add two WeightStatistics objects together.
-        
+
         Adds the sum of weights, the sum of squared weights, and the number of entries.
         Takes the minimum and maximum across the two WeightStatistics objects. Modifies
         this object in place.
@@ -1134,7 +1135,7 @@ class PackedSelection:
     def delayed_mode(self):
         """
         Is the PackedSelection in delayed mode?
-        
+
         Returns
         -------
             res: bool

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -22,6 +22,23 @@ import coffea.util
 
 
 class WeightStatistics:
+    """
+    Container for statistics about the weight, including the sum of squared weights
+    and number of entries.
+    
+    Parameters
+    ----------
+        sumw: float
+            The sum of weights
+        sumw2: float
+            The sum of squared weights
+        minw: float
+            The minimum weight
+        maxw: float
+            The maximum weight
+        n: int
+            The number of entries
+    """
     def __init__(self, sumw=0.0, sumw2=0.0, minw=numpy.inf, maxw=-numpy.inf, n=0):
         self.sumw = sumw
         self.sumw2 = sumw2
@@ -36,6 +53,17 @@ class WeightStatistics:
         return WeightStatistics()
 
     def add(self, other):
+        """Add two WeightStatistics objects together.
+        
+        Adds the sum of weights, the sum of squared weights, and the number of entries.
+        Takes the minimum and maximum across the two WeightStatistics objects. Modifies
+        this object in place.
+
+        Parameters
+        ----------
+            other: WeightStatistics
+                The other WeightStatistics object to add to this one
+        """
         self.sumw += other.sumw
         self.sumw2 += other.sumw2
         self.minw = min(self.minw, other.minw)
@@ -76,6 +104,8 @@ class Weights:
 
     @property
     def weightStatistics(self):
+        """Statistics about the weight, including the sum of squared weights
+        and number of entries."""
         return self._weightStats
 
     def __add_eager(self, name, weight, weightUp, weightDown, shift):
@@ -349,7 +379,7 @@ class Weights:
 
     @lru_cache
     def weight(self, modifier=None):
-        """Current event weight vector
+        """Returns the current event weight vector
 
         Parameters
         ----------
@@ -1102,6 +1132,14 @@ class PackedSelection:
 
     @property
     def delayed_mode(self):
+        """
+        Is the PackedSelection in delayed mode?
+        
+        Returns
+        -------
+            res: bool
+                True if the PackedSelection is in delayed mode
+        """
         if isinstance(self._data, dask_awkward.Array):
             return True
         elif isinstance(self._data, numpy.ndarray):
@@ -1114,6 +1152,14 @@ class PackedSelection:
 
     @property
     def maxitems(self):
+        """
+        What is the maximum supported number of selections in this PackedSelection?
+
+        Returns
+        -------
+            res: bool
+                The maximum supported number of selections
+        """
         return PackedSelection._supported_types[self._dtype]
 
     def __add_delayed(self, name, selection, fill_value):

--- a/src/coffea/btag_tools/btagscalefactor.py
+++ b/src/coffea/btag_tools/btagscalefactor.py
@@ -25,7 +25,12 @@ class BTagScaleFactor:
     _FLAV_B, _FLAV_C, _FLAV_UDSG = range(3)
     _flavor = numpy.array([0, 4, 5, 6])
     _flavor2btvflavor = {0: _FLAV_UDSG, 4: _FLAV_C, 5: _FLAV_B}
-    _wpString = {"loose": _LOOSE, "medium": _MEDIUM, "tight": _TIGHT, "reshape": _RESHAPE}
+    _wpString = {
+        "loose": _LOOSE,
+        "medium": _MEDIUM,
+        "tight": _TIGHT,
+        "reshape": _RESHAPE,
+    }
     _expectedColumns = [
         "OperatingPoint",
         "measurementType",

--- a/src/coffea/btag_tools/btagscalefactor.py
+++ b/src/coffea/btag_tools/btagscalefactor.py
@@ -21,15 +21,15 @@ class BTagScaleFactor:
             If set true, keep the parsed dataframe as an attribute (.df) for later inspection
     """
 
-    _LOOSE, _MEDIUM, _TIGHT, _RESHAPE = range(4)
+    LOOSE, MEDIUM, TIGHT, RESHAPE = range(4)
     _FLAV_B, _FLAV_C, _FLAV_UDSG = range(3)
     _flavor = numpy.array([0, 4, 5, 6])
     _flavor2btvflavor = {0: _FLAV_UDSG, 4: _FLAV_C, 5: _FLAV_B}
     _wpString = {
-        "loose": _LOOSE,
-        "medium": _MEDIUM,
-        "tight": _TIGHT,
-        "reshape": _RESHAPE,
+        "loose": LOOSE,
+        "medium": MEDIUM,
+        "tight": TIGHT,
+        "reshape": RESHAPE,
     }
     _expectedColumns = [
         "OperatingPoint",
@@ -96,13 +96,13 @@ class BTagScaleFactor:
                 f"The BTag csv file {filename} is in the new UL format which is not supported by coffea.btag_tools.\n"
                 "Instead one can use correctionlib for UL scale factors."
             )
-        cut = (df["jetFlavor"] == self.FLAV_B) & (df["measurementType"] == methods[0])
+        cut = (df["jetFlavor"] == self._FLAV_B) & (df["measurementType"] == methods[0])
         if len(methods) > 1:
-            cut |= (df["jetFlavor"] == self.FLAV_C) & (
+            cut |= (df["jetFlavor"] == self._FLAV_C) & (
                 df["measurementType"] == methods[1]
             )
         if len(methods) > 2:
-            cut |= (df["jetFlavor"] == self.FLAV_UDSG) & (
+            cut |= (df["jetFlavor"] == self._FLAV_UDSG) & (
                 df["measurementType"] == methods[2]
             )
         cut &= df["OperatingPoint"] == workingpoint
@@ -170,7 +170,7 @@ class BTagScaleFactor:
                 flavor, eta, pt, discr = (x[idx] for x in bin_low_edges)
                 mapping[idx] = findbin(flavor, eta, pt, discr)
 
-            if self.workingpoint == BTagScaleFactor._RESHAPE:
+            if self.workingpoint == BTagScaleFactor.RESHAPE:
                 self._corrections[syst] = dense_mapped_lookup(
                     (self._flavor, edges_eta, edges_pt, edges_discr),
                     mapping,
@@ -214,7 +214,7 @@ class BTagScaleFactor:
         """
         if systematic not in self._corrections:
             raise ValueError("Unrecognized systematic: %s" % systematic)
-        if self.workingpoint == BTagScaleFactor._RESHAPE:
+        if self.workingpoint == BTagScaleFactor.RESHAPE:
             if discr is None:
                 raise ValueError("RESHAPE scale factor requires a discriminant array")
             return self._corrections[systematic](

--- a/src/coffea/btag_tools/btagscalefactor.py
+++ b/src/coffea/btag_tools/btagscalefactor.py
@@ -21,11 +21,11 @@ class BTagScaleFactor:
             If set true, keep the parsed dataframe as an attribute (.df) for later inspection
     """
 
-    LOOSE, MEDIUM, TIGHT, RESHAPE = range(4)
-    FLAV_B, FLAV_C, FLAV_UDSG = range(3)
+    _LOOSE, _MEDIUM, _TIGHT, _RESHAPE = range(4)
+    _FLAV_B, _FLAV_C, _FLAV_UDSG = range(3)
     _flavor = numpy.array([0, 4, 5, 6])
-    _flavor2btvflavor = {0: FLAV_UDSG, 4: FLAV_C, 5: FLAV_B}
-    _wpString = {"loose": LOOSE, "medium": MEDIUM, "tight": TIGHT, "reshape": RESHAPE}
+    _flavor2btvflavor = {0: _FLAV_UDSG, 4: _FLAV_C, 5: _FLAV_B}
+    _wpString = {"loose": _LOOSE, "medium": _MEDIUM, "tight": _TIGHT, "reshape": _RESHAPE}
     _expectedColumns = [
         "OperatingPoint",
         "measurementType",
@@ -165,7 +165,7 @@ class BTagScaleFactor:
                 flavor, eta, pt, discr = (x[idx] for x in bin_low_edges)
                 mapping[idx] = findbin(flavor, eta, pt, discr)
 
-            if self.workingpoint == BTagScaleFactor.RESHAPE:
+            if self.workingpoint == BTagScaleFactor._RESHAPE:
                 self._corrections[syst] = dense_mapped_lookup(
                     (self._flavor, edges_eta, edges_pt, edges_discr),
                     mapping,
@@ -209,7 +209,7 @@ class BTagScaleFactor:
         """
         if systematic not in self._corrections:
             raise ValueError("Unrecognized systematic: %s" % systematic)
-        if self.workingpoint == BTagScaleFactor.RESHAPE:
+        if self.workingpoint == BTagScaleFactor._RESHAPE:
             if discr is None:
                 raise ValueError("RESHAPE scale factor requires a discriminant array")
             return self._corrections[systematic](

--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -1,4 +1,5 @@
 from coffea.dataset_tools.apply_processor import apply_to_dataset, apply_to_fileset
+from coffea.dataset_tools.dataset_query import DataDiscoveryCLI, print_dataset_query
 from coffea.dataset_tools.manipulations import (
     filter_files,
     get_failed_steps_for_dataset,
@@ -9,10 +10,9 @@ from coffea.dataset_tools.manipulations import (
     slice_files,
 )
 from coffea.dataset_tools.preprocess import preprocess
-from coffea.dataset_tools.dataset_query import DataDiscoveryCLI, print_dataset_query
 from coffea.dataset_tools.rucio_utils import (
-    get_rucio_client,
     get_dataset_files_replicas,
+    get_rucio_client,
     query_dataset,
 )
 

--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -9,8 +9,19 @@ from coffea.dataset_tools.manipulations import (
     slice_files,
 )
 from coffea.dataset_tools.preprocess import preprocess
+from coffea.dataset_tools.dataset_query import DataDiscoveryCLI, print_dataset_query
+from coffea.dataset_tools.rucio_utils import (
+    get_rucio_client,
+    get_dataset_files_replicas,
+    query_dataset,
+)
 
 __all__ = [
+    "get_rucio_client",
+    "get_dataset_files_replicas",
+    "query_dataset",
+    "DataDiscoveryCLI",
+    "print_dataset_query",
     "preprocess",
     "apply_to_dataset",
     "apply_to_fileset",

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -98,7 +98,7 @@ def apply_to_fileset(
 ) -> dict[str, DaskOutputType] | tuple[dict[str, DaskOutputType], dask_awkward.Array]:
     """
     Apply the supplied function or processor to the supplied fileset (set of datasets).
-    
+
     Parameters
     ----------
         data_manipulation : ProcessorABC or GenericHEPAnalysis

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -40,6 +40,7 @@ def apply_to_dataset(
 ) -> DaskOutputType | tuple[DaskOutputType, dask_awkward.Array]:
     """
     Apply the supplied function or processor to the supplied dataset.
+
     Parameters
     ----------
         data_manipulation : ProcessorABC or GenericHEPAnalysis
@@ -97,6 +98,7 @@ def apply_to_fileset(
 ) -> dict[str, DaskOutputType] | tuple[dict[str, DaskOutputType], dask_awkward.Array]:
     """
     Apply the supplied function or processor to the supplied fileset (set of datasets).
+    
     Parameters
     ----------
         data_manipulation : ProcessorABC or GenericHEPAnalysis

--- a/src/coffea/dataset_tools/dataset_query.py
+++ b/src/coffea/dataset_tools/dataset_query.py
@@ -4,7 +4,7 @@ import json
 import os
 import random
 from collections import defaultdict
-from typing import List, Any, Hashable, Dict
+from typing import Dict, List
 
 import yaml
 from dask.distributed import Client
@@ -15,14 +15,14 @@ from rich.table import Table
 from rich.tree import Tree
 
 from . import rucio_utils
-from .preprocess import preprocess, FilesetSpecOptional
+from .preprocess import preprocess
 
 
 def print_dataset_query(
     query: str,
-    dataset_list: Dict[str, Dict[str,list[str]]],
+    dataset_list: Dict[str, Dict[str, list[str]]],
     console: Console,
-    selected: list[str] = []
+    selected: list[str] = [],
 ) -> None:
     """
     Pretty-print the results of a rucio query in a table.
@@ -112,6 +112,7 @@ class DataDiscoveryCLI:
     It can be accessed in a Python script or interpreter via this class, or from the
     command line (as in `python -m coffea.dataset_tools.dataset_query --help`).
     """
+
     def __init__(self):
         self.console = Console()
         self.rucio_client = None
@@ -224,7 +225,7 @@ Some basic commands:
     def do_query(self, query=None):
         """
         Look for datasets with * wildcards (like in DAS)
-        
+
         Parameters
         ----------
             query: str | None, default None
@@ -264,7 +265,7 @@ Some basic commands:
         """
         Selected the datasets from the list of query results. Input a list of indices
         also with range 4-6 or "all".
-        
+
         Parameters
         ----------
             selection: list[str] | None, default None
@@ -326,7 +327,7 @@ Some basic commands:
     def do_replicas(self, mode=None, selection=None):
         """
         Query Rucio for replicas.
-        
+
         Parameters
         ----------
             mode: str, default None
@@ -487,7 +488,7 @@ Some basic commands:
     def do_allowlist_sites(self, sites=None):
         """
         Restrict the grid sites available for replicas query only to the requested list
-        
+
         Parameters
         ----------
             sites: list[str] | None, default None
@@ -510,7 +511,7 @@ Some basic commands:
     def do_blocklist_sites(self, sites=None):
         """
         Exclude grid sites from the available sites for replicas query
-        
+
         Parameters
         ----------
             sites: list[str] | None, default None
@@ -531,9 +532,9 @@ Some basic commands:
             print(f"- {s}")
 
     def do_regex_sites(self, regex=None):
-        """
+        r"""
         Select sites with a regex for replica queries: e.g.  "T[123]_(FR|IT|BE|CH|DE)_\w+"
-        
+
         Parameters
         ----------
             regex: str | None, default None
@@ -549,7 +550,7 @@ Some basic commands:
         """
         Show the active sites filters (allowed, disallowed, and regex) and ask to clear
         them
-        
+
         Parameters
         ----------
             ask_clear: bool, default True
@@ -600,7 +601,7 @@ Some basic commands:
     def do_save(self, filename=None):
         """
         Save the replica information in yaml format
-        
+
         Parameters:
             filename: str | None, default None
                 The name of the file to save the information into

--- a/src/coffea/dataset_tools/dataset_query.py
+++ b/src/coffea/dataset_tools/dataset_query.py
@@ -4,7 +4,7 @@ import json
 import os
 import random
 from collections import defaultdict
-from typing import List
+from typing import List, Any, Hashable, Dict
 
 import yaml
 from dask.distributed import Client
@@ -15,10 +15,29 @@ from rich.table import Table
 from rich.tree import Tree
 
 from . import rucio_utils
-from .preprocess import preprocess
+from .preprocess import preprocess, FilesetSpecOptional
 
 
-def print_dataset_query(query, dataset_list, console, selected=[]):
+def print_dataset_query(
+    query: str,
+    dataset_list: Dict[str, Dict[str,list[str]]],
+    console: Console,
+    selected: list[str] = []
+) -> None:
+    """
+    Pretty-print the results of a rucio query in a table.
+
+    Parameters
+    ----------
+        query: str
+            The query given to rucio
+        dataset_list: dict[str, dict[str,list[str]]]
+            The second output of a call to query_dataset with tree=True
+        console: Console
+            A Console object to print to
+        selected: list[str], default []
+            A list of selected datasets
+    """
     table = Table(title=f"Query: [bold red]{query}")
     table.add_column("Name", justify="left", style="cyan", no_wrap=True)
     table.add_column("Tag", style="magenta", no_wrap=True)
@@ -88,6 +107,11 @@ def get_indices_query(input_str: str, maxN: int) -> List[int]:
 
 
 class DataDiscoveryCLI:
+    """
+    Simplifies dataset query, replicas, filters, and uproot preprocessing with Dask.
+    It can be accessed in a Python script or interpreter via this class, or from the
+    command line (as in `python -m coffea.dataset_tools.dataset_query --help`).
+    """
     def __init__(self):
         self.console = Console()
         self.rucio_client = None
@@ -140,7 +164,7 @@ Some basic commands:
   - [bold cyan]query-results[/]: List the results of the last dataset query
   - [bold cyan]list-selected[/]: Print a list of the selected datasets
   - [bold cyan]list-replicas[/]: Print the selected files replicas for the selected dataset
-  - [bold cyan]sites-filters[/]: show the active sites filters and ask to clear them
+  - [bold cyan]sites-filters[/]: Show the active sites filters and ask to clear them
   - [bold cyan]allow-sites[/]: Restrict the grid sites available for replicas query only to the requested list
   - [bold cyan]block-sites[/]: Exclude grid sites from the available sites for replicas query
   - [bold cyan]regex-sites[/]: Select sites with a regex for replica queries: e.g.  "T[123]_(FR|IT|BE|CH|DE)_\w+"
@@ -198,7 +222,14 @@ Some basic commands:
         print(self.rucio_client.whoami())
 
     def do_query(self, query=None):
-        # Your code here
+        """
+        Look for datasets with * wildcards (like in DAS)
+        
+        Parameters
+        ----------
+            query: str | None, default None
+                The query to pass to rucio. If None, will prompt the user for an input.
+        """
         if query is None:
             query = Prompt.ask(
                 "[yellow bold]Query for[/]",
@@ -218,6 +249,7 @@ Some basic commands:
         print("Use the command [bold red]select[/] to selected the datasets")
 
     def do_query_results(self):
+        """List the results of the last dataset query"""
         if self.last_query_list:
             print_dataset_query(
                 self.last_query,
@@ -229,8 +261,19 @@ Some basic commands:
             print("First [bold red]query (Q)[/] for a dataset")
 
     def do_select(self, selection=None, metadata=None):
-        """Selected the datasets from the list of query results. Input a list of indices
-        also with range 4-6 or "all"."""
+        """
+        Selected the datasets from the list of query results. Input a list of indices
+        also with range 4-6 or "all".
+        
+        Parameters
+        ----------
+            selection: list[str] | None, default None
+                A list of indices corresponding to selected datasets. Should be a
+                string, with indices separated by spaces. Can include ranges (like "4-6")
+                or "all".
+            metadata: dict[Hashable,Any], default None
+                Metadata to store in associated with selected datasets.
+        """
         if not self.last_query_list:
             print("First [bold red]query (Q)[/] for a dataset")
             return
@@ -260,6 +303,7 @@ Some basic commands:
                 )
 
     def do_list_selected(self):
+        """Print a list of the selected datasets"""
         print("[cyan]Selected datasets:")
         table = Table(title="Selected datasets")
         table.add_column("Index", justify="left", style="cyan", no_wrap=True)
@@ -280,12 +324,20 @@ Some basic commands:
         self.console.print(table)
 
     def do_replicas(self, mode=None, selection=None):
-        """Query Rucio for replicas.
-        mode: - None:  ask the user about the mode
-              - round-robin (take files randomly from available sites),
-              - choose: ask the user to choose from a list of sites
-              - first: take the first site from the rucio query
-        selection: list of indices or 'all' to select all the selected datasets for replicas query
+        """
+        Query Rucio for replicas.
+        
+        Parameters
+        ----------
+            mode: str, default None
+                One of the following
+                    - None:  ask the user about the mode
+                    - round-robin (take files randomly from available sites),
+                    - choose: ask the user to choose from a list of sites
+                    - first: take the first site from the rucio query
+            selection: str, default None
+                list of indices or 'all' to select all the selected datasets for
+                replicas query
         """
         if selection is None:
             selection = Prompt.ask(
@@ -433,6 +485,16 @@ Some basic commands:
         return self.final_output
 
     def do_allowlist_sites(self, sites=None):
+        """
+        Restrict the grid sites available for replicas query only to the requested list
+        
+        Parameters
+        ----------
+            sites: list[str] | None, default None
+                The sites to allow the replicas query to look at. If passing in a list,
+                elements of the list are sites. If passing in None, the prompt requires
+                a single string containing a comma-separated listing.
+        """
         if sites is None:
             sites = Prompt.ask(
                 "[yellow]Restrict the available sites to (comma-separated list)"
@@ -446,6 +508,16 @@ Some basic commands:
             print(f"- {s}")
 
     def do_blocklist_sites(self, sites=None):
+        """
+        Exclude grid sites from the available sites for replicas query
+        
+        Parameters
+        ----------
+            sites: list[str] | None, default None
+                The sites to prevent the replicas query from looking at. If passing in a
+                list elements of the list are sites. If passing in None, the prompt
+                requires a single string containing a comma-separated listing.
+        """
         if sites is None:
             sites = Prompt.ask(
                 "[yellow]Exclude the sites (comma-separated list)"
@@ -459,6 +531,14 @@ Some basic commands:
             print(f"- {s}")
 
     def do_regex_sites(self, regex=None):
+        """
+        Select sites with a regex for replica queries: e.g.  "T[123]_(FR|IT|BE|CH|DE)_\w+"
+        
+        Parameters
+        ----------
+            regex: str | None, default None
+                Sites to use for replica queries, described with a regex string.
+        """
         if regex is None:
             regex = Prompt.ask("[yellow]Regex to restrict the available sites")
         if len(regex):
@@ -466,6 +546,16 @@ Some basic commands:
             print(f"New sites regex: [cyan]{self.sites_regex}")
 
     def do_sites_filters(self, ask_clear=True):
+        """
+        Show the active sites filters (allowed, disallowed, and regex) and ask to clear
+        them
+        
+        Parameters
+        ----------
+            ask_clear: bool, default True
+                If True, ask the user via prompt if allow, disallow, and regex filters
+                should be cleared.
+        """
         print("[green bold]Allow-listed sites:")
         if self.sites_allowlist:
             for s in self.sites_allowlist:
@@ -479,13 +569,14 @@ Some basic commands:
         print(f"[bold cyan]Sites regex: [italics]{self.sites_regex}")
 
         if ask_clear:
-            if Confirm.ask("Clear sites restrinction?", default=False):
+            if Confirm.ask("Clear sites restriction?", default=False):
                 self.sites_allowlist = None
                 self.sites_blocklist = None
                 self.sites_regex = None
                 print("[bold green]Sites filters cleared")
 
     def do_list_replicas(self):
+        """Print the selected files replicas for the selected dataset"""
         selection = Prompt.ask(
             "[yellow bold]Select datasets indices[/] (e.g 1 4 6-10)", default="all"
         )
@@ -507,7 +598,13 @@ Some basic commands:
             self.console.print(tree)
 
     def do_save(self, filename=None):
-        """Save the replica information in yaml format"""
+        """
+        Save the replica information in yaml format
+        
+        Parameters:
+            filename: str | None, default None
+                The name of the file to save the information into
+        """
         if not filename:
             filename = Prompt.ask(
                 "[yellow bold]Output file name (.yaml or .json)", default="output.json"
@@ -529,8 +626,21 @@ Some basic commands:
         align_to_clusters=None,
         scheduler_url=None,
     ):
-        """Perform preprocessing for concrete fileset extraction.
-        Args:  output_file [step_size] [align to file cluster boundaries] [dask scheduler url]
+        """
+        Perform preprocessing for concrete fileset extraction into a file, compressed
+        with gzip.
+
+        Parameters
+        ----------
+            output_file: str | None, default None
+                The name of the file to write the preprocessed file into
+            step_size: int | None, default None
+                The chunk size for file splitting
+            align_to_clusters: bool | None, default None
+                Whether or not round to the cluster size in a root file. See
+                align_clusters parameter in coffea.dataset_tools.preprocess.
+            scheduler_url: str | None, default None
+                Dask scheduler URL where the preprocessing should take place
         """
         if not output_file:
             output_file = Prompt.ask(
@@ -572,12 +682,25 @@ Some basic commands:
         Initialize the DataDiscoverCLI by querying a set of datasets defined in `dataset_definitions`
         and selected results and replicas following the options.
 
-        - query_results_strategy:  "all" or "manual" to be prompt for selection
-        - replicas_strategy:
-            - "round-robin": select randomly from the available sites for each file
-            - "choose": filter the sites with a list of indices for all the files
-            - "first": take the first result returned by rucio
-            - "manual": to be prompt for manual decision dataset by dataset
+        Parameters
+        ----------
+            dataset_definition: Dict[str,Dict[Hashable,Any]]
+                Keys are dataset queries (ie: something that can be passed to do_query())
+            query_results_strategy: str, default "all"
+                How to decide which datasets to select. If "manual", user will be prompted
+                for selection
+            replicas_strategy: str, default "round-robin"
+                Options are:
+                    - "round-robin": select randomly from the available sites for each file
+                    - "choose": filter the sites with a list of indices for all the files
+                    - "first": take the first result returned by rucio
+                    - "manual": to be prompt for manual decision dataset by dataset
+
+        Returns
+        -------
+            out_replicas: FilesetSpecOptional
+                An uproot-readable fileset. At this point, the fileset is not fully
+                preprocessed, but this can be done with do_preprocess().
         """
         for dataset_query, dataset_meta in dataset_definition.items():
             print(f"\nProcessing query: {dataset_query}")

--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -196,7 +196,7 @@ def get_failed_steps_for_fileset(
 ):
     """
     Modify an input dataset to only contain the files and row-ranges for *failed* processing jobs as specified in the supplied report.
-    
+
     Parameters
     ----------
         fileset: FilesetSpec

--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -12,6 +12,7 @@ from coffea.dataset_tools.preprocess import CoffeaFileSpec, DatasetSpec, Fileset
 def max_chunks(fileset: FilesetSpec, maxchunks: int | None = None) -> FilesetSpec:
     """
     Modify the input dataset so that only the first "maxchunks" chunks of each file will be processed.
+
     Parameters
     ----------
         fileset: FilesetSpec
@@ -30,6 +31,7 @@ def max_chunks(fileset: FilesetSpec, maxchunks: int | None = None) -> FilesetSpe
 def slice_chunks(fileset: FilesetSpec, theslice: Any = slice(None)) -> FilesetSpec:
     """
     Modify the input dataset so that only the chunks of each file specified by the input slice are processed.
+
     Parameters
     ----------
         fileset: FilesetSpec
@@ -56,6 +58,7 @@ def slice_chunks(fileset: FilesetSpec, theslice: Any = slice(None)) -> FilesetSp
 def max_files(fileset: FilesetSpec, maxfiles: int | None = None) -> FilesetSpec:
     """
     Modify the input dataset so that only the first "maxfiles" files of each dataset will be processed.
+
     Parameters
     ----------
         fileset: FilesetSpec
@@ -74,6 +77,7 @@ def max_files(fileset: FilesetSpec, maxfiles: int | None = None) -> FilesetSpec:
 def slice_files(fileset: FilesetSpec, theslice: Any = slice(None)) -> FilesetSpec:
     """
     Modify the input dataset so that only the files of each dataset specified by the input slice are processed.
+
     Parameters
     ----------
         fileset: FilesetSpec
@@ -111,6 +115,7 @@ def filter_files(
 ) -> FilesetSpec:
     """
     Modify the input dataset so that only the files of each dataset that pass the filter remain.
+
     Parameters
     ----------
         fileset: FilesetSpec
@@ -134,6 +139,7 @@ def get_failed_steps_for_dataset(
 ) -> DatasetSpec:
     """
     Modify an input dataset to only contain the files and row-ranges for *failed* processing jobs as specified in the supplied report.
+
     Parameters
     ----------
         dataset: DatasetSpec
@@ -190,6 +196,7 @@ def get_failed_steps_for_fileset(
 ):
     """
     Modify an input dataset to only contain the files and row-ranges for *failed* processing jobs as specified in the supplied report.
+    
     Parameters
     ----------
         fileset: FilesetSpec

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -32,7 +32,7 @@ def get_steps(
 ) -> awkward.Array | dask_awkward.Array:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
-    
+
     Parameters
     ----------
         normed_files: awkward.Array | dask_awkward.Array

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -32,6 +32,7 @@ def get_steps(
 ) -> awkward.Array | dask_awkward.Array:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
+    
     Parameters
     ----------
         normed_files: awkward.Array | dask_awkward.Array


### PR DESCRIPTION
The dataset discovery tools were not previously included in the `dataset_tools` sub package's `__all__`, resulting in them not appearing in the docs. This PR adds objects to `__all__` and makes some edits so those objects are documented more clearly by Sphinx.