### PR TITLE
feat: make `postprocess` optional in `ProcessorABC` and additionally accept single-argument callables in executors in the place of processors

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1718,7 +1718,11 @@ class Runner:
             )
         wrapped_out["exception"] = e
 
-        if not self.use_dataframes:
+        if (
+            not self.use_dataframes
+            and hasattr(processor_instance, "postprocess")
+            and callable(processor_instance.postprocess)
+        ):
             postprocess_out = processor_instance.postprocess(wrapped_out["out"])
             if postprocess_out is not None:
                 wrapped_out["out"] = postprocess_out

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -15,11 +15,13 @@ from functools import partial
 from io import BytesIO
 from itertools import repeat
 from typing import (
+    Any,
     Callable,
     Optional,
     Union,
 )
 
+import awkward
 import cloudpickle
 import lz4.frame as lz4f
 import toml
@@ -1400,7 +1402,9 @@ class Runner:
         use_dataframes: bool,
         savemetrics: bool,
         item: WorkItem,
-        processor_instance: ProcessorABC | Callable,
+        processor_instance: Union[
+            ProcessorABC, Callable[[awkward.highlevel.Array], Any]
+        ],
         uproot_options: dict,
         iteritems_options: dict,
         checkpointer: CheckpointerABC,
@@ -1522,7 +1526,9 @@ class Runner:
     def __call__(
         self,
         fileset: dict,
-        processor_instance: ProcessorABC | Callable,
+        processor_instance: Union[
+            ProcessorABC, Callable[[awkward.highlevel.Array], Any]
+        ],
         *args,
         treename: Optional[str] = None,
         uproot_options: Optional[dict] = {},
@@ -1612,7 +1618,9 @@ class Runner:
     def run(
         self,
         fileset: Union[dict, str, list[WorkItem], Generator],
-        processor_instance: ProcessorABC | Callable,
+        processor_instance: Union[
+            ProcessorABC, Callable[[awkward.highlevel.Array], Any]
+        ],
         *args,
         treename: Optional[str] = None,
         uproot_options: Optional[dict] = {},

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1719,7 +1719,9 @@ class Runner:
         wrapped_out["exception"] = e
 
         if not self.use_dataframes:
-            processor_instance.postprocess(wrapped_out["out"])
+            postprocess_out = processor_instance.postprocess(wrapped_out["out"])
+            if postprocess_out is not None:
+                wrapped_out["out"] = postprocess_out
 
         if "metrics" in wrapped_out.keys():
             wrapped_out["metrics"]["chunks"] = len(chunks)

--- a/src/coffea/processor/processor.py
+++ b/src/coffea/processor/processor.py
@@ -43,10 +43,9 @@ class ProcessorABC(metaclass=ABCMeta):
         """
         pass
 
-    @abstractmethod
     def postprocess(self, accumulator):
         """Final processing on aggregated accumulator
 
-        Do any final processing on the resulting accumulator object, it should be modified in-place
+        Do any final processing on the resulting accumulator object
         """
         pass


### PR DESCRIPTION
Closes https://github.com/scikit-hep/coffea/issues/1383