### PR TITLE
feat: Change Jet and FatJet Vector behaviour to be compatible with other lepton classes

### DIFF
--- a/src/coffea/nanoevents/methods/delphes.py
+++ b/src/coffea/nanoevents/methods/delphes.py
@@ -194,7 +194,7 @@ behavior.update(awkward._util.copy_behaviors("Particle", "MasslessParticle", beh
 class MasslessParticle(Particle, base.NanoCollection):
     @property
     def mass(self):
-        return 0.0 * self.pt
+        return awkward.zeros_like(self.pt)
 
 
 _set_repr_name("MasslessParticle")

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -509,7 +509,7 @@ class Jet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     @property
     def charge(self):
         return 0.0 * self.pt
-        
+
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""
@@ -573,9 +573,7 @@ JetArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 JetArray.ProjectionClass4D = JetArray  # noqa: F821
 JetArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
 
-behavior.update(
-    awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior)
-)
+behavior.update(awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior))
 
 
 @awkward.mixin_class(behavior)
@@ -592,7 +590,7 @@ class FatJet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
     @property
     def charge(self):
         return 0.0 * self.pt
-        
+
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -403,11 +403,11 @@ class Photon(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
 
     @property
     def mass(self):
-        return 0.0 * self.pt
+        return awkward.zeros_like(self.pt)
 
     @property
     def charge(self):
-        return 0.0 * self.pt
+        return awkward.zeros_like(self.pt)
 
     @property
     def isLoose(self):
@@ -508,8 +508,8 @@ class Jet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
 
     @property
     def charge(self):
-        return 0.0 * self.pt
-
+        return awkward.zeros_like(self.pt)
+        
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""
@@ -573,7 +573,9 @@ JetArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 JetArray.ProjectionClass4D = JetArray  # noqa: F821
 JetArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
 
-behavior.update(awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior))
+behavior.update(
+    awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior)
+)
 
 
 @awkward.mixin_class(behavior)
@@ -589,8 +591,8 @@ class FatJet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
 
     @property
     def charge(self):
-        return 0.0 * self.pt
-
+        return awkward.zeros_like(self.pt)
+        
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -492,11 +492,11 @@ FsrPhotonArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 FsrPhotonArray.ProjectionClass4D = FsrPhotonArray  # noqa: F821
 FsrPhotonArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
 
-behavior.update(awkward._util.copy_behaviors("PtEtaPhiMLorentzVector", "Jet", behavior))
+behavior.update(awkward._util.copy_behaviors("PtEtaPhiMCandidate", "Jet", behavior))
 
 
 @awkward.mixin_class(behavior)
-class Jet(vector.PtEtaPhiMLorentzVector, base.NanoCollection, base.Systematic):
+class Jet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     """NanoAOD narrow radius jet object"""
 
     LOOSE = 0
@@ -506,6 +506,10 @@ class Jet(vector.PtEtaPhiMLorentzVector, base.NanoCollection, base.Systematic):
     TIGHTLEPVETO = 2
     "jetId bit position"
 
+    @property
+    def charge(self):
+        return 0.0 * self.pt
+        
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""
@@ -570,12 +574,12 @@ JetArray.ProjectionClass4D = JetArray  # noqa: F821
 JetArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
 
 behavior.update(
-    awkward._util.copy_behaviors("PtEtaPhiMLorentzVector", "FatJet", behavior)
+    awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior)
 )
 
 
 @awkward.mixin_class(behavior)
-class FatJet(vector.PtEtaPhiMLorentzVector, base.NanoCollection, base.Systematic):
+class FatJet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     """NanoAOD large radius jet object"""
 
     LOOSE = 0
@@ -585,6 +589,10 @@ class FatJet(vector.PtEtaPhiMLorentzVector, base.NanoCollection, base.Systematic
     TIGHTLEPVETO = 2
     "jetId bit position"
 
+    @property
+    def charge(self):
+        return 0.0 * self.pt
+        
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -509,7 +509,7 @@ class Jet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic):
     @property
     def charge(self):
         return awkward.zeros_like(self.pt)
-        
+
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""
@@ -573,9 +573,7 @@ JetArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 JetArray.ProjectionClass4D = JetArray  # noqa: F821
 JetArray.MomentumClass = vector.LorentzVectorArray  # noqa: F821
 
-behavior.update(
-    awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior)
-)
+behavior.update(awkward._util.copy_behaviors("PtEtaPhiMCandidate", "FatJet", behavior))
 
 
 @awkward.mixin_class(behavior)
@@ -592,7 +590,7 @@ class FatJet(candidate.PtEtaPhiMCandidate, base.NanoCollection, base.Systematic)
     @property
     def charge(self):
         return awkward.zeros_like(self.pt)
-        
+
     @property
     def isLoose(self):
         """Returns a boolean array marking loose jets according to jetId index"""


### PR DESCRIPTION
changing Jet and FatJet's base vector class from vector.PtEtaPhiMLorentzVector to candidate.PtEtaPhiMCandidate with introduction of charge property to match operations with lepton classes (ie Muon and Electron)