### PR TITLE
chore: change log level of pytest to info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ addopts = [
   "-rfesxX",
   "-v",
 ]
-log_level = "DEBUG"
+log_level = "INFO"
 filterwarnings = [
   "ignore:There is no current event loop",
 ]


### PR DESCRIPTION
debug logging makes the pytest output extremely long mainly due to numba and some fsspec logging. It's often impossible to even see which tests failed unless you pipe the sdout to a log file or grep through your terminal scrollback. I'm changing it to info.