### PR TITLE
fix: consistent length zero weight stats between awkward1 and awkward2

### DIFF
--- a/coffea/analysis_tools.py
+++ b/coffea/analysis_tools.py
@@ -96,11 +96,31 @@ class Weights:
         if self._storeIndividual:
             self._weights[name] = weight
         self.__add_variation(name, weight, weightUp, weightDown, shift)
+        if weight.size == 0:
+            dtype = weight.dtype
+            if dtype in (
+                numpy.int8,
+                numpy.int16,
+                numpy.int32,
+                numpy.int64,
+                numpy.uint8,
+                numpy.uint16,
+                numpy.uint32,
+                numpy.uint64,
+            ):
+                min = numpy.iinfo(dtype).max
+                max = numpy.iinfo(dtype).min
+            else:
+                min = numpy.inf
+                max = -numpy.inf
+        else:
+            min = weight.min()
+            max = weight.max()
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            awkward.min(weight, mask_identity=False),
-            awkward.max(weight, mask_identity=False),
+            min,
+            max,
             weight.size,
         )
 
@@ -158,11 +178,31 @@ class Weights:
         ):
             systName = f"{name}_{modifier}"
             self.__add_variation(systName, weight, weightUp, weightDown, shift)
+        if weight.size == 0:
+            dtype = weight.dtype
+            if dtype in (
+                numpy.int8,
+                numpy.int16,
+                numpy.int32,
+                numpy.int64,
+                numpy.uint8,
+                numpy.uint16,
+                numpy.uint32,
+                numpy.uint64,
+            ):
+                min = numpy.iinfo(dtype).max
+                max = numpy.iinfo(dtype).min
+            else:
+                min = numpy.inf
+                max = -numpy.inf
+        else:
+            min = weight.min()
+            max = weight.max()
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            weight.min(initial=numpy.inf),
-            weight.max(initial=-numpy.inf),
+            min,
+            max,
             weight.size,
         )
 


### PR DESCRIPTION
I just found out that `mask_identity` doesn't work for awkward1
awkward2:
```
In [1]: import awkward as ak

In [2]: ak.max([], mask_identity=False)
Out[2]: np.float64(-inf)

In [3]:
```
awkward1:
```
In [1]: import awkward as ak

In [2]: ak.max([], mask_identity=False)

In [3]:
```
Reducing over empty weights will just give you None instead of the operation's identity. It seems like `mask_identity` gets ignored in awkward1 and so does `initial`. Therefore I'm manually adding the operation's identity in weight statistics min and max calculation to mimic awkward2's behavior in plain numpy.