### PR TITLE
feat: add typetracing to autodetect which columns are needed

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -767,15 +767,19 @@ class NanoEventsFactory:
 
         events = self._events()
         if events is None:
+            form = self._schema.form
+            buffer_key = partial(_key_formatter, self._partition_key)
             events = awkward.from_buffers(
-                self._schema.form,
+                form,
                 len(self),
                 self._mapping,
-                buffer_key=partial(_key_formatter, self._partition_key),
+                buffer_key=buffer_key,
                 behavior=self._schema.behavior(),
                 attrs={"@events_factory": self},
                 allow_noncanonical_form=True,
             )
+            events.attrs["@form"] = form
+            events.attrs["@buffer_key"] = buffer_key
             self._events = weakref.ref(events)
 
         return events

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -23,7 +23,7 @@ def _make_typetracer(
         form=events.attrs["@form"],
         buffer_key=events.attrs["@buffer_key"],
         behavior=events.behavior,
-        attrs=events.attrs,
+        attrs=events.attrs.copy(),
         highlevel=True,
     )
     tracer.attrs["@original_array"] = tracer
@@ -70,7 +70,7 @@ def _make_length_zero_one_tracer(
         allow_noncanonical_form=False,
         highlevel=True,
         behavior=events.behavior,
-        attrs=events.attrs,
+        attrs=events.attrs.copy(),
     )
     array.attrs["@original_array"] = array
 

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import Callable
 
 import awkward as ak
@@ -7,7 +8,66 @@ import awkward as ak
 from coffea.nanoevents.util import unquote
 
 
