### PR TITLE
ci: change pre-commit schedule to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ ci:
     autofix_prs: true
     autoupdate_branch: ''
     autoupdate_commit_msg: 'ci(pre-commit): pre-commit autoupdate'
-    autoupdate_schedule: weekly
+    autoupdate_schedule: monthly
     skip: []
     submodules: false
 


### PR DESCRIPTION
I got a bit annoyed from the pre-commit spam. I don't think we need to do it weekly.