### PR TITLE
fix: use `awkward` for min and max in `Weights` to avoid inconsistencies between eager/virtual and dask mode

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -215,8 +215,8 @@ class Weights:
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            weight.min(initial=numpy.inf),
-            weight.max(initial=-numpy.inf),
+            awkward.min(weight, mask_identity=False),
+            awkward.max(weight, mask_identity=False),
             weight.size,
         )
         self._names.append(name)
@@ -316,8 +316,8 @@ class Weights:
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            weight.min(initial=numpy.inf),
-            weight.max(initial=-numpy.inf),
+            awkward.min(weight, mask_identity=False),
+            awkward.max(weight, mask_identity=False),
             weight.size,
         )
         self._names.append(name)


### PR DESCRIPTION
There's a problem if the input weight happens to be of integer dtype. `np.max` with infinity initial will complain that `OverflowError: cannot convert float infinity to integer`. Instead, let's use the awkward implementation that will set the initial minimum/maximum to the maximum/minimum value that can be represented by that integer dtype.