### PR TITLE
fix: do not reverse fileset after preprocessing

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1544,10 +1544,6 @@ class Runner:
 
             self._preprocess_fileset_root(fileset)
             fileset = self._filter_badfiles(fileset)
-
-            # reverse fileset list to match the order of files as presented in version
-            # v0.7.4. This fixes tests using maxchunks.
-            fileset.reverse()
         elif self.format == "parquet":
             raise NotImplementedError("Parquet format is not supported yet.")
 


### PR DESCRIPTION
I don't understand the need for this. Maybe someone expects the first datasets of their fileset to be submitted for execution first.