### PR TITLE
feat: nanoevents without domain-specific mini-language

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -740,7 +740,7 @@ class NanoEventsFactory:
             base_form["parameters"]["metadata"] = metadata
         if not callable(schemaclass):
             raise ValueError("Invalid schemaclass type")
-        if schemaclass.__name__ == 'NanoAODSchema':
+        if schemaclass.__name__ == "NanoAODSchema":
             schema = schemaclass(base_form, tree)
         else:
             schema = schemaclass(base_form)

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -101,7 +101,7 @@ class _OnlySliceableAs:
 
 class _map_schema_uproot(_map_schema_base):
     def __init__(
-        self, schemaclass=BaseSchema, metadata=None, behavior=None, version=None, file=None
+        self, schemaclass=BaseSchema, metadata=None, behavior=None, version=None
     ):
         super().__init__(
             schemaclass=schemaclass,
@@ -109,7 +109,6 @@ class _map_schema_uproot(_map_schema_base):
             behavior=behavior,
             version=version,
         )
-        self.file = file
 
     def __call__(self, form):
         from coffea.nanoevents.mapping.uproot import _lazify_form
@@ -135,7 +134,7 @@ class _map_schema_uproot(_map_schema_base):
         }
 
         return (
-            awkward.forms.form.from_dict(self.schemaclass(lform, uproot.dask({self.file: "Events"}, ak_add_doc=True), self.version).form),
+            awkward.forms.form.from_dict(self.schemaclass(lform, self.version).form),
             self,
         )
 
@@ -361,7 +360,6 @@ class NanoEventsFactory:
                 behavior=dict(schemaclass.behavior()),
                 metadata=metadata,
                 version="latest",
-                file=file,
             )
 
             to_open = file
@@ -730,6 +728,8 @@ class NanoEventsFactory:
                 A schema class deriving from `BaseSchema` and implementing the desired view of the file
             metadata : dict
                 Arbitrary metadata to add to the `base.NanoEvents` object
+            tree : TTree
+                Pass TTree directly to schema
             mode:
                 Nanoevents will use "eager", "virtual", or "dask" as a backend.
 
@@ -740,9 +740,7 @@ class NanoEventsFactory:
             base_form["parameters"]["metadata"] = metadata
         if not callable(schemaclass):
             raise ValueError("Invalid schemaclass type")
-        print(schemaclass.__name__)
         if schemaclass.__name__ == 'NanoAODSchema':
-            print('Success!')
             schema = schemaclass(base_form, tree)
         else:
             schema = schemaclass(base_form)

--- a/src/coffea/nanoevents/schemas/base.py
+++ b/src/coffea/nanoevents/schemas/base.py
@@ -1,8 +1,9 @@
+import awkward
+import numpy
+
 from coffea.nanoevents import transforms
 from coffea.nanoevents.util import concat, quote
 
-import numpy
-import awkward
 
 def listarray_form(content, offsets):
     if offsets["class"] != "NumpyArray":
@@ -97,7 +98,8 @@ def nest_jagged_forms(parent, child, counts_name, name):
     parent["content"]["fields"].append(name)
     parent["content"]["contents"].append(inner)
 
-#move to transforms?
+
+# move to transforms?
 def local2globalindex(index, counts):
     """
     Convert a local index to a global index
@@ -119,15 +121,19 @@ def local2globalindex(index, counts):
     index = awkward.fill_none(index, -1)
     return index
 
-#move to transforms?
+
+# move to transforms?
 def nestedindex_form(indices):
-    '''
+    """
     Concatenate a list of indices along a new axis
     Outputs a jagged array with same outer shape as index arrays
     Add examples to documentation?
 
