### PR TITLE
feat: add `@original_array` attr to events in virtual mode

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -761,5 +761,7 @@ class NanoEventsFactory:
                 allow_noncanonical_form=True,
             )
             self._events = weakref.ref(events)
+            if self._mode == "virtual":
+                events.attrs["@original_array"] = events
 
         return events


### PR DESCRIPTION
This shouldn't be harmful in terms of memory right? It's a reference not a copy. So this is going to hold references to materialized buffers until nanoevents are recreated (when processing the next for example). Those materialized buffers stay in memory while processing a chunk anyways.