### PR TITLE
perf: use numpy only in eager weight statistics

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -212,11 +212,31 @@ class Weights:
         if self._storeIndividual:
             self._weights[name] = weight
         self.__add_variation(name, weight, weightUp, weightDown, shift)
+        if weight.size == 0:
+            dtype = weight.dtype
+            if dtype in (
+                numpy.int8,
+                numpy.int16,
+                numpy.int32,
+                numpy.int64,
+                numpy.uint8,
+                numpy.uint16,
+                numpy.uint32,
+                numpy.uint64,
+            ):
+                min = numpy.iinfo(dtype).max
+                max = numpy.iinfo(dtype).min
+            else:
+                min = numpy.inf
+                max = -numpy.inf
+        else:
+            min = weight.min()
+            max = weight.max()
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            awkward.min(weight, mask_identity=False),
-            awkward.max(weight, mask_identity=False),
+            min,
+            max,
             weight.size,
         )
         self._names.append(name)
@@ -313,11 +333,31 @@ class Weights:
         ):
             systName = f"{name}_{modifier}"
             self.__add_variation(systName, weight, weightUp, weightDown, shift)
+        if weight.size == 0:
+            dtype = weight.dtype
+            if dtype in (
+                numpy.int8,
+                numpy.int16,
+                numpy.int32,
+                numpy.int64,
+                numpy.uint8,
+                numpy.uint16,
+                numpy.uint32,
+                numpy.uint64,
+            ):
+                min = numpy.iinfo(dtype).max
+                max = numpy.iinfo(dtype).min
+            else:
+                min = numpy.inf
+                max = -numpy.inf
+        else:
+            min = weight.min()
+            max = weight.max()
         self._weightStats[name] = WeightStatistics(
             weight.sum(),
             (weight**2).sum(),
-            awkward.min(weight, mask_identity=False),
-            awkward.max(weight, mask_identity=False),
+            min,
+            max,
             weight.size,
         )
         self._names.append(name)


### PR DESCRIPTION
Awkward is known to be much slower than plain numpy for kernel operations due to A) python overhead and B) numpy kernels being naturally faster. Example:
```py
In [3]: array = ak.Array(np.random.normal(size=1_000_000))

In [4]: %timeit np.min(array.layout.data)
70.6 μs ± 408 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [5]: %timeit ak.min(array)
3.18 ms ± 20.3 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```
So I'd rather follow the pattern and use plain numpy in eager weights/packed selection like we do everywhere else.