-def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]:
+def _make_typetracer(events):
+    tracer, report = ak.typetracer.typetracer_with_report(
+        form=events.attrs["@form"],
+        buffer_key=events.attrs["@buffer_key"],
+        behavior=events.behavior,
+        attrs=events.attrs,
+        highlevel=True,
+    )
+    tracer.attrs["@original_array"] = tracer
+
+    return tracer, report
+
+
+def _make_length_zero_one_tracer(events, length):
+    form = ak.forms.from_dict(events.attrs["@form"])
+    buffer_key = events.attrs["@buffer_key"]
+    buffer_keys = form.expected_from_buffers(buffer_key=buffer_key).keys()
+
+    if length == 0:
+        buffers = ak.to_buffers(
+            form.length_zero_array(),
+            byteorder=ak._util.native_byteorder,
+        )[2].values()
+    elif length == 1:
+        buffers = ak.to_buffers(
+            form.length_one_array(),
+            byteorder=ak._util.native_byteorder,
+        )[2].values()
+    else:
+        raise ValueError("length must be 0 or 1")
+
+    report = []
+
+    def generate(buffer, report, buffer_key):
+        report.append(buffer_key)
+        return buffer
+
+    container = {}
+    for key, buffer in zip(buffer_keys, buffers):
+        container[key] = partial(generate, buffer=buffer, report=report, buffer_key=key)
+    array = ak.from_buffers(
+        form=form,
+        length=length,
+        container=container,
+        buffer_key=buffer_key,
+        backend=ak.backend(events),
+        byteorder=ak._util.native_byteorder,
+        allow_noncanonical_form=False,
+        highlevel=True,
+        behavior=events.behavior,
+        attrs=events.attrs,
+    )
+    array.attrs["@original_array"] = array
+
+    return array, report
+
+
+def trace(
+    fun: Callable, events: ak.Array, mode: str = "typetracer", throw: bool = True
+) -> frozenset[str]:
     """
     Trace the execution of a function on NanoEvents to determine which buffers are touched.
 
@@ -17,6 +77,11 @@ def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]
         The function to trace.
     events : ak.Array
         The ak.Array instance to use for tracing.
+    mode : str, optional
+        Can be 'typetracer', 'length_zero_array', or 'length_one_array'.
+        The tracing mode to use. 'typetracer' uses Awkward's typetracer, while 'length_zero_array' and
+        'length_one_array' create arrays of length-zero or length-one, respectively, to trace actual data access.
+        Default is 'typetracer'.
     throw : bool, optional
         If True, exceptions during function execution will be raised; otherwise, they will be caught and
         printed. Default is True.
@@ -34,13 +99,16 @@ def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]
             "events must have '@form' and '@buffer_key' attributes set; it is automatically set when using `NanoEventsFactory.from_*(...).events()`"
         )
 
-    tracer, report = ak.typetracer.typetracer_with_report(
-        form=events.attrs["@form"],
-        buffer_key=events.attrs["@buffer_key"],
-        behavior=events.behavior,
-        attrs=events.attrs,
-        highlevel=True,
-    )
+    if mode == "typetracer":
+        tracer, report = _make_typetracer(events)
+    elif mode == "length_zero_array":
+        tracer, report = _make_length_zero_one_tracer(events, length=0)
+    elif mode == "length_one_array":
+        tracer, report = _make_length_zero_one_tracer(events, length=1)
+    else:
+        raise ValueError(
+            "mode must be one of 'typetracer', 'length_zero_array', or 'length_one_array'"
+        )
 
     try:
         _ = fun(tracer)
@@ -50,10 +118,11 @@ def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]
         else:
             print(f"Exception during function tracing: {e}")
 
+    touched = report.data_touched if mode == "typetracer" else report
     # translate the touched buffer keys to branch names
     keys = set()
     # each buffer key encodes the necessary branches through a "!load" instruction in the coffea DSL
-    for _buffer_key in report.data_touched:
+    for _buffer_key in touched:
         elements = unquote(_buffer_key.split("/")[-1]).split(",")
         keys |= {
             elements[idx - 1] for idx, instr in enumerate(elements) if instr == "!load"

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import Callable
 
 import awkward as ak
-from util import unquote
+
+from coffea.nanoevents.util import unquote
 
 
 def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]:

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -226,6 +226,7 @@ def trace(fun: Callable, events: ak.Array) -> frozenset[str]:
 
     try:
         touched |= trace_with_typetracer(fun, events)
+        return frozenset(touched)
     except Exception as e1:
         warnings.warn(
             f"Exception during typetracer tracing: {e1}",
@@ -234,6 +235,7 @@ def trace(fun: Callable, events: ak.Array) -> frozenset[str]:
         )
     try:
         touched |= trace_with_length_zero_array(fun, events)
+        return frozenset(touched)
     except Exception as e2:
         warnings.warn(
             f"Exception during length-zero array tracing: {e2}",
@@ -242,6 +244,7 @@ def trace(fun: Callable, events: ak.Array) -> frozenset[str]:
         )
     try:
         touched |= trace_with_length_one_array(fun, events)
+        return frozenset(touched)
     except Exception as e3:
         warnings.warn(
             f"Exception during length-one array tracing: {e3}",

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from functools import partial
 from typing import Callable
 
@@ -84,7 +85,7 @@ def trace(
         Default is 'typetracer'.
     throw : bool, optional
         If True, exceptions during function execution will be raised; otherwise, they will be caught and
-        printed. Default is True.
+        a warning will be issued. Default is True.
 
     Returns
     -------
@@ -116,7 +117,7 @@ def trace(
         if throw:
             raise e
         else:
-            print(f"Exception during function tracing: {e}")
+            warnings.warn(f"Exception during function tracing: {e}")
 
     touched = report.data_touched if mode == "typetracer" else report
     # translate the touched buffer keys to branch names

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -8,6 +8,13 @@ import awkward as ak
 
 from coffea.nanoevents.util import unquote
 
+__all__ = [
+    "trace_with_typetracer",
+    "trace_with_length_zero_array",
+    "trace_with_length_one_array",
+    "trace",
+]
+
 
 def _make_typetracer(
     events: ak.Array,
@@ -70,60 +77,7 @@ def _make_length_zero_one_tracer(
     return array, report
 
 
-def trace(
-    fun: Callable, events: ak.Array, mode: str = "typetracer", throw: bool = True
-) -> frozenset[str]:
-    """
-    Trace the execution of a function on NanoEvents to determine which buffers are touched.
-
-    Parameters
-    ----------
-    fun : Callable
-        The function to trace.
-    events : ak.Array
-        The ak.Array instance to use for tracing.
-    mode : str, optional
-        Can be 'typetracer', 'length_zero_array', or 'length_one_array'.
-        The tracing mode to use. 'typetracer' uses Awkward's typetracer, while 'length_zero_array' and
-        'length_one_array' create length-zero and length-one arrays respectively, to trace actual data access.
-        Default is 'typetracer'.
-    throw : bool, optional
-        If True, exceptions during function execution will be raised; otherwise, they will be caught and
-        a warning will be issued. Default is True.
-
-    Returns
-    -------
-    frozenset[str]
-        A set of branch names that were touched during the execution of the function.
-    """
-    if not isinstance(events, ak.Array):
-        raise TypeError("events must be an instance of ak.Array")
-
-    if "@form" not in events.attrs or "@buffer_key" not in events.attrs:
-        raise ValueError(
-            "events must have '@form' and '@buffer_key' attributes set; it is automatically set when using `NanoEventsFactory.from_*(...).events()`"
-        )
-
-    if mode == "typetracer":
-        tracer, report = _make_typetracer(events)
-    elif mode == "length_zero_array":
-        tracer, report = _make_length_zero_one_tracer(events, length=0)
-    elif mode == "length_one_array":
-        tracer, report = _make_length_zero_one_tracer(events, length=1)
-    else:
-        raise ValueError(
-            "mode must be one of 'typetracer', 'length_zero_array', or 'length_one_array'"
-        )
-
-    try:
-        _ = fun(tracer)
-    except Exception as e:
-        if throw:
-            raise e
-        else:
-            warnings.warn(f"Exception during function tracing: {e}")
-
-    touched = report.data_touched if mode == "typetracer" else report
+def _form_keys_to_columns(touched: list) -> frozenset[str]:
     # translate the touched buffer keys to branch names
     keys = set()
     # each buffer key encodes the necessary branches through a "!load" instruction in the coffea DSL
@@ -133,3 +87,166 @@ def trace(
             elements[idx - 1] for idx, instr in enumerate(elements) if instr == "!load"
         }
     return frozenset(keys)
+
+
+def _check_inputs(fun: Callable, events: ak.Array) -> None:
+    if not callable(fun):
+        raise TypeError(
+            "fun must be a callable function that accepts a single ak.Array argument"
+        )
+    if not isinstance(events, ak.Array):
+        raise TypeError("events must be an instance of ak.Array")
+    if "@form" not in events.attrs or "@buffer_key" not in events.attrs:
+        raise ValueError(
+            "events must have '@form' and '@buffer_key' attributes set; it is automatically set when using `NanoEventsFactory.from_*(...).events()`"
+        )
+
+
+def _attempt_tracing(fun: Callable, tracer: ak.Array, throw: bool) -> None:
+    try:
+        _ = fun(tracer)
+    except Exception as e:
+        if throw:
+            raise e
+        else:
+            warnings.warn(
+                f"Exception during function tracing: {e}",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+
+
+def trace_with_typetracer(
+    fun: Callable, events: ak.Array, throw: bool = True
+) -> frozenset[str]:
+    """
+    Trace the execution of a function on NanoEvents using Awkward's typetracer to determine which buffers are touched.
+
+    Parameters
+    ----------
+    fun : Callable
+        The function to trace. It should accept a single argument, which is an ak.Array.
+    events : ak.Array
+        The ak.Array instance to use for tracing.
+    throw : bool, optional
+        If True, exceptions during function execution will be raised; otherwise, they will be caught and
+        a warning will be issued. Default is True.
+
+    Returns
+    -------
+    frozenset[str]
+        A set of branch names that were touched during the execution of the function.
+    """
+    _check_inputs(fun, events)
+    tracer, report = _make_typetracer(events)
+    _attempt_tracing(fun, tracer, throw)
+
+    return _form_keys_to_columns(report.data_touched)
+
+
+def trace_with_length_zero_array(
+    fun: Callable, events: ak.Array, throw: bool = True
+) -> frozenset[str]:
+    """
+    Trace the execution of a function on NanoEvents using a length-zero array to determine which buffers are touched.
+
+    Parameters
+    ----------
+    fun : Callable
+        The function to trace. It should accept a single argument, which is an ak.Array.
+    events : ak.Array
+        The ak.Array instance to use for tracing.
+    throw : bool, optional
+        If True, exceptions during function execution will be raised; otherwise, they will be caught and
+        a warning will be issued. Default is True.
+
+    Returns
+    -------
+    frozenset[str]
+        A set of branch names that were touched during the execution of the function.
+    """
+    _check_inputs(fun, events)
+    tracer, report = _make_length_zero_one_tracer(events, length=0)
+    _attempt_tracing(fun, tracer, throw)
+
+    return _form_keys_to_columns(report)
+
+
+def trace_with_length_one_array(
+    fun: Callable, events: ak.Array, throw: bool = True
+) -> frozenset[str]:
+    """
+    Trace the execution of a function on NanoEvents using a length-one array to determine which buffers are touched.
+
+    Parameters
+    ----------
+    fun : Callable
+        The function to trace. It should accept a single argument, which is an ak.Array.
+    events : ak.Array
+        The ak.Array instance to use for tracing.
+    throw : bool, optional
+        If True, exceptions during function execution will be raised; otherwise, they will be caught and
+        a warning will be issued. Default is True.
+
+    Returns
+    -------
+    frozenset[str]
+        A set of branch names that were touched during the execution of the function.
+    """
+    _check_inputs(fun, events)
+    tracer, report = _make_length_zero_one_tracer(events, length=1)
+    _attempt_tracing(fun, tracer, throw)
+
+    return _form_keys_to_columns(report)
+
+
+def trace(fun: Callable, events: ak.Array) -> frozenset[str]:
+    """
+    Trace the execution of a function on NanoEvents to determine which buffers are touched.
+
+    This function first attempts to use Awkward's typetracer for tracing. If that fails,
+    it attempts tracing with a length-zero array. If that also fails, it finally attempts
+    tracing with a length-one array.
+    Eventually, it reports the set union of all branches touched during the attempts.
+
+    Parameters
+    ----------
+    fun : Callable
+        The function to trace. It should accept a single argument, which is an ak.Array.
+    events : ak.Array
+        The ak.Array instance to use for tracing.
+
+    Returns
+    -------
+    frozenset[str]
+        A set of branch names that were touched during the execution of the function.
+    """
+    _check_inputs(fun, events)
+    touched = set()
+
+    try:
+        touched |= trace_with_typetracer(fun, events)
+    except Exception as e1:
+        warnings.warn(
+            f"Exception during typetracer tracing: {e1}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    try:
+        touched |= trace_with_length_zero_array(fun, events)
+    except Exception as e2:
+        warnings.warn(
+            f"Exception during length-zero array tracing: {e2}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    try:
+        touched |= trace_with_length_one_array(fun, events)
+    except Exception as e3:
+        warnings.warn(
+            f"Exception during length-one array tracing: {e3}",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    return frozenset(touched)

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import awkward as ak
+from util import unquote
+
+
+def trace(fun: Callable, events: ak.Array, throw: bool = True) -> frozenset[str]:
+    """
+    Trace the execution of a function on NanoEvents to determine which buffers are touched.
+
+    Parameters
+    ----------
+    fun : Callable
+        The function to trace.
+    events : ak.Array
+        The ak.Array instance to use for tracing.
+    throw : bool, optional
+        If True, exceptions during function execution will be raised; otherwise, they will be caught and
+        printed. Default is True.
+
+    Returns
+    -------
+    frozenset[str]
+        A set of branch names that were touched during the execution of the function.
+    """
+    if not isinstance(events, ak.Array):
+        raise TypeError("events must be an instance of ak.Array")
+
+    if "@form" not in events.attrs or "@buffer_key" not in events.attrs:
+        raise ValueError(
+            "events must have '@form' and '@buffer_key' attributes set; it is automatically set when using `NanoEventsFactory.from_*(...).events()`"
+        )
+
+    tracer, report = ak.typetracer.typetracer_with_report(
+        form=events.attrs["@form"],
+        buffer_key=events.attrs["@buffer_key"],
+        behavior=events.behavior,
+        attrs=events.attrs,
+        highlevel=True,
+    )
+
+    try:
+        _ = fun(tracer)
+    except Exception as e:
+        if throw:
+            raise e
+        else:
+            print(f"Exception during function tracing: {e}")
+
+    # translate the touched buffer keys to branch names
+    keys = set()
+    # each buffer key encodes the necessary branches through a "!load" instruction in the coffea DSL
+    for _buffer_key in report.data_touched:
+        elements = unquote(_buffer_key.split("/")[-1]).split(",")
+        keys |= {
+            elements[idx - 1] for idx, instr in enumerate(elements) if instr == "!load"
+        }
+    return frozenset(keys)

--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -9,7 +9,9 @@ import awkward as ak
 from coffea.nanoevents.util import unquote
 
 
-def _make_typetracer(events):
+def _make_typetracer(
+    events: ak.Array,
+) -> tuple[ak.Array, ak._nplikes.typetracer.TypeTracerReport]:
     tracer, report = ak.typetracer.typetracer_with_report(
         form=events.attrs["@form"],
         buffer_key=events.attrs["@buffer_key"],
@@ -22,7 +24,9 @@ def _make_typetracer(events):
     return tracer, report
 
 
-def _make_length_zero_one_tracer(events, length):
+def _make_length_zero_one_tracer(
+    events: ak.Array, length: int
+) -> tuple[ak.Array, list]:
     form = ak.forms.from_dict(events.attrs["@form"])
     buffer_key = events.attrs["@buffer_key"]
     buffer_keys = form.expected_from_buffers(buffer_key=buffer_key).keys()
@@ -81,7 +85,7 @@ def trace(
     mode : str, optional
         Can be 'typetracer', 'length_zero_array', or 'length_one_array'.
         The tracing mode to use. 'typetracer' uses Awkward's typetracer, while 'length_zero_array' and
-        'length_one_array' create arrays of length-zero or length-one, respectively, to trace actual data access.
+        'length_one_array' create length-zero and length-one arrays respectively, to trace actual data access.
         Default is 'typetracer'.
     throw : bool, optional
         If True, exceptions during function execution will be raised; otherwise, they will be caught and

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -163,7 +163,7 @@ def _compress(item, compression):
     else:
         with BytesIO() as bf:
             with lz4f.open(bf, mode="wb", compression_level=compression) as f:
-                pickle.dump(item, f, protocol=_PICKLE_PROTOCOL)
+                cloudpickle.dump(item, f, protocol=_PICKLE_PROTOCOL)
             result = bf.getvalue()
         return result
 
@@ -174,7 +174,7 @@ def _decompress(item):
         # make a copy of it, increasing the memory usage.
         with BytesIO(item) as bf:
             with lz4f.open(bf, mode="rb") as f:
-                return pickle.load(f)
+                return cloudpickle.load(f)
     else:
         return item
 

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -163,7 +163,7 @@ def _compress(item, compression):
     else:
         with BytesIO() as bf:
             with lz4f.open(bf, mode="wb", compression_level=compression) as f:
-                cloudpickle.dump(item, f, protocol=_PICKLE_PROTOCOL)
+                pickle.dump(item, f, protocol=_PICKLE_PROTOCOL)
             result = bf.getvalue()
         return result
 
@@ -174,7 +174,7 @@ def _decompress(item):
         # make a copy of it, increasing the memory usage.
         with BytesIO(item) as bf:
             with lz4f.open(bf, mode="rb") as f:
-                return cloudpickle.load(f)
+                return pickle.load(f)
     else:
         return item
 

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import awkward as ak
@@ -526,6 +527,10 @@ def _untypetracable_analysis(events):
     return events.MET.sumEt.to_numpy()
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Windows materialization problems, related to https://github.com/scikit-hep/coffea/issues/1364",
+)
 def test_tracing():
     from coffea.nanoevents.trace import (
         trace,

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -523,7 +523,7 @@ def _analysis(events):
 
 
 def _untypetracable_analysis(events):
-    events.MET.sumEt.to_numpy()
+    return events.MET.sumEt.to_numpy()
 
 
 def test_tracing():

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -593,7 +593,7 @@ def test_tracing():
         "nMuon",
     ]
 
-    necessary_columns = trace(_analysis, events)
+    necessary_columns = trace(_analysis, events)  # this will succeed with typetracer
     assert sorted(list(necessary_columns)) == [
         "Electron_eta",
         "Electron_jetIdx",

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -469,3 +469,193 @@ def test_systematics_harness(tests_directory, mode):
     jets_PtScale_down_pt = ak.flatten(jets.systematics.PtScale.down.pt)
     assert ak.all(ak.isclose(get_array(jets_PtScale_up_pt), expected_jet_pt * 1.10))
     assert ak.all(ak.isclose(get_array(jets_PtScale_down_pt), expected_jet_pt * 0.90))
+
+
+def _analysis(events):
+    # COPIED FROM AGC: https://github.com/iris-hep/calver-coffea-agc-demo/blob/2025_IRISHEP_Training/agc-coffea-2025-virtual-arrays-and-executors.ipynb
+    import awkward as ak
+    import numpy as np
+
+    # pT > 30 GeV for leptons, > 25 GeV for jets
+    selected_electrons = events.Electron[
+        (events.Electron.pt > 30) & (np.abs(events.Electron.eta) < 2.1)
+    ]
+    selected_muons = events.Muon[
+        (events.Muon.pt > 30) & (np.abs(events.Muon.eta) < 2.1)
+    ]
+    selected_jets = events.Jet[(events.Jet.pt > 25) & (np.abs(events.Jet.eta) < 2.4)]
+
+    # single lepton requirement
+    event_filters = (
+        ak.count(selected_electrons.pt, axis=1) + ak.count(selected_muons.pt, axis=1)
+    ) == 1
+    # at least four jets
+    event_filters = event_filters & (ak.count(selected_jets.pt, axis=1) >= 4)
+    # at least two b-tagged jets ("tag" means score above threshold)
+    B_TAG_THRESHOLD = 0.5
+    event_filters = event_filters & (
+        ak.sum(selected_jets.btagDeepFlavB > B_TAG_THRESHOLD, axis=1) >= 2
+    )
+
+    # apply filters
+    selected_jets = selected_jets[event_filters]
+
+    trijet = ak.combinations(
+        selected_jets, 3, fields=["j1", "j2", "j3"]
+    )  # trijet candidate
+    trijet["p4"] = trijet.j1 + trijet.j2 + trijet.j3  # four-momentum of tri-jet system
+
+    trijet["max_btag"] = np.maximum(
+        trijet.j1.btagDeepFlavB,
+        np.maximum(trijet.j2.btagDeepFlavB, trijet.j3.btagDeepFlavB),
+    )
+    trijet = trijet[
+        trijet.max_btag > B_TAG_THRESHOLD
+    ]  # at least one-btag in trijet candidates
+    # pick trijet candidate with largest pT and calculate mass of system
+    trijet_mass = trijet["p4"][ak.argmax(trijet.p4.pt, axis=1, keepdims=True)].mass
+
+    # ensure we can handle cross-references
+    # just touch them so they land in the report
+    _ = ak.flatten(events.Electron.matched_jet)
+
+    return ak.flatten(trijet_mass)
+
+
+def _untypetracable_analysis(events):
+    events.MET.sumEt.to_numpy()
+
+
+def test_tracing():
+    from coffea.nanoevents.trace import (
+        trace,
+        trace_with_length_one_array,
+        trace_with_length_zero_array,
+        trace_with_typetracer,
+    )
+
+    events = NanoEventsFactory.from_root(
+        {"tests/samples/nano_dy.root": "Events"},
+        mode="virtual",
+        access_log=(access_log := []),
+    ).events()
+
+    necessary_columns = trace_with_typetracer(_analysis, events)
+    assert sorted(list(necessary_columns)) == [
+        "Electron_eta",
+        "Electron_jetIdx",
+        "Electron_phi",  # actual typetracer overtouching
+        "Electron_pt",
+        "Jet_btagDeepFlavB",
+        "Jet_eta",
+        "Jet_mass",
+        "Jet_phi",
+        "Jet_pt",
+        "Muon_eta",
+        "Muon_phi",  # actual typetracer overtouching
+        "Muon_pt",
+        "nElectron",
+        "nJet",
+        "nMuon",
+    ]
+
+    necessary_columns = trace_with_length_zero_array(_analysis, events)
+    assert sorted(list(necessary_columns)) == [
+        "Electron_eta",
+        "Electron_jetIdx",
+        "Electron_pt",
+        "Jet_btagDeepFlavB",
+        "Jet_eta",
+        "Jet_mass",
+        "Jet_phi",
+        "Jet_pt",
+        "Muon_eta",
+        "Muon_pt",
+        "nElectron",
+        "nJet",
+        "nMuon",
+    ]
+
+    necessary_columns = trace_with_length_one_array(_analysis, events)
+    assert sorted(list(necessary_columns)) == [
+        "Electron_eta",
+        "Electron_jetIdx",
+        "Electron_pt",
+        "Jet_btagDeepFlavB",
+        "Jet_eta",
+        "Jet_mass",
+        "Jet_phi",
+        "Jet_pt",
+        "Muon_eta",
+        "Muon_pt",
+        "nElectron",
+        "nJet",
+        "nMuon",
+    ]
+
+    necessary_columns = trace(_analysis, events)
+    assert sorted(list(necessary_columns)) == [
+        "Electron_eta",
+        "Electron_jetIdx",
+        "Electron_phi",  # actual typetracer overtouching
+        "Electron_pt",
+        "Jet_btagDeepFlavB",
+        "Jet_eta",
+        "Jet_mass",
+        "Jet_phi",
+        "Jet_pt",
+        "Muon_eta",
+        "Muon_phi",  # actual typetracer overtouching
+        "Muon_pt",
+        "nElectron",
+        "nJet",
+        "nMuon",
+    ]
+
+    assert access_log == []
+    _ = _analysis(events)
+    assert sorted(set(access_log)) == [
+        "Electron_eta",
+        "Electron_jetIdx",
+        "Electron_pt",
+        "Jet_btagDeepFlavB",
+        "Jet_eta",
+        "Jet_mass",
+        "Jet_phi",
+        "Jet_pt",
+        "Muon_eta",
+        "Muon_pt",
+        "nElectron",
+        "nJet",
+        "nMuon",
+    ]
+
+    events = NanoEventsFactory.from_root(
+        {"tests/samples/nano_dy.root": "Events"},
+        mode="virtual",
+        access_log=(access_log := []),
+    ).events()
+
+    with pytest.raises(TypeError, match="from an nplike without known data"):
+        necessary_columns = trace_with_typetracer(
+            _untypetracable_analysis, events, throw=True
+        )
+    necessary_columns = trace_with_typetracer(
+        _untypetracable_analysis, events, throw=False
+    )
+    assert sorted(list(necessary_columns)) == []  # nothing found
+
+    necessary_columns = trace_with_length_zero_array(_untypetracable_analysis, events)
+    assert sorted(list(necessary_columns)) == ["MET_sumEt"]
+
+    necessary_columns = trace_with_length_one_array(_untypetracable_analysis, events)
+    assert sorted(list(necessary_columns)) == ["MET_sumEt"]
+
+    necessary_columns = trace(
+        _untypetracable_analysis, events
+    )  # this will fall back to length-zero array
+    assert sorted(list(necessary_columns)) == ["MET_sumEt"]
+
+    assert access_log == []
+    _untypetracable_analysis(events)
+    assert sorted(set(access_log)) == ["MET_sumEt"]

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -544,7 +544,7 @@ def test_tracing():
     assert sorted(list(necessary_columns)) == [
         "Electron_eta",
         "Electron_jetIdx",
-        "Electron_phi",  # actual typetracer overtouching
+        "Electron_phi",  # actual typetracer "overtouching", see https://github.com/scikit-hep/vector/pull/542
         "Electron_pt",
         "Jet_btagDeepFlavB",
         "Jet_eta",
@@ -552,7 +552,7 @@ def test_tracing():
         "Jet_phi",
         "Jet_pt",
         "Muon_eta",
-        "Muon_phi",  # actual typetracer overtouching
+        "Muon_phi",  # actual typetracer "overtouching", see https://github.com/scikit-hep/vector/pull/542
         "Muon_pt",
         "nElectron",
         "nJet",
@@ -597,7 +597,7 @@ def test_tracing():
     assert sorted(list(necessary_columns)) == [
         "Electron_eta",
         "Electron_jetIdx",
-        "Electron_phi",  # actual typetracer overtouching
+        "Electron_phi",  # actual typetracer "overtouchng", see https://github.com/scikit-hep/vector/pull/542
         "Electron_pt",
         "Jet_btagDeepFlavB",
         "Jet_eta",
@@ -605,7 +605,7 @@ def test_tracing():
         "Jet_phi",
         "Jet_pt",
         "Muon_eta",
-        "Muon_phi",  # actual typetracer overtouching
+        "Muon_phi",  # actual typetracer "overtouching", see https://github.com/scikit-hep/vector/pull/542
         "Muon_pt",
         "nElectron",
         "nJet",

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 import awkward as ak
@@ -527,10 +526,6 @@ def _untypetracable_analysis(events):
     return events.MET.sumEt.to_numpy()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="Windows materialization problems, related to https://github.com/scikit-hep/coffea/issues/1364",
-)
 def test_tracing():
     from coffea.nanoevents.trace import (
         trace,


### PR DESCRIPTION
This PR adds a `trace` function that lets you trace e.g. `Processor.process` with awkward's typetracer to infer the necessary columns, e.g.:
```python
def analysis(events):
    # COPIED FROM AGC: https://github.com/iris-hep/calver-coffea-agc-demo/blob/2025_IRISHEP_Training/agc-coffea-2025-virtual-arrays-and-executors.ipynb
    import awkward as ak
    import numpy as np
    
    # pT > 30 GeV for leptons, > 25 GeV for jets
    selected_electrons = events.Electron[
        (events.Electron.pt > 30) & (np.abs(events.Electron.eta) < 2.1)
    ]
    selected_muons = events.Muon[
        (events.Muon.pt > 30) & (np.abs(events.Muon.eta) < 2.1)
    ]
    selected_jets = events.Jet[(events.Jet.pt > 25) & (np.abs(events.Jet.eta) < 2.4)]

    # single lepton requirement
    event_filters = (
        ak.count(selected_electrons.pt, axis=1) + ak.count(selected_muons.pt, axis=1)
    ) == 1
    # at least four jets
    event_filters = event_filters & (ak.count(selected_jets.pt, axis=1) >= 4)
    # at least two b-tagged jets ("tag" means score above threshold)
    B_TAG_THRESHOLD = 0.5
    event_filters = event_filters & (
        ak.sum(selected_jets.btagDeepFlavB > B_TAG_THRESHOLD, axis=1) >= 2
    )

    # apply filters
    selected_jets = selected_jets[event_filters]

    trijet = ak.combinations(
        selected_jets, 3, fields=["j1", "j2", "j3"]
    )  # trijet candidate
    trijet["p4"] = trijet.j1 + trijet.j2 + trijet.j3  # four-momentum of tri-jet system

    trijet["max_btag"] = np.maximum(
        trijet.j1.btagDeepFlavB, np.maximum(trijet.j2.btagDeepFlavB, trijet.j3.btagDeepFlavB)
    )
    trijet = trijet[
        trijet.max_btag > B_TAG_THRESHOLD
    ]  # at least one-btag in trijet candidates
    # pick trijet candidate with largest pT and calculate mass of system
    trijet_mass = trijet["p4"][ak.argmax(trijet.p4.pt, axis=1, keepdims=True)].mass

    # ensure we can handle cross-references
    # just touch them so they land in the report
    _ = ak.flatten(events.Electron.matched_jet)

    return ak.flatten(trijet_mass)
    
    
from coffea.nanoevents import NanoEventsFactory
from coffea.nanoevents.trace import trace

events = NanoEventsFactory.from_root(
  {"nanoaod.root": "Events"},
  mode="virtual",
  access_log=(access_log := []),
).events()

necessary_columns = trace(analysis, events)

print(necessary_columns)
# frozenset({
#   'Electron_eta',
#   'Electron_jetIdx',
#   'Electron_pt',
#   'Jet_btagDeepFlavB',
#   'Jet_eta',
#   'Jet_mass',
#   'Jet_phi',
#   'Jet_pt',
#   'Muon_eta',
#   'Muon_phi',
#   'Muon_pt',
#   'nElectron',
#   'nJet',
#   'nMuon',
# })
```

If `analysis` is not traceable, you can set `throw=False` in `trace`, i.e. `trace(analysis, events, throw=False)`, and it will trace as much as it can.


This feature works well together with https://github.com/scikit-hep/coffea/pull/1387 as you can then do:
```python
needed = trace(analysis, events)

preload = lambda b: b.name in needed

events = NanoEventsFactory.from_root(
  {"nanoaod.root": "Events"}, 
  mode="virtual", 
  access_log=(access_log := []), 
  preload=preload,
).events()
```
in order to preload everything the tracer could figure out automatically.