### PR TITLE
chore: Remove workaround in boolean_masks_to_categorical_integers function

### DIFF
--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -113,20 +113,9 @@ def boolean_masks_to_categorical_integers(
         mask_inputs.insert(0, awkward.ones_like(mask_inputs[0], dtype=bool))
     if insert_commonmask_as_zeros is not None:
         mask_inputs.insert(0, insert_commonmask_as_zeros[:, None])
-    irregular_masks = []
-    # TODO: _generate_slices is used to work around the issue addressed in awkward PR https://github.com/scikit-hep/awkward/pull/3312
-    # which was merged in awkward v2.7.2 (https://github.com/scikit-hep/awkward/releases/tag/v2.7.2) and this can be removed when it becomes the minimum version for coffea
-    for slc in _generate_slices(len(mask_inputs), max_elements=128):
-        # create subarrays of the masks to concatenate, to work around issue prior to awkward v2.7.2
-        irregular_masks.append(
-            awkward.from_regular(awkward.concatenate(mask_inputs[slc], axis=1), axis=1)
-        )
-    if len(irregular_masks) == 1:
-        # unwrap the new concatenated (irregular) masks if there is only one
-        irregular_mask = irregular_masks[0]
-    else:
-        # if multiple irregular masks were created, concatenate them a final time
-        irregular_mask = awkward.concatenate(irregular_masks, axis=1)
+    irregular_mask = awkward.from_regular(
+        awkward.concatenate(mask_inputs, axis=1), axis=1
+    )
     if return_mask:
         return irregular_mask
     # convert the boolean masks to categorical integers by calling local index and remove elements whose mask entry was false


### PR DESCRIPTION
This is a draft as it hits a still-extant limitation in awkward which prevents actually removing this TODO for now:
https://github.com/scikit-hep/awkward/pull/3312#issuecomment-3040247268

@ikrommyd tested changing the prototype array's dtype to > int8, which resolves the immediate error. Given the name and what it seems to do, it's unclear to me if there should be a try-except logic that starts with int8 and swaps when it reaches overflow, or if this needs some different approach, or if just brute-force swapping to int64 is sufficient.

If and when such an extension is added to awkward and that becomes the minimal version for coffea, this can be further developed (`irregular_mask_sequel` will need to be validated as having identical contents to the `irregular_mask`, at which point the slice logic can be deprecated and removed)