### PR TITLE
feat: add checkpointing functionality to coffea.processor.Runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
   "cachetools",
   "requests",
   "aiohttp",
+  "fsspec",
 ]
 dynamic = ["version"]
 

--- a/src/coffea/processor/__init__.py
+++ b/src/coffea/processor/__init__.py
@@ -11,7 +11,7 @@ from .accumulator import (
     set_accumulator,
     value_accumulator,
 )
-from .checkpointer import CheckpointerABC, LocalCheckpointer
+from .checkpointer import CheckpointerABC, SimpleCheckpointer
 from .executor import (
     DaskExecutor,
     FuturesExecutor,
@@ -31,7 +31,7 @@ __all__ = [
     "TaskVineExecutor",
     "Runner",
     "CheckpointerABC",
-    "LocalCheckpointer",
+    "SimpleCheckpointer",
     "accumulate",
     "Accumulatable",
     "AccumulatorABC",

--- a/src/coffea/processor/__init__.py
+++ b/src/coffea/processor/__init__.py
@@ -11,6 +11,7 @@ from .accumulator import (
     set_accumulator,
     value_accumulator,
 )
+from .checkpointer import CheckpointerABC, LocalCheckpointer
 from .executor import (
     DaskExecutor,
     FuturesExecutor,
@@ -29,6 +30,8 @@ __all__ = [
     "ParslExecutor",
     "TaskVineExecutor",
     "Runner",
+    "CheckpointerABC",
+    "LocalCheckpointer",
     "accumulate",
     "Accumulatable",
     "AccumulatorABC",

--- a/src/coffea/processor/checkpointer.py
+++ b/src/coffea/processor/checkpointer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import fsspec
+from rich import print
 
 from coffea.util import load, save
 

--- a/src/coffea/processor/checkpointer.py
+++ b/src/coffea/processor/checkpointer.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from abc import ABCMeta, abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from coffea.util import load, save
+
+if TYPE_CHECKING:
+    from coffea.processor import Accumulatable, ProcessorABC
+
+
+class CheckpointerABC(metaclass=ABCMeta):
+    """ABC for a generalized checkpointer
+
+    Checkpointers are used to save chunk outputs to disk, and reload them if the same chunk is processed again.
+    This is useful for long-running jobs that may be interrupted (resumable processing).
+
+    Examples
+    --------
+
+    >>> from datetime import datetime
+    >>> from coffea import processor
+    >>> from coffea.processor import LocalCheckpointer
+
+    # create a checkpointer that stores checkpoints in a directory with the current date/time
+    # (you may want to use a more specific directory in practice)
+    >>> datestring = datetime.now().strftime("%Y%m%d%H")
+    >>> checkpointer = LocalCheckpointer(checkpoint_dir=f"checkpoints/{datestring}", verbose=True)
+
+    # pass the checkpointer to a Runner
+    >>> run = processor.Runner(..., checkpointer=checkpointer)
+    >>> output = run(...)
+
+    After the run, the checkpoints will be stored in the directory ``checkpoints/{datestring}``. On a subsequent run,
+    if the same chunks are processed (and the same checkpointer, or rather ``checkpoint_dir`` is used),
+    the results will be loaded from disk instead of being recomputed.
+    """
+
+    @abstractmethod
+    def load(
+        self, metadata: Any, processor_instance: ProcessorABC
+    ) -> Accumulatable | None: ...
+
+    @abstractmethod
+    def save(
+        self, output: Accumulatable, metadata: Any, processor_instance: ProcessorABC
+    ) -> None: ...
+
+
+class LocalCheckpointer(CheckpointerABC):
+    def __init__(self, checkpoint_dir: str | Path, verbose: bool = False) -> None:
+        self.checkpoint_dir = Path(checkpoint_dir)
+        self.verbose = verbose
+
+    def filepath(self, metadata: Any, processor_instance: ProcessorABC) -> str:
+        del processor_instance  # not used here, but could be in subclasses
+
+        # build a path from metadata
+        path = self.checkpoint_dir
+        path /= metadata["dataset"]
+        path /= metadata["fileuuid"]
+        path /= metadata["treename"]
+        path /= f"{metadata['entrystart']}-{metadata['entrystop']}"
+
+        # ensure directory exists
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # add .coffea
+        suffix = ".coffea"
+        return str(path) + suffix
+
+    def load(
+        self, metadata: Any, processor_instance: ProcessorABC
+    ) -> Accumulatable | None:
+        try:
+            fname = self.filepath(metadata, processor_instance)
+            return load(fname)
+        except Exception as e:
+            if self.verbose:
+                print(f"Could not load checkpoint: {e}. May be the first run...")
+            return None
+
+    def save(
+        self, output: Accumulatable, metadata: Any, processor_instance: ProcessorABC
+    ) -> None:
+        try:
+            fname = self.filepath(metadata, processor_instance)
+            save(output, fname)
+        except Exception as e:
+            if self.verbose:
+                print(
+                    f"Could not save checkpoint: {e}. Continuing without checkpointing..."
+                )
+        return None

--- a/src/coffea/processor/checkpointer.py
+++ b/src/coffea/processor/checkpointer.py
@@ -57,10 +57,9 @@ class SimpleCheckpointer(CheckpointerABC):
         verbose: bool = False,
         overwrite: bool = True,
     ) -> None:
-        fs, token, paths = fsspec.get_fs_token_paths(checkpoint_dir)
-        assert len(paths) == 1, "Checkpoint directory must be a single path"
+        fs, path = fsspec.url_to_fs(checkpoint_dir)
         self.fs = fs
-        self.checkpoint_dir = paths[0]
+        self.checkpoint_dir = path
         self.verbose = verbose
         self.overwrite = overwrite
 

--- a/src/coffea/processor/checkpointer.py
+++ b/src/coffea/processor/checkpointer.py
@@ -21,12 +21,12 @@ class CheckpointerABC(metaclass=ABCMeta):
 
     >>> from datetime import datetime
     >>> from coffea import processor
-    >>> from coffea.processor import LocalCheckpointer
+    >>> from coffea.processor import SimpleCheckpointer
 
     # create a checkpointer that stores checkpoints in a directory with the current date/time
     # (you may want to use a more specific directory in practice)
     >>> datestring = datetime.now().strftime("%Y%m%d%H")
-    >>> checkpointer = LocalCheckpointer(checkpoint_dir=f"checkpoints/{datestring}", verbose=True)
+    >>> checkpointer = SimpleCheckpointer(checkpoint_dir=f"checkpoints/{datestring}", verbose=True)
 
     # pass the checkpointer to a Runner
     >>> run = processor.Runner(..., checkpointer=checkpointer)
@@ -48,7 +48,7 @@ class CheckpointerABC(metaclass=ABCMeta):
     ) -> None: ...
 
 
-class LocalCheckpointer(CheckpointerABC):
+class SimpleCheckpointer(CheckpointerABC):
     def __init__(
         self,
         checkpoint_dir: str | Path,

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1388,7 +1388,7 @@ class Runner:
         processor_instance: ProcessorABC,
         uproot_options: dict,
         iteritems_options: dict,
-        checkpointer=None,
+        checkpointer: CheckpointerABC,
     ) -> dict:
         if "timeout" in uproot_options:
             xrootdtimeout = uproot_options["timeout"]

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -29,6 +29,7 @@ from cachetools import LRUCache
 from ..nanoevents import NanoEventsFactory, schemas
 from ..util import _exception_chain, _hash, rich_bar
 from .accumulator import Accumulatable, accumulate, set_accumulator
+from .checkpointer import CheckpointerABC
 from .processor import ProcessorABC
 
 _PICKLE_PROTOCOL = pickle.HIGHEST_PROTOCOL
@@ -1023,6 +1024,8 @@ class Runner:
             determine chunking.  Defaults to a in-memory LRU cache that holds 100k entries
             (about 1MB depending on the length of filenames, etc.)  If you edit an input file
             (please don't) during a session, the session can be restarted to clear the cache.
+        checkpointer : CheckpointerABC, optional
+            A CheckpointerABC instance to manage checkpointing of each chunk output
     """
 
     executor: ExecutorBase
@@ -1039,6 +1042,7 @@ class Runner:
     use_skyhook: Optional[bool] = False
     skyhook_options: Optional[dict] = field(default_factory=dict)
     format: str = "root"
+    checkpointer: Optional[CheckpointerABC] = None
 
     @staticmethod
     def read_coffea_config():
@@ -1384,6 +1388,7 @@ class Runner:
         processor_instance: ProcessorABC,
         uproot_options: dict,
         iteritems_options: dict,
+        checkpointer=None,
     ) -> dict:
         if "timeout" in uproot_options:
             xrootdtimeout = uproot_options["timeout"]
@@ -1391,6 +1396,28 @@ class Runner:
             item, processor_instance = item
         if not isinstance(processor_instance, ProcessorABC):
             processor_instance = cloudpickle.loads(lz4f.decompress(processor_instance))
+
+        metadata = {
+            "dataset": item.dataset,
+            "filename": item.filename,
+            "treename": item.treename,
+            "entrystart": item.entrystart,
+            "entrystop": item.entrystop,
+            "fileuuid": (
+                str(uuid.UUID(bytes=item.fileuuid)) if len(item.fileuuid) > 0 else ""
+            ),
+        }
+        if item.usermeta is not None:
+            metadata.update(item.usermeta)
+
+        if checkpointer is not None:
+            if not isinstance(checkpointer, CheckpointerABC):
+                raise TypeError("Expected checkpointer to derive from CheckpointerABC")
+            # try to load from checkpoint
+            out = checkpointer.load(metadata, processor_instance)
+            # if we got something, return it
+            if out is not None:
+                return out
 
         try:
             if format == "root":
@@ -1405,19 +1432,6 @@ class Runner:
             raise Exception(
                 f"Failed to open file: {item!r}. The error was: {e!r}."
             ) from e
-
-        metadata = {
-            "dataset": item.dataset,
-            "filename": item.filename,
-            "treename": item.treename,
-            "entrystart": item.entrystart,
-            "entrystop": item.entrystop,
-            "fileuuid": (
-                str(uuid.UUID(bytes=item.fileuuid)) if len(item.fileuuid) > 0 else ""
-            ),
-        }
-        if item.usermeta is not None:
-            metadata.update(item.usermeta)
 
         with filecontext as file:
             if schema is None:
@@ -1464,9 +1478,7 @@ class Runner:
                     "Output of process() should not be None. Make sure your processor's process() function returns an accumulator."
                 )
             toc = time.time()
-            if use_dataframes:
-                return out
-            else:
+            if not use_dataframes:
                 if savemetrics:
                     metrics = {}
                     if isinstance(file, uproot.ReadOnlyDirectory):
@@ -1475,8 +1487,13 @@ class Runner:
                         metrics["columns"] = set(materialized)
                         metrics["entries"] = len(events)
                     metrics["processtime"] = toc - tic
-                    return {"out": out, "metrics": metrics, "processed": {item}}
-                return {"out": out, "processed": {item}}
+                    out = {"out": out, "metrics": metrics, "processed": {item}}
+                out = {"out": out, "processed": {item}}
+
+            if checkpointer is not None:
+                # save the output
+                checkpointer.save(out, metadata, processor_instance)
+            return out
 
     def __call__(
         self,
@@ -1622,6 +1639,7 @@ class Runner:
                 processor_instance="heavy",
                 uproot_options=uproot_options,
                 iteritems_options=iteritems_options,
+                checkpointer=self.checkpointer,
             )
         else:
             closure = partial(
@@ -1634,6 +1652,7 @@ class Runner:
                 processor_instance=pi_to_send,
                 uproot_options=uproot_options,
                 iteritems_options=iteritems_options,
+                checkpointer=self.checkpointer,
             )
 
         chunks = list(chunks)

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1491,6 +1491,10 @@ class Runner:
                 out = {"out": out, "processed": {item}}
 
             if checkpointer is not None:
+                if not isinstance(checkpointer, CheckpointerABC):
+                    raise TypeError(
+                        "Expected checkpointer to derive from CheckpointerABC"
+                    )
                 # save the output
                 checkpointer.save(out, metadata, processor_instance)
             return out

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -32,12 +32,12 @@ import warnings
 from functools import partial
 
 import cloudpickle
-import lz4.frame
+import fsspec
 
 
 def load(filename):
     """Load a coffea file from disk"""
-    with lz4.frame.open(filename) as fin:
+    with fsspec.open(filename, "rb", compression="lz4") as fin:
         output = cloudpickle.load(fin)
     return output
 
@@ -54,7 +54,7 @@ def save(output, filename, fast=True):
     care should be taken.
     """
     try:
-        with lz4.frame.open(filename, "wb") as fout:
+        with fsspec.open(filename, "wb", compression="lz4") as fout:
             p = cloudpickle.Pickler(fout)
             p.fast = fast
             p.dump(output)

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -64,13 +64,10 @@ def test_checkpointing():
     # number of WorkItems
     n_expected_checkpoints = len(chunks)
     ntries = 0
-    fs, token, paths = fsspec.get_fs_token_paths(checkpoint_dir)
+    fs, path = fsspec.url_to_fs(checkpoint_dir)
 
     # keep trying until we have as many checkpoints as WorkItems
-    while (
-        len(list(filter(fs.isfile, fs.glob(f"{paths[0]}/**"))))
-        != n_expected_checkpoints
-    ):
+    while len(list(filter(fs.isfile, fs.glob(f"{path}/**")))) != n_expected_checkpoints:
         fs.invalidate_cache()
         ntries += 1
         try:
@@ -81,13 +78,10 @@ def test_checkpointing():
 
     # make sure we have as many checkpoints as WorkItems
     fs.invalidate_cache()
-    assert (
-        len(list(filter(fs.isfile, fs.glob(f"{paths[0]}/**"))))
-        == n_expected_checkpoints
-    )
+    assert len(list(filter(fs.isfile, fs.glob(f"{path}/**")))) == n_expected_checkpoints
 
     # make sure we got the right answer
     assert out == {"cutflow": {"Data_pt": np.int64(84), "ZJets_pt": np.int64(18)}}
 
     # cleanup
-    fs.rm(paths[0], recursive=True)
+    fs.rm(path, recursive=True)

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -46,7 +46,7 @@ def test_checkpointing():
 
     executor = processor.IterativeExecutor()
 
-    checkpointer = processor.LocalCheckpointer(
+    checkpointer = processor.SimpleCheckpointer(
         path := (Path(__file__).parent / "test_checkpointing")
     )
     run = processor.Runner(

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -1,0 +1,81 @@
+import operator
+import os.path as osp
+import random
+import shutil
+from pathlib import Path
+
+import awkward as ak
+import numpy as np
+
+from coffea import processor
+from coffea.nanoevents import schemas
+
+# we want repeatable failures, and know that we never run indefinitely
+random.seed(1234)
+
+
+class UnstableNanoEventsProcessor(processor.ProcessorABC):
+    @property
+    def accumulator(self):
+        return {"cutflow": {}}
+
+    def process(self, events):
+        if random.random() < 0.5:
+            raise RuntimeError("Random failure for testing checkpointing")
+
+        output = self.accumulator
+        dataset = events.metadata["dataset"]
+        output["cutflow"]["%s_pt" % dataset] = ak.sum(ak.num(events.Muon, axis=1))
+        return output
+
+    def postprocess(self, accumulator):
+        return accumulator
+
+
+def test_checkpointing():
+    filelist = {
+        "ZJets": {
+            "treename": "Events",
+            "files": [osp.abspath("tests/samples/nano_dy.root")],
+        },
+        "Data": {
+            "treename": "Events",
+            "files": [osp.abspath("tests/samples/nano_dimuon.root")],
+        },
+    }
+
+    executor = processor.IterativeExecutor()
+
+    checkpointer = processor.LocalCheckpointer(
+        path := (Path(__file__).parent / "test_checkpointing")
+    )
+    run = processor.Runner(
+        executor=executor,
+        schema=schemas.NanoAODSchema,
+        chunksize=10,
+        format="root",
+        checkpointer=checkpointer,
+    )
+
+    # number of WorkItems
+    expected_checkpoints = len(list(run.preprocess(filelist, "Events")))
+    is_file = operator.methodcaller("is_file")
+    ntries = 0
+
+    # keep trying until we have as many checkpoints as WorkItems
+    while len(list(filter(is_file, path.rglob("*")))) != expected_checkpoints:
+        ntries += 1
+        try:
+            out = run(filelist, UnstableNanoEventsProcessor(), "Events")
+        except Exception:
+            print(f"Run failed, trying again, try number {ntries}...")
+            continue
+
+    # make sure we have as many checkpoints as WorkItems
+    assert len(list(filter(is_file, path.rglob("*")))) == expected_checkpoints
+
+    # make sure we got the right answer
+    assert out == {"cutflow": {"Data_pt": np.int64(84), "ZJets_pt": np.int64(18)}}
+
+    # cleanup
+    shutil.rmtree(path)


### PR DESCRIPTION
This is a first try to add optional checkpointing to coffea workflows that enable resumable workflows. For this, a new `CheckpointerABC` exists that can be subclassed to implement custom `load` and `save` methods (saving and loading the checkpoint). Those can be highly custom, i.e. only checkpointing TTbar chunks or only if we have a full moon...
A `LocalCheckpointer` implementation is provided (can be used if people have access to an NFS for example).

The usage is basically as follows (see also the doc string of `CheckpointerABC`):
```python
from datetime import datetime
from coffea import processor

# create a checkpointer that stores checkpoints in a directory with the current date/time
# (you may want to use a more specific directory in practice)
today = datetime.now().strftime("%Y%m%d")
checkpointer = processor.LocalCheckpointer(checkpoint_dir=f"checkpoints/{today}", verbose=True)

# pass the checkpointer to a Runner
run = processor.Runner(..., checkpointer=checkpointer)
output = run(...)
```
After the run, the checkpoints will be stored in the directory `checkpoints/{today}`. On a subsequent run, if the same chunks are processed (and the same checkpointer, or rather `checkpoint_dir` is used), the results will be loaded from disk instead of being recomputed.

The basic idea is that it checkpoints each chunk output. It is not clear to me how to checkpoint a tree-reduction, which is why this is not implemented here. Thus, re-running with everything checkpointed still means to run the tree-reduction step - but the bulk processing is not.

I verified that it works locally. All of this of course comes at the price of additional IO, but I fear there's no way to achieve resumable workflows otherwise. That's why this is opt-in.

Let me know what you think :) 