### PR TITLE
feat: add saving/loading for remote filesystems + fix pickling infinite recursion problems

### DIFF
--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -36,19 +36,29 @@ import cloudpickle
 import fsspec
 
 
-def load(filename):
-    """Load a coffea file from disk"""
-    with fsspec.open(filename, "rb", compression="lz4") as fin:
+def load(filename, compression="lz4"):
+    """Load a coffea file from disk
+
+    ``compression`` specified the algorithm to use to decompress the file.
+    It must be one of the ``fsspec`` supported compression string names.
+    These compression algorithms may have dependencies that need to be installed separately.
+    If it is ``None``, it means no compression.
+    """
+    with fsspec.open(filename, "rb", compression=compression) as fin:
         output = cloudpickle.load(fin)
     return output
 
 
-def save(output, filename):
+def save(output, filename, compression="lz4"):
     """Save a coffea object or collection thereof to disk.
 
     This function can accept any picklable object.  Suggested suffix: ``.coffea``
+
+    ``compression` can be one of the ``fsspec`` supported compression string names.
+    These compression algorithms may have dependencies that need to be installed separately.
+    if it is ``None``, it means no compression.
     """
-    with fsspec.open(filename, "wb", compression="lz4") as fout:
+    with fsspec.open(filename, "wb", compression=compression) as fout:
         cloudpickle.dump(output, fout)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,6 @@
 import os
 
+from coffea.processor import defaultdict_accumulator, dict_accumulator
 from coffea.processor.test_items import NanoEventsProcessor
 from coffea.util import load, save
 
@@ -12,6 +13,57 @@ def test_loadsave():
         newprocessor = load(filename)
         assert "pt" in newprocessor.accumulator
         assert newprocessor.accumulator["pt"].axes == aprocessor.accumulator["pt"].axes
+
+        output = {"test": "foo"}
+        save(output, filename)
+        newoutput = load(filename)
+        assert newoutput == output
+
+        output = {}
+        output["test"] = output
+        save(output, filename)
+        newoutput = load(filename)
+        assert newoutput["test"] is newoutput
+
+        output = lambda x: x + 1  # noqa E731
+        save(output, filename)
+        newoutput = load(filename)
+        assert newoutput(1) == 2
+        assert newoutput(2) == 3
+
+        def output(x):
+            return x + 1
+
+        save(output, filename)
+        newoutput = load(filename)
+        assert newoutput(1) == 2
+        assert newoutput(2) == 3
+
+        output = dict_accumulator(
+            {
+                "cutflow": defaultdict_accumulator(int),
+            }
+        )
+        output["cutflow"]["x"] += 1
+        output["cutflow"]["y"] += 2
+        save(output, filename)
+        newoutput = load(filename)
+        assert isinstance(newoutput, dict_accumulator)
+        assert isinstance(newoutput["cutflow"], defaultdict_accumulator)
+        assert newoutput["cutflow"]["x"] == 1
+        assert newoutput["cutflow"]["y"] == 2
+
+        output = defaultdict_accumulator(lambda: defaultdict_accumulator(int))
+        output["x"]["y"] += 1
+        output["x"]["z"] += 2
+        output["a"]["b"] += 3
+        save(output, filename)
+        newoutput = load(filename)
+        assert isinstance(newoutput, defaultdict_accumulator)
+        assert isinstance(newoutput["x"], defaultdict_accumulator)
+        assert newoutput["x"]["y"] == 1
+        assert newoutput["x"]["z"] == 2
+        assert newoutput["a"]["b"] == 3
     finally:
         if os.path.exists(filename):
             os.remove(filename)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,41 +1,44 @@
 import os
 
+import pytest
+
 from coffea.processor import defaultdict_accumulator, dict_accumulator
 from coffea.processor.test_items import NanoEventsProcessor
 from coffea.util import load, save
 
 
-def test_loadsave():
+@pytest.mark.parametrize("compression", [None, "lz4"])
+def test_loadsave(compression):
     filename = "testprocessor.coffea"
     try:
         aprocessor = NanoEventsProcessor()
-        save(aprocessor, filename)
-        newprocessor = load(filename)
+        save(aprocessor, filename, compression)
+        newprocessor = load(filename, compression)
         assert "pt" in newprocessor.accumulator
         assert newprocessor.accumulator["pt"].axes == aprocessor.accumulator["pt"].axes
 
         output = {"test": "foo"}
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert newoutput == output
 
         output = {}
         output["test"] = output
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert newoutput["test"] is newoutput
 
         output = lambda x: x + 1  # noqa E731
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert newoutput(1) == 2
         assert newoutput(2) == 3
 
         def output(x):
             return x + 1
 
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert newoutput(1) == 2
         assert newoutput(2) == 3
 
@@ -46,8 +49,8 @@ def test_loadsave():
         )
         output["cutflow"]["x"] += 1
         output["cutflow"]["y"] += 2
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert isinstance(newoutput, dict_accumulator)
         assert isinstance(newoutput["cutflow"], defaultdict_accumulator)
         assert newoutput["cutflow"]["x"] == 1
@@ -57,8 +60,8 @@ def test_loadsave():
         output["x"]["y"] += 1
         output["x"]["z"] += 2
         output["a"]["b"] += 3
-        save(output, filename)
-        newoutput = load(filename)
+        save(output, filename, compression)
+        newoutput = load(filename, compression)
         assert isinstance(newoutput, defaultdict_accumulator)
         assert isinstance(newoutput["x"], defaultdict_accumulator)
         assert newoutput["x"]["y"] == 1


### PR DESCRIPTION
This adds support for saving/loading using fsspec and also fixes the pickling problems introduced in https://github.com/scikit-hep/coffea/pull/1338.
Also extends the pickling tests.