### PR TITLE
fix: use `ak.mask` instead of `ak.Array.mask`

### DIFF
--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -80,8 +80,8 @@ def test_read_nanomc(tests_directory, suffix):
     events = factory.events()
 
     # test after views first
-    genroundtrips(events.GenPart.mask[events.GenPart.eta > 0])
-    genroundtrips(events.mask[ak.any(events.Electron.pt > 50, axis=1)].GenPart)
+    genroundtrips(ak.mask(events.GenPart, events.GenPart.eta > 0))
+    genroundtrips(ak.mask(events, ak.any(events.Electron.pt > 50, axis=1)).GenPart)
     genroundtrips(events.GenPart)
 
     genroundtrips(events.GenPart[events.GenPart.eta > 0])


### PR DESCRIPTION
This prevents the `test_read_nanomc` test to fail with the upcoming awkward-array release (or _current_ awkward-array master) as we decided to use a weak-ref in order to break a cyclic reference when using `.mask` (see https://github.com/scikit-hep/awkward/pull/3347)