### PR TITLE
fix: remove lru_cache from Weights

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -6,6 +6,7 @@ but have been migrated and updated to be compatible with awkward-array 1.0
 
 import warnings
 from collections import namedtuple
+from functools import lru_cache
 
 import awkward
 import dask.array
@@ -1209,6 +1210,7 @@ class PackedSelection:
         for name, selection in selections.items():
             self.add(name, selection, fill_value)
 
+    @lru_cache
     def require(self, **names):
         """Return a mask vector corresponding to specific requirements
 

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -6,7 +6,6 @@ but have been migrated and updated to be compatible with awkward-array 1.0
 
 import warnings
 from collections import namedtuple
-from functools import lru_cache
 
 import awkward
 import dask.array
@@ -347,7 +346,6 @@ class Weights:
         elif isinstance(weight, dask_awkward.Array):
             self.__add_variation_delayed(name, weight, weightUp, weightDown, shift)
 
-    @lru_cache
     def weight(self, modifier=None):
         """Current event weight vector
 
@@ -397,7 +395,6 @@ class Weights:
             include=tuple(include), exclude=tuple(exclude), modifier=modifier
         )
 
-    @lru_cache
     def _partial_weight(self, include, exclude, modifier=None):
         if not self._storeIndividual:
             raise ValueError(
@@ -1212,7 +1209,6 @@ class PackedSelection:
         for name, selection in selections.items():
             self.add(name, selection, fill_value)
 
-    @lru_cache
     def require(self, **names):
         """Return a mask vector corresponding to specific requirements
 


### PR DESCRIPTION
Fixes #1158 

We added an lru_cache a long time ago to keep the taskgraph from exploding. More recent dask has deterministic task graphs and so we can drop this workaround, which had some unintended side-effects.