### PR TITLE
fix: correct coffea version in docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Right now the docs say 0.1 as the git history (tags) are not fetched when the repository is checked out -

<img width="277" alt="image" src="https://github.com/user-attachments/assets/de0b6617-fb3e-409b-b49e-6dbc7c93e916">

<img width="127" alt="image" src="https://github.com/user-attachments/assets/147d998f-421d-47fa-8abf-96e579a96719">
