### PR TITLE
fix: reading of sub-branches in PHYSLITE schema for eager and virtual mode

### DIFF
--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -17,7 +17,7 @@ import numpy
 import uproot
 from uproot._util import no_filter
 
-from coffea.util import _remove_not_interpretable, compress_form, decompress_form
+from coffea.util import _is_interpretable, compress_form, decompress_form
 
 
 def get_steps(
@@ -86,7 +86,7 @@ def get_steps(
                 ak_add_doc={"__doc__": "title", "typename": "typename"},
                 filter_name=no_filter,
                 filter_typename=no_filter,
-                filter_branch=partial(_remove_not_interpretable, emit_warning=False),
+                filter_branch=partial(_is_interpretable, emit_warning=False),
             ).layout.form.to_json()
             # the function cache needs to be popped if present to prevent memory growth
             if hasattr(dask.base, "function_cache"):

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -23,7 +23,7 @@ from coffea.nanoevents.mapping import (
 )
 from coffea.nanoevents.schemas import BaseSchema, NanoAODSchema
 from coffea.nanoevents.util import key_to_tuple, quote, tuple_to_key, unquote
-from coffea.util import _remove_not_interpretable
+from coffea.util import _is_interpretable
 
 _offsets_label = quote(",!offsets")
 
@@ -372,7 +372,7 @@ class NanoEventsFactory:
                 full_paths=True,
                 open_files=False,
                 ak_add_doc={"__doc__": "title", "typename": "typename"},
-                filter_branch=_remove_not_interpretable,
+                filter_branch=_is_interpretable,
                 steps_per_file=steps_per_file,
                 known_base_form=known_base_form,
                 decompression_executor=decompression_executor,

--- a/src/coffea/nanoevents/mapping/uproot.py
+++ b/src/coffea/nanoevents/mapping/uproot.py
@@ -152,9 +152,6 @@ class UprootSourceMapping(BaseSourceMapping):
                     f"Skipping {key} because it contains characters that NanoEvents cannot accept [,!]"
                 )
                 continue
-            if len(branch):
-                # The branch is split and its sub-branches will be enumerated by tree.iteritems
-                continue
             if isinstance(
                 branch.interpretation,
                 uproot.interpretation.identify.UnknownInterpretation,

--- a/src/coffea/nanoevents/mapping/uproot.py
+++ b/src/coffea/nanoevents/mapping/uproot.py
@@ -7,6 +7,7 @@ import uproot
 
 from coffea.nanoevents.mapping.base import BaseSourceMapping, UUIDOpener
 from coffea.nanoevents.util import quote, tuple_to_key
+from coffea.util import _is_interpretable
 
 
 class TrivialUprootOpener(UUIDOpener):
@@ -152,19 +153,9 @@ class UprootSourceMapping(BaseSourceMapping):
                     f"Skipping {key} because it contains characters that NanoEvents cannot accept [,!]"
                 )
                 continue
-            if isinstance(
-                branch.interpretation,
-                uproot.interpretation.identify.UnknownInterpretation,
-            ):
-                warnings.warn(f"Skipping {key} as it is not interpretable by Uproot")
+            if not _is_interpretable(branch):
                 continue
-            try:
-                form = branch.interpretation.awkward_form(None)
-            except uproot.interpretation.objects.CannotBeAwkward:
-                warnings.warn(
-                    f"Skipping {key} as it is it cannot be represented as an Awkward array"
-                )
-                continue
+            form = branch.interpretation.awkward_form(None)
             # until awkward-forth is available, this fixer is necessary
             if cls._fix_awkward_form_of_iter:
                 form = uproot._util.recursively_fix_awkward_form_of_iter(

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -209,7 +209,7 @@ def decompress_form(form_compressedb64):
     return gzip.decompress(base64.b64decode(form_compressedb64)).decode("utf-8")
 
 
-def _remove_not_interpretable(branch, emit_warning=True):
+def _is_interpretable(branch, emit_warning=True):
     if isinstance(
         branch.interpretation, uproot.interpretation.identify.uproot.AsGrouped
     ):

--- a/tests/test_nanoevents_edm4hep.py
+++ b/tests/test_nanoevents_edm4hep.py
@@ -19,7 +19,7 @@ def _events(**kwargs):
 @pytest.fixture(scope="module")
 def eager_events():
     return _events(
-        mode="eager", uproot_options={"filter_name": lambda x: "PARAMETERS" not in x}
+        mode="eager", iteritems_options={"filter_name": lambda x: "PARAMETERS" not in x}
     )
 
 

--- a/tests/test_nanoevents_fcc_edm4hep1.py
+++ b/tests/test_nanoevents_fcc_edm4hep1.py
@@ -20,7 +20,7 @@ def _events(**kwargs):
 @pytest.fixture(scope="module")
 def eager_events():
     return _events(
-        mode="eager", uproot_options={"filter_name": lambda x: "PARAMETERS" not in x}
+        mode="eager", iteritems_options={"filter_name": lambda x: "PARAMETERS" not in x}
     )
 
 

--- a/tests/test_nanoevents_fcc_winter2023.py
+++ b/tests/test_nanoevents_fcc_winter2023.py
@@ -19,7 +19,7 @@ def _events(**kwargs):
 @pytest.fixture(scope="module")
 def eager_events():
     return _events(
-        mode="eager", uproot_options={"filter_name": lambda x: "PARAMETERS" not in x}
+        mode="eager", iteritems_options={"filter_name": lambda x: "PARAMETERS" not in x}
     )
 
 

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -9,13 +9,17 @@ import pytest
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
 
 
-def _events(filter=None):
+def _events(filter=None, mode="dask"):
+    if mode == "dask":
+        kwargs = dict(uproot_options=dict(filter_name=filter))
+    else:
+        kwargs = dict(iteritems_options=dict(filter_name=filter))
     path = os.path.abspath("tests/samples/PHYSLITE_example.root")
     factory = NanoEventsFactory.from_root(
         {path: "CollectionTree"},
         schemaclass=PHYSLITESchema,
-        mode="dask",
-        uproot_options=dict(filter_name=filter),
+        mode=mode,
+        **kwargs,
     )
     return factory.events()
 
@@ -145,6 +149,121 @@ def test_electron_forms():
         "form_key": "node0",
     }
     assert json.dumps(expected_json) == mocked.to_json()
