### PR TITLE
feat: pass `iteritems_options` through executors

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -259,8 +259,8 @@ class NanoEventsFactory:
         schemaclass=NanoAODSchema,
         metadata=None,
         uproot_options={},
-        access_log=None,
         iteritems_options={},
+        access_log=None,
         use_ak_forth=True,
         mode="virtual",
         known_base_form=None,
@@ -277,9 +277,9 @@ class NanoEventsFactory:
                 or ``uproot.dask()``) already opened file using e.g. ``uproot.open()``.
             treepath : str, optional
                 Name of the tree to read in the file. Used only if ``file`` is a ``uproot.reading.ReadOnlyDirectory``.
-            entry_start : int, optional (eager mode only)
+            entry_start : int, optional (eager and virtual mode only)
                 Start at this entry offset in the tree (default 0)
-            entry_stop : int, optional (eager mode only)
+            entry_stop : int, optional (eager and virtual mode only)
                 Stop at this entry offset in the tree (default end of tree)
             steps_per_file: int, optional
                 Partition files into this many steps (previously "chunks")
@@ -296,6 +296,8 @@ class NanoEventsFactory:
                 Arbitrary metadata to add to the `base.NanoEvents` object
             uproot_options : dict, optional
                 Any options to pass to ``uproot.open`` or ``uproot.dask``
+            iteritems_options : dict, optional (eager and virtual mode only)
+                Any options to pass to ``tree.iteritems`` when iterating over the tree's branches to extract the form.
             access_log : list, optional
                 Pass a list instance to record which branches were lazily accessed by this instance
             use_ak_forth:

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1380,6 +1380,7 @@ class Runner:
         item: WorkItem,
         processor_instance: ProcessorABC,
         uproot_options: dict,
+        iteritems_options: dict,
     ) -> dict:
         if "timeout" in uproot_options:
             xrootdtimeout = uproot_options["timeout"]
@@ -1426,6 +1427,7 @@ class Runner:
                         mode="virtual",
                         entry_start=item.entrystart,
                         entry_stop=item.entrystop,
+                        iteritems_options=iteritems_options,
                     )
                     events = factory.events()
                 elif format == "parquet":
@@ -1467,6 +1469,7 @@ class Runner:
         processor_instance: ProcessorABC,
         treename: Optional[str] = None,
         uproot_options: Optional[dict] = {},
+        iteritems_options: Optional[dict] = {},
     ) -> Accumulatable:
         """Run the processor_instance on a given fileset
 
@@ -1483,8 +1486,12 @@ class Runner:
                 treename can also be defined in fileset, which will override the passed treename
             uproot_options : dict, optional
                 Any options to pass to ``uproot.open``
+            iteritems_options : dict, optional
+                Any options to pass to ``tree.iteritems``
         """
-        wrapped_out = self.run(fileset, processor_instance, treename, uproot_options)
+        wrapped_out = self.run(
+            fileset, processor_instance, treename, uproot_options, iteritems_options
+        )
         if self.use_dataframes:
             return wrapped_out  # not wrapped anymore
         if self.savemetrics:
@@ -1537,6 +1544,7 @@ class Runner:
         processor_instance: ProcessorABC,
         treename: Optional[str] = None,
         uproot_options: Optional[dict] = {},
+        iteritems_options: Optional[dict] = {},
     ) -> Accumulatable:
         """Run the processor_instance on a given fileset
 
@@ -1559,6 +1567,8 @@ class Runner:
                 Not needed if processing premade chunks
             uproot_options : dict, optional
                 Any options to pass to ``uproot.open``
+            iteritems_options : dict, optional
+                Any options to pass to ``tree.iteritems``
         """
 
         meta = False
@@ -1596,6 +1606,7 @@ class Runner:
                 self.savemetrics,
                 processor_instance="heavy",
                 uproot_options=uproot_options,
+                iteritems_options=iteritems_options,
             )
         else:
             closure = partial(
@@ -1607,6 +1618,7 @@ class Runner:
                 self.savemetrics,
                 processor_instance=pi_to_send,
                 uproot_options=uproot_options,
+                iteritems_options=iteritems_options,
             )
 
         chunks = list(chunks)


### PR DESCRIPTION
Allows the user to define `iteritems_options` (maybe to filter out branches) when running with executors.