### PR TITLE
fix: use loky.ProcessPoolExecutor as default pool in FuturesExecutor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
   "dask[array]>=2024.3.0",
   "dask-awkward>=2025.9.0",
   "dask-histogram>=2025.2.0",
+  "loky>=3.5.6",
   "vector>=1.4.1,!=1.6.0",
   "correctionlib>=2.6.0",
   "pyarrow>=6.0.0",

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -524,7 +524,7 @@ class _CloudPickleProcessPoolExecutor(concurrent.futures.ProcessPoolExecutor):
     ):
         if mp_context is None:
             mp_context = multiprocessing.get_context()
-            mp_context.reducer = cloudpickle.Pickler()
+            mp_context.reduction.ForkingPickler = cloudpickle.Pickler
         super().__init__(
             max_workers=max_workers,
             mp_context=mp_context,

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -511,13 +511,28 @@ class IterativeExecutor(ExecutorBase):
                 0,
             )
 
+
 # this class changes the default pickler of ProcessPoolExecutor to the default cloudpickle.Pickler
 class _CloudPickleProcessPoolExecutor(concurrent.futures.ProcessPoolExecutor):
-    def __init__(self, max_workers=None, mp_context=None, initializer=None, initargs=(), max_tasks_per_child=None):
+    def __init__(
+        self,
+        max_workers=None,
+        mp_context=None,
+        initializer=None,
+        initargs=(),
+        max_tasks_per_child=None,
+    ):
         if mp_context is None:
             mp_context = multiprocessing.get_context()
-            mp_context.reducer = cloudpickle.Pickler()            
-        super().__init__(max_workers=max_workers, mp_context=mp_context, initializer=initializer, initargs=initargs, max_tasks_per_child=max_tasks_per_child)
+            mp_context.reducer = cloudpickle.Pickler()
+        super().__init__(
+            max_workers=max_workers,
+            mp_context=mp_context,
+            initializer=initializer,
+            initargs=initargs,
+            max_tasks_per_child=max_tasks_per_child,
+        )
+
 
 @dataclass
 class FuturesExecutor(ExecutorBase):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -28,6 +28,7 @@ def test_processorabc():
 
 
 def test_issue1408():
+    from coffea import processor
 
     class P(processor.ProcessorABC):
         def process(self, events):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -26,6 +26,7 @@ def test_processorabc():
     acc = None
     super(test, proc).postprocess(acc)
 
+
 def test_issue1408():
 
     class P(processor.ProcessorABC):
@@ -34,6 +35,13 @@ def test_issue1408():
 
         def postprocess(self, accumulator):
             pass
+
     fileset = {"dy": {"files": {"tests/samples/nano_dy.root": "Events"}}}
     run = processor.Runner(executor=processor.FuturesExecutor())
-    print(run(fileset=fileset, processor_instance=P(), iteritems_options={"filter_name": lambda name: True}))
+    print(
+        run(
+            fileset=fileset,
+            processor_instance=P(),
+            iteritems_options={"filter_name": lambda name: True},
+        )
+    )

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -25,3 +25,15 @@ def test_processorabc():
 
     acc = None
     super(test, proc).postprocess(acc)
+
+def test_issue1408():
+
+    class P(processor.ProcessorABC):
+        def process(self, events):
+            return True
+
+        def postprocess(self, accumulator):
+            pass
+    fileset = {"dy": {"files": {"tests/samples/nano_dy.root": "Events"}}}
+    run = processor.Runner(executor=processor.FuturesExecutor())
+    print(run(fileset=fileset, processor_instance=P(), iteritems_options={"filter_name": lambda name: True}))


### PR DESCRIPTION
Fixes #1408