### PR TITLE
fix: make nanoevents properly copiable and do not store the `@original_array` attribute as that will get copied

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -268,6 +268,8 @@ class Weights:
 
         .. note:: ``weightUp`` and ``weightDown`` are assumed to be rvalue-like and may be modified in-place by this function
         """
+        if name in self._names:
+            raise ValueError(f"Weight '{name}' already exists")
         if name.endswith("Up") or name.endswith("Down"):
             raise ValueError(
                 "Avoid using 'Up' and 'Down' in weight names, instead pass appropriate shifts to add() call"
@@ -385,6 +387,8 @@ class Weights:
 
         .. note:: ``weightUp`` and ``weightDown`` are assumed to be rvalue-like and may be modified in-place by this function
         """
+        if name in self._names:
+            raise ValueError(f"Weight '{name}' already exists")
         if name.endswith("Up") or name.endswith("Down"):
             raise ValueError(
                 "Avoid using 'Up' and 'Down' in weight names, instead pass appropriate shifts to add() call"

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -268,8 +268,6 @@ class Weights:
 
         .. note:: ``weightUp`` and ``weightDown`` are assumed to be rvalue-like and may be modified in-place by this function
         """
-        if name in self._names:
-            raise ValueError(f"Weight '{name}' already exists")
         if name.endswith("Up") or name.endswith("Down"):
             raise ValueError(
                 "Avoid using 'Up' and 'Down' in weight names, instead pass appropriate shifts to add() call"
@@ -387,8 +385,6 @@ class Weights:
 
         .. note:: ``weightUp`` and ``weightDown`` are assumed to be rvalue-like and may be modified in-place by this function
         """
-        if name in self._names:
-            raise ValueError(f"Weight '{name}' already exists")
         if name.endswith("Up") or name.endswith("Down"):
             raise ValueError(
                 "Avoid using 'Up' and 'Down' in weight names, instead pass appropriate shifts to add() call"

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -283,7 +283,7 @@ class Weights:
             self.__add_delayed(name, weight, weightUp, weightDown, shift)
         else:
             raise ValueError(
-                f"Incompatible weights: self._weight={type(self.weight)}, weight={type(weight)}"
+                f"Incompatible weights: self._weight={type(self._weight)}, weight={type(weight)}"
             )
 
     def __add_multivariation_eager(
@@ -404,7 +404,7 @@ class Weights:
             )
         else:
             raise ValueError(
-                f"Incompatible weights: self._weight={type(self.weight)}, weight={type(weight)}"
+                f"Incompatible weights: self._weight={type(self._weight)}, weight={type(weight)}"
             )
 
     def __add_variation_eager(self, name, weight, weightUp, weightDown, shift):

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -776,7 +776,5 @@ class NanoEventsFactory:
                 allow_noncanonical_form=True,
             )
             self._events = weakref.ref(events)
-            if self._mode == "virtual":
-                events.attrs["@original_array"] = events
 
         return events

--- a/src/coffea/nanoevents/schemas/nanoaod.py
+++ b/src/coffea/nanoevents/schemas/nanoaod.py
@@ -340,7 +340,7 @@ class NanoAODSchema(BaseSchema):
                 output[name].setdefault("parameters", {})
                 output[name]["parameters"].update({"collection_name": name})
 
-        return output.keys(), output.values()
+        return list(output.keys()), list(output.values())
 
     @classmethod
     def behavior(cls):


### PR DESCRIPTION
Couple of lessons learned from converting HiggsDNA.