### PR TITLE
perf: use fast `uproot.num_entries` method instead of `TTree.num_entries`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ dask-worker-space/
 
 # VCS versioning
 src/coffea/_version.py
+
+# pyright LSP
+pyrightconfig.json

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -75,7 +75,7 @@ def get_steps(
             else:
                 raise e
 
-        num_entries = tree.num_entries
+        num_entries = next(uproot.num_entries(f"{arg.file}:{arg.object_path}"))[-1]
 
         form_json = None
         form_hash = None

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -375,7 +375,11 @@ class NanoEventsFactory:
         if entry_start is None or entry_start < 0:
             entry_start = 0
         if entry_stop is None or entry_stop > tree.num_entries:
-            entry_stop = tree.num_entries
+            if treepath is not None:
+                # if treepath exists, attempt the faster uproot.num_entries method
+                entry_stop = next(uproot.num_entries(f"{file}:{treepath}"))[-1]
+            else:
+                entry_stop = tree.num_entries
 
         partition_key = (
             str(tree.file.uuid),

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -374,12 +374,10 @@ class NanoEventsFactory:
 
         if entry_start is None or entry_start < 0:
             entry_start = 0
-        if entry_stop is None or entry_stop > tree.num_entries:
-            if treepath is not None:
-                # if treepath exists, attempt the faster uproot.num_entries method
-                entry_stop = next(uproot.num_entries(f"{file}:{treepath}"))[-1]
-            else:
-                entry_stop = tree.num_entries
+        # should use uproot.num_entries instead...
+        nentries = tree.num_entries
+        if entry_stop is None or entry_stop > nentries:
+                entry_stop = nentries
 
         partition_key = (
             str(tree.file.uuid),

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -377,7 +377,7 @@ class NanoEventsFactory:
         # should use uproot.num_entries instead...
         nentries = tree.num_entries
         if entry_stop is None or entry_stop > nentries:
-                entry_stop = nentries
+            entry_stop = nentries
 
         partition_key = (
             str(tree.file.uuid),


### PR DESCRIPTION
`uproot.num_entries` is a fast path to get the number of events. It should always be faster than `TTree.num_entries`. This may become noticeable for preprocessing very large filesets.

The nanoevents factory should use `uproot.num_entries` aswell (at some point), in this PR I just removed the overhead of calculating it twice.