### PR TITLE
feat: add storage_options support to NanoEventsFactory.from_parquet

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -479,6 +479,7 @@ class NanoEventsFactory:
         schemaclass=NanoAODSchema,
         metadata=None,
         parquet_options={},
+        storage_options=None,
         skyhook_options={},
         access_log=None,
     ):
@@ -507,6 +508,8 @@ class NanoEventsFactory:
                 Arbitrary metadata to add to the `base.NanoEvents` object
             parquet_options : dict, optional
                 Any options to pass to ``pyarrow.parquet.ParquetFile``
+            storage_options : dict, optional
+                Options to pass to ``fsspec`` when opening the file. Only used when ``file`` is a string path.
             access_log : list, optional
                 Pass a list instance to record which branches were lazily accessed by this instance
 
@@ -567,7 +570,7 @@ class NanoEventsFactory:
             table_file = pyarrow.parquet.ParquetFile(file, **parquet_options)
         elif isinstance(file, str):
             fs_file = fsspec.open(
-                file, "rb"
+                file, "rb", **(storage_options or {})
             ).open()  # Call open to materialize the file
             table_file = pyarrow.parquet.ParquetFile(fs_file, **parquet_options)
         elif isinstance(file, pyarrow.parquet.ParquetFile):

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -123,7 +123,7 @@ def test_read_nanomc(tests_directory, suffix):
 def test_read_from_uri(tests_directory, suffix):
     """Make sure we can properly open the file when a uri is used"""
     path = Path(f"{tests_directory}/samples/nano_dy.{suffix}").as_uri()
-
+    print(path)
     nanoversion = NanoAODSchema
     factory = getattr(
         NanoEventsFactory, f"from_{suffix.removeprefix('extensionarray.')}"
@@ -133,8 +133,34 @@ def test_read_from_uri(tests_directory, suffix):
         mode="eager",
     )
     events = factory.events()
-
+    # is this assertion correct? syntax wrong and 40 in all files
     assert len(events) == 40 if suffix == "root" else 10
+
+    # Test storage_options for parquet files
+    if suffix == "parquet":
+        from unittest.mock import patch
+
+        import fsspec
+
+        path_str = f"{tests_directory}/samples/nano_dy.{suffix}"
+        storage_opts = {"some_option": "some_value"}
+
+        original_open = fsspec.open
+
+        def mock_open(file, mode, **kwargs):
+            assert kwargs == storage_opts
+            return original_open(file, mode)
+
+        with patch("fsspec.open", side_effect=mock_open) as mock_fsspec_open:
+            factory = NanoEventsFactory.from_parquet(
+                path_str,
+                schemaclass=nanoversion,
+                storage_options=storage_opts,
+                mode="eager",
+            )
+            events = factory.events()
+            assert len(events) == 40
+            mock_fsspec_open.assert_called_once()
 
 
 @pytest.mark.parametrize("suffix", suffixes)

--- a/tests/test_nanoevents.py
+++ b/tests/test_nanoevents.py
@@ -123,7 +123,6 @@ def test_read_nanomc(tests_directory, suffix):
 def test_read_from_uri(tests_directory, suffix):
     """Make sure we can properly open the file when a uri is used"""
     path = Path(f"{tests_directory}/samples/nano_dy.{suffix}").as_uri()
-    print(path)
     nanoversion = NanoAODSchema
     factory = getattr(
         NanoEventsFactory, f"from_{suffix.removeprefix('extensionarray.')}"
@@ -133,8 +132,7 @@ def test_read_from_uri(tests_directory, suffix):
         mode="eager",
     )
     events = factory.events()
-    # is this assertion correct? syntax wrong and 40 in all files
-    assert len(events) == 40 if suffix == "root" else 10
+    assert len(events) == 40
 
     # Test storage_options for parquet files
     if suffix == "parquet":


### PR DESCRIPTION
  ## Summary
  Adds `storage_options` keyword argument to `NanoEventsFactory.from_parquet()` to match the API from `awkward.from_parquet()`. This allows users to pass fsspec options for
  accessing remote filesystems like S3.

  ## Changes
  - Add `storage_options` parameter to `from_parquet()` method
  - Pass `storage_options` to `fsspec.open()` for string paths
  - Add docstring for the new parameter
  - Add test to verify `storage_options` is correctly passed to fsspec
  - Fix assertion in nanoaod reading from URI unit test 