### PR TITLE
fix: backport double cb typo to 0.7.x

### DIFF
--- a/coffea/lookup_tools/doublecrystalball.py
+++ b/coffea/lookup_tools/doublecrystalball.py
@@ -204,7 +204,7 @@ class doublecrystalball_gen(rv_continuous):
         """
         Shape parameter bounds are m > 1 and beta > 0.
         """
-        return (mL > 1) & (betaL > 0) & (mH > 1) & (betaH > 1)
+        return (mL > 1) & (betaL > 0) & (mH > 1) & (betaH > 0)
 
 
 doublecrystalball = doublecrystalball_gen(


### PR DESCRIPTION
Backport https://github.com/scikit-hep/coffea/pull/1243.
Someone may want to import it for muon corrections.