-    '''
-    if not all(isinstance(index.layout, awkward.contents.listoffsetarray.ListOffsetArray) for index in indices):
+    """
+    if not all(
+        isinstance(index.layout, awkward.contents.listoffsetarray.ListOffsetArray)
+        for index in indices
+    ):
         raise RuntimeError
     # return awkward.concatenate([idx[:, None] for idx in indexers], axis=1)
 
@@ -136,12 +142,12 @@ def nestedindex_form(indices):
     # also store parameters
     parameters = {}
     for i, idx in enumerate(indices):
-        if '__doc__' in parameters:
-            parameters['__doc__'] += ' and '
-            parameters['__doc__'] += awkward.parameters(idx)['__doc__']
+        if "__doc__" in parameters:
+            parameters["__doc__"] += " and "
+            parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
         else:
-            parameters['__doc__'] = 'nested from '
-            parameters['__doc__'] += awkward.parameters(idx)['__doc__']
+            parameters["__doc__"] = "nested from "
+            parameters["__doc__"] += awkward.parameters(idx)["__doc__"]
         # flatten the index
         indices[i] = awkward.Array(idx.layout.content)
 
@@ -157,22 +163,25 @@ def nestedindex_form(indices):
             awkward.contents.NumpyArray(out),
         )
     )
-    #reapply the offsets
+    # reapply the offsets
     out = awkward.Array(
         awkward.contents.ListOffsetArray(
             offsets_stored,
             out.layout,
-            parameters = parameters,
+            parameters=parameters,
         )
     )
     return out
 
-#move to transforms?
+
+# move to transforms?
 def counts2nestedindex_form(local_counts, target_offsets):
     """Turn jagged local counts into doubly-jagged global index into a target
     Outputs a jagged array with same axis-0 shape as counts axis-1
     """
-    if not isinstance(local_counts.layout, awkward.contents.listoffsetarray.ListOffsetArray):
+    if not isinstance(
+        local_counts.layout, awkward.contents.listoffsetarray.ListOffsetArray
+    ):
         raise RuntimeError
     if not isinstance(target_offsets.layout, awkward.contents.numpyarray.NumpyArray):
         raise RuntimeError
@@ -189,7 +198,7 @@ def counts2nestedindex_form(local_counts, target_offsets):
         numpy.arange(offsets[-1], dtype=numpy.int64),
         awkward.flatten(local_counts),
     )
-    #reapply the offsets
+    # reapply the offsets
     out = awkward.Array(
         awkward.contents.ListOffsetArray(
             offsets_stored,
@@ -198,23 +207,26 @@ def counts2nestedindex_form(local_counts, target_offsets):
     )
     return out
 
-#move to transforms?
+
+# move to transforms?
 def counts2offsets(counts):
-    #Cumulative sum of counts
+    # Cumulative sum of counts
     offsets = numpy.empty(len(counts) + 1, dtype=numpy.int64)
     offsets[0] = 0
     numpy.cumsum(counts, out=offsets[1:])
     return offsets
 
-#move to transforms?
+
+# move to transforms?
 def check_equal_lengths(
-        contents: list[awkward.contents.Content],
+    contents: list[awkward.contents.Content],
 ) -> int | awkward._nplikes.shape.UnknownLength:
     length = contents[0].length
     for layout in contents:
         if layout.length != length:
             raise ValueError("all arrays must have the same length")
     return length
+
 
 def zip_depth2(content, offsets, with_name, behavior, parameters=None):
     # if with_name is not None:
@@ -233,12 +245,11 @@ def zip_depth2(content, offsets, with_name, behavior, parameters=None):
     length = check_equal_lengths(contents)
     out = awkward.contents.ListOffsetArray(
         offsets=offsets,
-        content=awkward.contents.RecordArray(
-            contents, fields, length=length
-        ),
+        content=awkward.contents.RecordArray(contents, fields, length=length),
     )
     out = awkward.Array(out, behavior=behavior, with_name=with_name)
     return out
+
 
 def zip_depth1(content, with_name, behavior, parameters=None):
     # if with_name is not None:
@@ -255,11 +266,10 @@ def zip_depth1(content, with_name, behavior, parameters=None):
         for v in content.values()
     ]
     length = check_equal_lengths(contents)
-    out = awkward.contents.RecordArray(
-        contents, fields, length
-    )
+    out = awkward.contents.RecordArray(contents, fields, length)
     out = awkward.Array(out, behavior=behavior, with_name=with_name)
     return out
+
 
 class BaseSchema:
     """Base schema builder

--- a/src/coffea/nanoevents/schemas/nanoaod.py
+++ b/src/coffea/nanoevents/schemas/nanoaod.py
@@ -1,8 +1,18 @@
 import warnings
+
 import awkward
 
 from coffea.nanoevents import transforms
-from coffea.nanoevents.schemas.base import BaseSchema, zip_forms, zip_depth1, zip_depth2, counts2offsets, local2globalindex, nestedindex_form, counts2nestedindex_form
+from coffea.nanoevents.schemas.base import (
+    BaseSchema,
+    counts2nestedindex_form,
+    counts2offsets,
+    local2globalindex,
+    nestedindex_form,
+    zip_depth1,
+    zip_depth2,
+)
+
 
 def _key_formatter(prefix, form_key, form, attribute):
     if attribute == "offsets":
@@ -281,9 +291,7 @@ class NanoAODSchema(BaseSchema):
         # Create nested indexer from Idx1, Idx2, ... arrays
         for name, indexers in self.nested_items.items():
             if all(idx in branches for idx in indexers):
-                branches[name] = nestedindex_form(
-                    [branches[idx] for idx in indexers]
-                )
+                branches[name] = nestedindex_form([branches[idx] for idx in indexers])
 
         # Create nested indexer from n* counts arrays
         for name, (local_counts, target) in self.nested_index_items.items():
@@ -306,14 +314,16 @@ class NanoAODSchema(BaseSchema):
                 offsets = awkward.index.Index(offsets)
 
                 content = {
-                    k[len(name) + 1:]: v
+                    k[len(name) + 1 :]: v
                     for k, v in branches.items()
                     if k.startswith(name + "_")
                 }
-                output[name] = zip_depth2(content,
-                                           offsets,
-                                           with_name=self.mixins.get(name, "NanoCollection"),
-                                           behavior=self.behavior())
+                output[name] = zip_depth2(
+                    content,
+                    offsets,
+                    with_name=self.mixins.get(name, "NanoCollection"),
+                    behavior=self.behavior(),
+                )
 
             elif "n" + name in branches:
                 # list singleton, can use branch's own offsets
@@ -324,18 +334,20 @@ class NanoAODSchema(BaseSchema):
             else:
                 # simple collection
                 content = {
-                    k[len(name) + 1:]: v
+                    k[len(name) + 1 :]: v
                     for k, v in branches.items()
                     if k.startswith(name + "_")
                 }
-                output[name] = zip_depth1(content,
-                                           with_name=NanoAODSchema.mixins.get(name, "NanoCollection"),
-                                           behavior=NanoAODSchema.behavior())
+                output[name] = zip_depth1(
+                    content,
+                    with_name=NanoAODSchema.mixins.get(name, "NanoCollection"),
+                    behavior=NanoAODSchema.behavior(),
+                )
 
         # zipping once again
-        final_output = zip_depth1(output,
-                                   with_name="NanoEvents",
-                                   behavior=NanoAODSchema.behavior())
+        final_output = zip_depth1(
+            output, with_name="NanoEvents", behavior=NanoAODSchema.behavior()
+        )
 
         # return output.keys(), output.values()
         return final_output


### PR DESCRIPTION
The idea of the project:
1. **I/O-layer:** NanoAODschema should be constructed directly from the output of `uproot.dask`, `uproot.open`
2. Rewrite schema building by using “no-data-loading/touching” zipping operations (using parts of the code from ak.zip_no_broadcast) of the inputs coming from the **I/O layer**, instead of building awkward forms.
3. Propagate all schema specifics to the rearranged array, e.g., particle collection cross-references for NanoAOD. This will allow to entirely remove some of the features implemented through a DSL.