### PR TITLE
build: Remove 'servicex' extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Set python test settings
       run: |
-        echo "INSTALL_EXTRAS='[dev,parsl,dask,servicex]'" >> $GITHUB_ENV
+        echo "INSTALL_EXTRAS='[dev,parsl,dask]'" >> $GITHUB_ENV
 
     - name: Install uv
       run: python -m pip install --upgrade uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,12 +83,6 @@ spark = [
 parsl = [
   "parsl>=2022.12.1"
 ]
-servicex = [
-  "aiostream",
-  "tenacity",
-  "servicex>=2.5.3",
-  "func-adl_servicex",
-]
 rucio = [
   "rucio-clients>=32;python_version>'3.8'",
   "rucio-clients<32;python_version<'3.9'",


### PR DESCRIPTION
In discussion with @BenGalewsky @ponyisi and @lgray on 2024-11-20 it was decided that the `servicex` extra is very out of date, and no longer actively used.