### PR TITLE
chore: explicit no python jitting in a few places

### DIFF
--- a/src/coffea/nanoevents/transforms.py
+++ b/src/coffea/nanoevents/transforms.py
@@ -630,7 +630,7 @@ def get_index_ranges(begin, end):
     return ranges
 
 
-@numba.jit
+@numba.njit
 def get_array_from_indices_kernel(indices, target, builder):
     for ev in range(len(indices)):
         builder.begin_list()
@@ -643,7 +643,7 @@ def get_array_from_indices_kernel(indices, target, builder):
     return builder
 
 
-@numba.jit
+@numba.njit
 def get_array_from_indices_nested_target_kernel(indices, target, builder):
     for ev in range(len(indices)):
         builder.begin_list()
@@ -770,7 +770,7 @@ def begin_end_mapping_nested_target_form(begin_form, end_form, target_form):
 
 
 # begin_end_mapping_with_xyzrecord
-@numba.jit
+@numba.njit
 def get_array_from_indices_xyzrecord_target_kernel(indices, target, builder):
     for ev in range(len(indices)):
         builder.begin_list()


### PR DESCRIPTION
I think this can be `njit`. `jit` by default is `nopython=True` in the latest numba versions.
It's also to avoids this warning if someone is using an earlier numba version
```
/eos/user/i/ikrommyd/.local/lib/python3.11/site-packages/coffea/nanoevents/transforms.py:633: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  @numba.jit
/eos/user/i/ikrommyd/.local/lib/python3.11/site-packages/coffea/nanoevents/transforms.py:646: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  @numba.jit
/eos/user/i/ikrommyd/.local/lib/python3.11/site-packages/coffea/nanoevents/transforms.py:773: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
```