### PR TITLE
fix: backport length zero weights min/max calculation treatment

### DIFF
--- a/coffea/analysis_tools.py
+++ b/coffea/analysis_tools.py
@@ -98,8 +98,8 @@ class Weights:
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            weight.min(),
-            weight.max(),
+            weight.min(initial=numpy.inf),
+            weight.max(initial=-numpy.inf),
             weight.size,
         )
 
@@ -160,8 +160,8 @@ class Weights:
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            weight.min(),
-            weight.max(),
+            weight.min(initial=numpy.inf),
+            weight.max(initial=-numpy.inf),
             weight.size,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ python-requires = ">=3.8,<3.12"
 spark = ["ipywidgets", "pyspark>=2.4.1,<3.0.0", "jinja2"]
 parsl = ["parsl>=2024.12.09"]
 dask = [
-    "dask[dataframe]>=2.6.0",
-    "distributed>=2.6.0",
+    "dask[dataframe]>=2023.04.0,<2025.4.0",
+    "distributed>=2023.04.0,<2025.4.0",
     "bokeh>=1.3.4",
     "blosc",
 ]


### PR DESCRIPTION
Backport of https://github.com/scikit-hep/coffea/pull/1328 to coffea 0.7.x