### PR TITLE
fix: TemporaryDirectory does not create parents in taskvine executor

### DIFF
--- a/coffea/processor/taskvine_executor.py
+++ b/coffea/processor/taskvine_executor.py
@@ -78,6 +78,7 @@ class CoffeaVine(Manager):
         self,
         executor,
     ):
+        os.makedirs(executor.filepath, exist_ok=True)
         self._staging_dir_obj = TemporaryDirectory(
             prefix="vine-tmp-", dir=executor.filepath
         )


### PR DESCRIPTION
Fix needed for coffea-casa.