### PR TITLE
feat: add dataset to the `FileMeta` hash to allow different metadata for the same file if used in multiple datasets

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -62,7 +62,7 @@ class FileMeta:
         self.metadata = metadata
 
     def __str__(self):
-        return f"FileMeta({self.filename}:{self.treename})"
+        return f"FileMeta({self.dataset}:{self.filename}:{self.treename})"
 
     def __hash__(self):
         return _hash((self.dataset, self.filename, self.treename))

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -65,12 +65,15 @@ class FileMeta:
         return f"FileMeta({self.filename}:{self.treename})"
 
     def __hash__(self):
-        # As used to lookup metadata, no need for dataset
-        return _hash((self.filename, self.treename))
+        return _hash((self.dataset, self.filename, self.treename))
 
     def __eq__(self, other):
         # In case of hash collisions
-        return self.filename == other.filename and self.treename == other.treename
+        return (
+            self.dataset == other.dataset
+            and self.filename == other.filename
+            and self.treename == other.treename
+        )
 
     def maybe_populate(self, cache):
         if cache and self in cache:


### PR DESCRIPTION
Fixes https://github.com/scikit-hep/coffea/issues/1384

We use a cache to cache the metadata. The keys are the `hash` of the `FileMeta` objects. So when you preprocess a file from a dataset, its metadata are cached. The `hash` however, is only a function of the file name and the tree name, so when you preprocess the same file but from a different dataset, the code says "Oh I have the metadata for that in the cache, let's grab it from there". I'm solving it by making the hash a function of the dataset name too.

In general, it's bad to use the same file twice because you are sub-optimizing reading. They will be treated as two different files and be read separately. However, if people are allowed to do it, we shouldn't deliberately mess up their metadata I think.