### PR TITLE
feat: do not enforce dask awkward arrays in jetmet tools

### DIFF
--- a/src/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/src/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -6,7 +6,6 @@ import dask_awkward
 import numpy
 
 from coffea.lookup_tools.jme_standard_function import jme_standard_function
-from coffea.util import maybe_map_partitions
 
 
 def _checkConsistency(against, tocheck):
@@ -180,7 +179,7 @@ class FactorizedJetCorrector:
                 behavior=zl_out.behavior,
             )
 
-            return maybe_map_partitions(
+            return dask_awkward.map_partitions(
                 func,
                 *tuple(kwargs.values()),
                 label=f"{self._campaign}-{self._dataera}-{self._datatype}-{levels}-{self._jettype}",

--- a/src/coffea/jetmet_tools/FactorizedJetCorrector.py
+++ b/src/coffea/jetmet_tools/FactorizedJetCorrector.py
@@ -6,6 +6,7 @@ import dask_awkward
 import numpy
 
 from coffea.lookup_tools.jme_standard_function import jme_standard_function
+from coffea.util import maybe_map_partitions
 
 
 def _checkConsistency(against, tocheck):
@@ -168,7 +169,7 @@ class FactorizedJetCorrector:
             zl_out = func(
                 *tuple(
                     awkward.Array(
-                        arg._meta.layout.form.length_zero_array(highlevel=False),
+                        arg.layout.form.length_zero_array(highlevel=False),
                         behavior=arg.behavior,
                     )
                     for arg in kwargs.values()
@@ -179,7 +180,7 @@ class FactorizedJetCorrector:
                 behavior=zl_out.behavior,
             )
 
-            return dask_awkward.map_partitions(
+            return maybe_map_partitions(
                 func,
                 *tuple(kwargs.values()),
                 label=f"{self._campaign}-{self._dataera}-{self._datatype}-{levels}-{self._jettype}",


### PR DESCRIPTION
These `dak.from_awkward` calls for arrays containing virtual buffers are very problematic. They cause headaches and are problematic with pickling especially when a distributed client is alive.
They also force the user to do a `.compute()` on the output of the jetmet tools which has been very confusing to the users so far. Creating dask-awkward arrays when using executors is very counter-intuitive. It should be avoided