### PR TITLE
fix: use consistent rich console

### DIFF
--- a/binder/dataset_discovery.ipynb
+++ b/binder/dataset_discovery.ipynb
@@ -25,14 +25,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "09103c77-b8e6-4d61-920b-b1ff8fba8791",
    "metadata": {},
    "outputs": [],
    "source": [
     "from coffea.dataset_tools import rucio_utils\n",
     "from coffea.dataset_tools.dataset_query import print_dataset_query\n",
-    "from rich.console import Console\n",
+    "from coffea.util import coffea_console\n",
     "from rich.table import Table"
    ]
   },
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "4487d997-dc22-4a47-87df-4da14fa5b35a",
    "metadata": {},
    "outputs": [
@@ -230,8 +230,7 @@
     }
    ],
    "source": [
-    "console = Console()\n",
-    "print_dataset_query(query, outtree, console)"
+    "print_dataset_query(query, outtree)"
    ]
   },
   {
@@ -306,13 +305,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "3e4fc6c2-f378-40d2-a4ea-f265b6c18887",
    "metadata": {},
    "outputs": [],
    "source": [
     "def print_replicas(sites_counts):\n",
-    "    console.print(f\"[cyan]Sites availability for dataset: [red]{dataset}\")\n",
+    "    coffea_console.print(f\"[cyan]Sites availability for dataset: [red]{dataset}\")\n",
     "    table = Table(title=\"Available replicas\")\n",
     "    table.add_column(\"Index\", justify=\"center\")\n",
     "    table.add_column(\"Site\", justify=\"left\", style=\"cyan\", no_wrap=True)\n",
@@ -328,7 +327,7 @@
     "        table.add_row(\n",
     "            str(i), site, f\"{stat} / {Nfiles}\", f\"{stat*100/Nfiles:.1f}%\"\n",
     "        )\n",
-    "    console.print(table)"
+    "    coffea_console.print(table)"
    ]
   },
   {
@@ -733,14 +732,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "39846193-d6f2-4de5-ba42-a089d1b0786d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from coffea.dataset_tools import rucio_utils\n",
-    "from coffea.dataset_tools.dataset_query import print_dataset_query\n",
-    "from rich.console import Console\n",
     "from coffea.dataset_tools.dataset_query import DataDiscoveryCLI"
    ]
   },

--- a/src/coffea/dataset_tools/dataset_query.py
+++ b/src/coffea/dataset_tools/dataset_query.py
@@ -13,6 +13,8 @@ from rich.prompt import Confirm, FloatPrompt, IntPrompt, Prompt
 from rich.table import Table
 from rich.tree import Tree
 
+from coffea.util import coffea_console
+
 from . import rucio_utils
 from .preprocess import preprocess
 
@@ -20,7 +22,7 @@ from .preprocess import preprocess
 def print_dataset_query(
     query: str,
     dataset_list: dict[str, dict[str, list[str]]],
-    console: Console,
+    console: Console = coffea_console,
     selected: list[str] = [],
 ) -> None:
     """
@@ -113,7 +115,7 @@ class DataDiscoveryCLI:
     """
 
     def __init__(self):
-        self.console = Console()
+        self.console = coffea_console
         self.rucio_client = None
         self.selected_datasets = []
         self.selected_datasets_metadata = []

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -12,6 +12,7 @@ import numba
 import numpy
 import uproot
 from dask.base import unpack_collections
+from rich.console import Console
 from rich.progress import (
     BarColumn,
     Column,
@@ -162,6 +163,14 @@ class SpeedColumn(ProgressColumn):
         return Text(f"{speed:{self.fmt}}", style="progress.data.speed")
 
 
+coffea_console = Console()
+coffea_console.__doc__ += """
+\nA `rich.console.Console` for coffea. Used through-out coffea for consistent logging and
+progress bars. May be used by users for their own logging. Using the same console
+ensures that output is nicely integrated with coffea's progress bars.
+"""
+
+
 def rich_bar():
     return Progress(
         TextColumn("[bold blue]{task.description}", justify="right"),
@@ -180,6 +189,7 @@ def rich_bar():
         TextColumn("[progress.data.speed]{task.fields[unit]}/s", justify="right"),
         "]",
         auto_refresh=False,
+        console=coffea_console,
     )
 
 


### PR DESCRIPTION
Using a common `rich.console.Console` for logging/printing in e.g. a Processor ensures that the progress bar and the logging of the Runner (with e.g. a IterativeExecutor) is properly displayed.

Users should import `from coffea.util import coffea_console` and use `coffea_console.print(...)` when they want to use a rich Console to log/print something.

PS: If someone wanted to debug interactively, and had issues with embedded IPython shells (or pdb) and `rich` progress bars, have a look at this: https://github.com/Textualize/rich/issues/1053#issuecomment-1970920245 (@felixzinn).