+
+
+@pytest.mark.parametrize("mode", ["dask", "virtual", "eager"])
+def test_jet_forms(mode):
+    def filter_name(name):
+        return name in [
+            "AnalysisJetsAuxDyn.pt",
+            "AnalysisJetsAuxDyn.eta",
+            "AnalysisJetsAuxDyn.phi",
+            "AnalysisJetsAuxDyn.m",
+            "AnalysisJetsAuxDyn.btaggingLink",  # this one is split into sub branches, important to test this
+        ]
+
+    events = _events(filter_name, mode=mode)
+
+    if mode == "dask":
+        mocked, _, _ = ak.to_buffers(mock_empty(events.form))
+    else:
+        mocked, _, _ = ak.to_buffers(events)
+    expected_json = {
+        "class": "RecordArray",
+        "fields": ["Jets"],
+        "contents": [
+            {
+                "class": "ListOffsetArray",
+                "offsets": "i64",
+                "content": {
+                    "class": "RecordArray",
+                    "fields": ["pt", "_eventindex", "eta", "phi", "m", "btaggingLink"],
+                    "contents": [
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "float32",
+                            "inner_shape": [],
+                            "parameters": {
+                                "__doc__": "AnalysisJetsAuxDyn.pt",
+                                "typename": "std::vector<float>",
+                            },
+                            "form_key": "node3",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "int64",
+                            "inner_shape": [],
+                            "parameters": {},
+                            "form_key": "node4",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "float32",
+                            "inner_shape": [],
+                            "parameters": {
+                                "__doc__": "AnalysisJetsAuxDyn.eta",
+                                "typename": "std::vector<float>",
+                            },
+                            "form_key": "node5",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "float32",
+                            "inner_shape": [],
+                            "parameters": {
+                                "__doc__": "AnalysisJetsAuxDyn.phi",
+                                "typename": "std::vector<float>",
+                            },
+                            "form_key": "node6",
+                        },
+                        {
+                            "class": "NumpyArray",
+                            "primitive": "float32",
+                            "inner_shape": [],
+                            "parameters": {
+                                "__doc__": "AnalysisJetsAuxDyn.m",
+                                "typename": "std::vector<float>",
+                            },
+                            "form_key": "node7",
+                        },
+                        {
+                            "class": "RecordArray",
+                            "fields": ["m_persKey", "m_persIndex"],
+                            "contents": [
+                                {
+                                    "class": "NumpyArray",
+                                    "primitive": "uint32",
+                                    "inner_shape": [],
+                                    "parameters": {},
+                                    "form_key": "node9",
+                                },
+                                {
+                                    "class": "NumpyArray",
+                                    "primitive": "uint32",
+                                    "inner_shape": [],
+                                    "parameters": {},
+                                    "form_key": "node10",
+                                },
+                            ],
+                            "parameters": {},
+                            "form_key": "node8",
+                        },
+                    ],
+                    "parameters": {"__record__": "Particle", "collection_name": "Jets"},
+                    "form_key": "node2",
+                },
+                "parameters": {},
+                "form_key": "node1",
+            }
+        ],
+        "parameters": {
+            "__doc__": "CollectionTree",
+            "__record__": "NanoEvents",
+            "metadata": {},
+        },
+        "form_key": "node0",
+    }
+    assert expected_json == json.loads(mocked.to_json())
 
 
 def test_entry_start_and_entry_stop():

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -59,7 +59,8 @@ def mock_empty(form, behavior={}):
     )
 
 
-def test_electron_forms():
+@pytest.mark.parametrize("mode", ["dask", "virtual", "eager"])
+def test_electron_forms(mode):
     def filter_name(name):
         return name in [
             "AnalysisElectronsAuxDyn.pt",
@@ -68,9 +69,12 @@ def test_electron_forms():
             "AnalysisElectronsAuxDyn.m",
         ]
 
-    events = _events(filter_name)
+    events = _events(filter_name, mode=mode)
 
-    mocked, _, _ = ak.to_buffers(mock_empty(events.form))
+    if mode == "dask":
+        mocked, _, _ = ak.to_buffers(mock_empty(events.form))
+    else:
+        mocked, _, _ = ak.to_buffers(events)
 
     expected_json = {
         "class": "RecordArray",


### PR DESCRIPTION
@ikrommyd found that eager and virtual mode currently doesn't read branches with sub-branches correctly. This is because branches with sub-branches are removed from the forms received in eager mode (by `UprootSourceMapping._extract_base_form`), but not in dask mode.

I added a test for this in case of the Jet collection, parametrized for all 3 modes (also made the existing test for the electron collection parametrized) and it passes when i remove the corresponding logic from `UprootSourceMapping._extract_base_form`. So far it doesn't seem to break anything except for triggering another unreadable branch (happens in the currently failing physlite test). We should probably try to make a bit more consistent what happens in `_remove_not_interpretable` and `UprootSourceMapping._extract_base_form`.

@ikrommyd - can you add your fix for that, maybe also having a brief look at `_remove_not_interpretable`?