### PR TITLE
feat: disable_worker_transfers option to taskvine executor

### DIFF
--- a/coffea/processor/executor.py
+++ b/coffea/processor/executor.py
@@ -555,6 +555,10 @@ class TaskVineExecutor(ExecutorBase):
             Number of replicas for temporary results in the cluster before checkpointing to manager
             with an accumulation. If less than 2, only one copy of a result is kept, which reduces
             cluster disk usage, but results need to be regenerated if workers are lost.
+        disable_worker_transfers: bool
+            Disable file transfers between workers. In normal operation, TaskVine will attempt to transfer
+            common and intermediate results between workers as needed, but some workers network
+            setup do not allow for this. Default is False.
 
         verbose : bool
             If true, emit a message on each task submission and completion.
@@ -600,6 +604,7 @@ class TaskVineExecutor(ExecutorBase):
     treereduction: int = 10
     concurrent_reads: int = 2
     replicas: int = 3
+    disable_worker_transfers: bool = False
     chunksize: int = 100000
     dynamic_chunksize: Optional[Dict] = None
     custom_init: Optional[Callable] = None

--- a/coffea/processor/taskvine_executor.py
+++ b/coffea/processor/taskvine_executor.py
@@ -503,6 +503,9 @@ class CoffeaVine(Manager):
         self.tune("attempt-schedule-depth", 200)
         self.tune("hungry-minimum", 100)
 
+        if executor.disable_worker_transfers:
+            self.disable_peer_transfers()
+
         # if resource_monitor is given, and not 'off', then monitoring is activated.
         # anything other than 'measure' is assumed to be 'watchdog' mode, where in
         # addition to measuring resources, tasks are killed if they go over their
@@ -613,7 +616,7 @@ class CoffeaVineTask(PythonTask):
         # disable vine serialization as coffea does its own.
         self.disable_output_serialization()
 
-        if bring_back_output:
+        if bring_back_output or m.executor.disable_worker_transfers:
             self.set_output_cache(True)
         else:
             self.enable_temp_output()


### PR DESCRIPTION
Adds taskvine executor option to disable worker-to-worker transfers when they are not available in the cluster.