### PR TITLE
chore: remove vector deprecation warning and add a warning for the switch to the virtual mode default

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -27,6 +27,21 @@ from coffea.util import _remove_not_interpretable
 _offsets_label = quote(",!offsets")
 
 
+warnings.warn(
+    """NanoEventsFactory.from_root() behavior has changed.
+    The default behavior is that now it reads the input root file using
+    the newly developed virtual arrays backend of awkward instead of dask.
+    The backend choice is controlled by the `mode` argument of the method
+    which can be set to "eager", "virtual", or "dask".
+    The new default is "virtual" while the `delayed` argument has been removed.
+    The old `delayed=True` is now equivalent to `mode="dask"`.
+    The old `delayed=False` is now equivalent to `mode="eager"`.
+    """,
+    DeprecationWarning,
+    stacklevel=3,
+)
+
+
 def _key_formatter(prefix, form_key, form, attribute):
     if attribute == "offsets":
         form_key += _offsets_label

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -44,12 +44,10 @@ A small example::
 """
 
 import numbers
-from datetime import datetime
 
 import awkward
 import numba
 import numpy
-import pytz
 import vector
 from dask_awkward import dask_method
 from vector.backends.awkward import (
@@ -58,20 +56,21 @@ from vector.backends.awkward import (
     MomentumAwkward4D,
 )
 
-from coffea.util import deprecate
+# TODO: add this back in when there is an actual plan to only use scikit-hep vector
+# from coffea.util import deprecate
 
-_cst = pytz.timezone("US/Central")
-_depttime = _cst.localize(datetime(2024, 12, 31, 11, 59, 59))
-deprecate(
-    (
-        "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. "
-        "Nanoevents schemas internal to coffea will be migrated. "
-        "Otherwise please consider using that package!"
-    ),
-    version="2025.1.0",
-    date=str(_depttime),
-    category=FutureWarning,
-)
+# _cst = pytz.timezone("US/Central")
+# _depttime = _cst.localize(datetime(2024, 12, 31, 11, 59, 59))
+# deprecate(
+#     (
+#         "coffea.nanoevents.methods.vector will be removed and replaced with scikit-hep vector. "
+#         "Nanoevents schemas internal to coffea will be migrated. "
+#         "Otherwise please consider using that package!"
+#     ),
+#     version="2025.1.0",
+#     date=str(_depttime),
+#     category=FutureWarning,
+# )
 
 
 @numba.vectorize(


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/coffea/issues/1281 until there is a concrete plan to use scikit-hep vector entirely.