### PR TITLE
feat: Pydantic preprocessing and interfacing to NanoEventsFactory

### DIFF
--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -22,10 +22,18 @@ from coffea.dataset_tools.manipulations import (
     slice_chunks,
     slice_files,
 )
-from coffea.dataset_tools.preprocess import preprocess
+from coffea.dataset_tools.preprocess import (
+    preprocess,
+    preprocess_legacy,
+    preprocess_parquet,
+    preprocess_root,
+)
 
 __all__ = [
     "preprocess",
+    "preprocess_legacy",
+    "preprocess_parquet",
+    "preprocess_root",
     "apply_to_dataset",
     "apply_to_fileset",
     "max_chunks",

--- a/src/coffea/dataset_tools/filespec.py
+++ b/src/coffea/dataset_tools/filespec.py
@@ -503,7 +503,9 @@ class DatasetSpec(BaseModel):
 
                                     from coffea.util import decompress_form
 
-                                    _ = awkward.forms.from_json(decompress_form(data["form"]))
+                                    _ = awkward.forms.from_json(
+                                        decompress_form(data["form"])
+                                    )
                                     new_data["compressed_form"] = data["form"]
                                 except Exception:
                                     raise RuntimeError(
@@ -511,7 +513,9 @@ class DatasetSpec(BaseModel):
                                     )
                     else:
                         # if there's already a compressed_form, take that and ignore the form
-                        new_data["compressed_form"] = copy.deepcopy(data["compressed_form"])
+                        new_data["compressed_form"] = copy.deepcopy(
+                            data["compressed_form"]
+                        )
                 elif k == "files":
                     # promote files list to dict if necessary
                     if isinstance(v, list):

--- a/src/coffea/dataset_tools/filespec.py
+++ b/src/coffea/dataset_tools/filespec.py
@@ -375,12 +375,7 @@ class InputFiles(
             except Exception:
                 # we failed to promote to the concrete spec, do nothing else
                 pass
-        if all(preprocessed.values()):
-            try:
-                self.root = PreprocessedFiles(self.root).root
-            except Exception:
-                # We couldn't promote to PreprocessedFiles, do nothing
-                pass
+        # Ideally we would promote to PreprocessedFiles if all files are concrete specs, but since we can't change the class of Self in this method, we leave this to be handled in DatasetSpec.post_validate, which can change the class of Self if necessary
         return self
 
 
@@ -430,7 +425,7 @@ class PreprocessedFiles(
 
 
 class DatasetSpec(BaseModel):
-    files: InputFiles | PreprocessedFiles
+    files: PreprocessedFiles | InputFiles
     metadata: dict[Hashable, Any] = {}
     format: str | None = None
     compressed_form: str | None = None
@@ -600,6 +595,24 @@ class DatasetSpec(BaseModel):
         if not self.set_check_format():
             raise ValueError(f"format: format must be one of {self._valid_formats()}")
 
+        # Promote InputFiles to PreprocessedFiles if all files are concrete specs
+        # This is needed because InputFiles.promote_and_check_files() cannot change the class of Self
+        if isinstance(self.files, InputFiles) and not isinstance(
+            self.files, PreprocessedFiles
+        ):
+            print("DatasetSpec: promoting files to PreprocessedFiles if all files are concrete specs", file=sys.stderr)
+            all_concrete = all(
+                isinstance(v, (CoffeaROOTFileSpec, CoffeaParquetFileSpec))
+                for v in self.files.values()
+            )
+            if all_concrete:
+                try:
+                    self.files = PreprocessedFiles(dict(self.files.root))
+                except Exception:
+                    # If promotion fails, keep the InputFiles
+                    pass
+            print(f"DatasetSpec: after promotion attempt, files is of type {type(self.files)}", file=sys.stderr)
+        print(f"DatasetSpec: post validation complete with files of type {type(self.files)} and compressed_form {self.compressed_form}", file=sys.stderr)
         return self
 
     @property

--- a/src/coffea/dataset_tools/filespec.py
+++ b/src/coffea/dataset_tools/filespec.py
@@ -476,64 +476,78 @@ class DatasetSpec(BaseModel):
 
     @model_validator(mode="before")
     def preprocess_data(cls, data: Any) -> Any:
+        # Catch a simple case of old style input: a list of files; files will be further handled/converted in dict path if they embed the object_path
+        if isinstance(data, list) and all(isinstance(f, str) for f in data):
+            data = {"files": copy.deepcopy(data)}
         if isinstance(data, dict):
-            data = copy.deepcopy(data)
-            files = data.pop("files")
-            # promote files list to dict if necessary
-            if isinstance(files, list):
-                # If files is a list, convert it to a dict and let it pass through the rest of the promotion logic
-                tmp = [f.rsplit(":", maxsplit=1) for f in files]
-                files = {}
-                for fsplit in tmp:
-                    # Need a valid split into file name and object path
-                    if len(fsplit) > 1:
-                        # but ensure we don't catch 'root://' and split that
-                        if fsplit[1].startswith("//"):
-                            # no object path
-                            files[":".join(fsplit)] = None
+            new_data = {}
+            for k, v in data.items():
+                if k == "form":
+                    if "compressed_form" not in data:
+                        # assume this was an uncompressed awkward form, try to compress it
+                        if v is None:
+                            new_data["compressed_form"] = None
                         else:
-                            # file name and object path
-                            files[fsplit[0]] = fsplit[1]
+                            try:
+                                import awkward
+
+                                from coffea.util import compress_form
+
+                                new_data["compressed_form"] = compress_form(
+                                    awkward.forms.from_json(data["form"])
+                                )
+                            except Exception:
+                                # if we can't compress it, test if it can be decompressed
+                                try:
+                                    import awkward
+
+                                    from coffea.util import decompress_form
+
+                                    _ = awkward.forms.from_json(decompress_form(data["form"]))
+                                    new_data["compressed_form"] = data["form"]
+                                except Exception:
+                                    raise RuntimeError(
+                                        f"form: provided form could neither be compressed nor decompressed, please provide a valid (compressed_)form, got {data['form']}"
+                                    )
                     else:
-                        # no object path
-                        files[fsplit[0]] = None
-            data["files"] = files
-            if "form" in data.keys():
-                _form = data.pop("form")
-                if "compressed_form" not in data.keys():
-                    # assume this was an uncompressed awkward form, try to compress it
-                    try:
-                        import awkward
-
-                        from coffea.util import compress_form
-
-                        data["compressed_form"] = compress_form(
-                            awkward.forms.from_json(_form)
-                        )
-                    except Exception:
-                        # if we can't compress it, test if it can be decompressed
-                        try:
-                            import awkward
-
-                            from coffea.util import decompress_form
-
-                            _ = awkward.forms.from_json(decompress_form(_form))
-                            data["compressed_form"] = _form
-                        except Exception:
-                            raise RuntimeError(
-                                "form: provided form could neither be compressed nor decompressed, please provide a valid compressed_form"
-                            )
+                        # if there's already a compressed_form, take that and ignore the form
+                        new_data["compressed_form"] = copy.deepcopy(data["compressed_form"])
+                elif k == "files":
+                    # promote files list to dict if necessary
+                    if isinstance(v, list):
+                        # If files is a list, convert it to a dict and let it pass through the rest of the promotion logic
+                        tmp = [f.rsplit(":", maxsplit=1) for f in v]
+                        files = {}
+                        for fsplit in tmp:
+                            # Need a valid split into file name and object path
+                            if len(fsplit) > 1:
+                                # but ensure we don't catch 'root://' and split that
+                                if fsplit[1].startswith("//"):
+                                    # no object path
+                                    files[":".join(fsplit)] = None
+                                else:
+                                    # file name and object path
+                                    files[fsplit[0]] = fsplit[1]
+                            else:
+                                # no object path
+                                files[fsplit[0]] = None
+                        new_data["files"] = files
+                    else:
+                        new_data["files"] = copy.deepcopy(v)
                 else:
-                    data["compressed_form"] = data["compressed_form"]
-            if "metadata" not in data.keys() or data["metadata"] is None:
-                data["metadata"] = {}
+                    new_data[k] = copy.deepcopy(v)
+            if "files" not in new_data.keys():
+                # If the structure is {filename0: object_path0, filename1: object_path1, ...}, embed as "files" key
+                new_data = {"files": new_data}
+            if "metadata" not in new_data.keys() or new_data["metadata"] is None:
+                new_data["metadata"] = {}
         elif isinstance(data, DatasetSpec):
-            data = data.model_dump()
+            new_data = data.model_dump()
         elif not isinstance(data, DatasetSpec):
             raise ValueError(
                 "DatasetSpec expects a dictionary with a 'files' key DatasetSpec instance"
             )
-        return data
+        return new_data
 
     def _check_form(self) -> bool | None:
         """Check the form can be decompressed into an awkward form, if present"""

--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -269,7 +269,7 @@ def filter_files(
         to_apply_to = getattr(entry, "files") if is_datasetspec else entry["files"]
         updated = dict(filter(thefilter, to_apply_to.items()))
         if is_datasetspec:
-            out[name].files = InputFiles(updated)
+            out[name].files = PreprocessedFiles(updated)
         else:
             out[name]["files"] = updated
     return out

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -704,7 +704,7 @@ def _preprocess_parquet(
 
     Parameters
     ----------
-        fileset: FilesetSpecOptional
+        fileset: DataGroupSpec
             The set of datasets whose files will be preprocessed.
         step_size: int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
@@ -731,11 +731,15 @@ def _preprocess_parquet(
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
     Returns
     -------
-        out_available : FilesetSpec
+        out_available : DataGroupSpec
             The subset of files in each dataset that were successfully preprocessed, organized by dataset.
-        out_updated : FilesetSpecOptional
+        out_updated : DataGroupSpec
             The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
     """
+    if not isinstance(datagroupspec, DataGroupSpec):
+        raise ValueError(
+            f"_preprocess_parquet expects a DataGroupSpec, got {type(datagroupspec)}"
+        )
     out_updated = datagroupspec.model_dump()
     out_available = datagroupspec.model_dump()
 

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -510,16 +510,20 @@ def preprocess(
         out_updated = DataGroupSpec(out_updated)
     return out_available, out_updated
 
-def _normalize_parquet_file_info(file_info):
+def _normalize_parquet_file_info(file_info, return_form_or_metadata=False):
     """
     Structure file info akin to _normalize_file_info for uproot files, which returns a list of (filename, object_path, steps, num_entries, uuid) tuples.
     """
     normed_files = None
+    form = None
+    metadata = None
     if isinstance(file_info, list):
         normed_files = [(file, None, None, None, None) for file in file_info]
     elif(isinstance(file_info, dict) and "files" not in file_info):
         normed_files = [(file, object_path, None, None, None) for file, object_path in file_info.items()]
     elif isinstance(file_info, dict) and "files" in file_info:
+        form = file_info.get("form", None)
+        metadata = file_info.get("metadata", None)
         normed_files = []
         for filename, maybe_nested in file_info["files"].items():
             if isinstance(maybe_nested, dict):
@@ -534,6 +538,8 @@ def _normalize_parquet_file_info(file_info):
                 raise ValueError(
                     f"The file_info dictionary must contain either a string, dictionary, or None as the value. _normalize_parquet_file_info got {file_info}"
                 )
+    if return_form_or_metadata:
+        return normed_files, form, metadata
     return normed_files
 
 def get_parquet_form_uuid_steps(

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -509,3 +509,442 @@ def preprocess(
         out_available = DataGroupSpec(out_available)
         out_updated = DataGroupSpec(out_updated)
     return out_available, out_updated
+
+def _normalize_parquet_file_info(file_info):
+    """
+    Structure file info akin to _normalize_file_info for uproot files, which returns a list of (filename, object_path, steps, num_entries, uuid) tuples.
+    """
+    normed_files = None
+    if isinstance(file_info, list):
+        normed_files = [(file, None, None, None, None) for file in file_info]
+    elif(isinstance(file_info, dict) and "files" not in file_info):
+        normed_files = [(file, object_path, None, None, None) for file, object_path in file_info.items()]
+    elif isinstance(file_info, dict) and "files" in file_info:
+        normed_files = []
+        for filename, maybe_nested in file_info["files"].items():
+            if isinstance(maybe_nested, dict):
+                object_path = maybe_nested.get("object_path", None)
+                steps = maybe_nested.get("steps", None)
+                num_entries = maybe_nested.get("num_entries", None)
+                uuid = maybe_nested.get("uuid", None)
+                normed_files.append((filename, object_path, steps, num_entries, uuid))
+            elif isinstance(maybe_nested, str) or maybe_nested is None:
+                normed_files.append((filename, maybe_nested, None, None, None))
+            else:
+                raise ValueError(
+                    f"The file_info dictionary must contain either a string, dictionary, or None as the value. _normalize_parquet_file_info got {file_info}"
+                )
+    return normed_files
+
+def get_parquet_form_uuid_steps(
+    normed_files: awkward.Array | dask_awkward.Array,
+    step_size: int | None = None,
+    use_row_groups: bool = False,
+    recalculate_steps: bool = False,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = False,
+    step_size_safety_factor: float = 0.5,
+    parquet_options: dict = {},
+) -> awkward.Array | dask_awkward.Array:
+    """
+    Given a list of normalized file and object paths, determine the form, steps, uuid for each file according to the supplied processing options.
+
+    Parameters
+    ----------
+        normed_files: awkward.Array | dask_awkward.Array
+            The list of normalized file descriptions to process for steps.
+        step_size: int | None, default None
+            If specified, the size of the steps to make when analyzing the input files.
+        use_row_groups: bool, default False
+            Calculate steps according to the row_groups in the parquet files.
+        recalculate_steps: bool, default False
+            If steps are present in the input normed files, force the recalculation of those steps, instead
+            of only recalculating the steps if the uuid has changed.
+        skip_bad_files: bool, False
+            Instead of failing, catch exceptions specified by file_exceptions and return null data.
+        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (OSError,)
+            What exceptions to catch when skipping bad files.
+        save_form: bool, default False
+            Extract the form of the TTree from the file so we can skip opening files later.
+        step_size_safety_factor: float, default 0.5
+            When using align_clusters, if a resulting step is larger than step_size by this factor
+            warn the user that the resulting steps may be highly irregular.
+
+    Returns
+    -------
+        array : awkward.Array | dask_awkward.Array
+            The normalized file descriptions, appended with the calculated steps for those files.
+    """
+    nf_backend = awkward.backend(normed_files)
+    lz_or_nf = awkward.typetracer.length_zero_if_typetracer(normed_files)
+
+    array = [] if nf_backend != "typetracer" else lz_or_nf
+    for arg in lz_or_nf:
+        try:
+            the_file = awkward.metadata_from_parquet(arg.file, **parquet_options)
+        except file_exceptions as e:
+            if skip_bad_files:
+                array.append(None)
+                continue
+            else:
+                raise e
+
+        num_entries = the_file['num_rows']
+
+        form_json = None
+        form_hash = None
+        if save_form:
+            form = the_file['form']
+            form_str = form.to_json()
+            # the function cache needs to be popped if present to prevent memory growth
+            if hasattr(dask.base, "function_cache"):
+                dask.base.function_cache.popitem()
+
+            form_hash = hashlib.md5(form_str.encode("utf-8")).hexdigest()
+            form_json = compress_form(form_str)
+
+        target_step_size = num_entries if step_size is None else step_size
+
+        file_uuid = the_file.get('uuid', None)
+
+        out_uuid = arg.uuid
+        out_steps = arg.steps
+
+        if out_uuid != file_uuid or recalculate_steps:
+            if use_row_groups:
+                row_group_entries = the_file['col_counts']
+                out = [0]
+                this_offset = 0
+                for c in row_group_entries:
+                    this_offset += c
+                    if this_offset >= out[-1] + target_step_size:
+                        out.append(this_offset)
+                if this_offset != out[-1]:
+                    out.append(this_offset)
+                out = numpy.array(out, dtype="int64")
+                out = numpy.stack((out[:-1], out[1:]), axis=1)
+
+                step_mask = (
+                    out[:, 1] - out[:, 0]
+                    > (1 + step_size_safety_factor) * target_step_size
+                )
+                if numpy.any(step_mask):
+                    warnings.warn(
+                        f"In file {arg.file}, steps: {out[step_mask]} with use_row_groups=True are "
+                        f"{step_size_safety_factor*100:.0f}% larger than target "
+                        f"step size: {target_step_size}!"
+                    )
+            else:
+                n_steps_target = max(round(num_entries / target_step_size), 1)
+                actual_step_size = math.ceil(num_entries / n_steps_target)
+                out = numpy.array(
+                    [
+                        [
+                            i * actual_step_size,
+                            min((i + 1) * actual_step_size, num_entries),
+                        ]
+                        for i in range(n_steps_target)
+                    ],
+                    dtype="int64",
+                )
+
+            out_uuid = file_uuid
+            out_steps = out.tolist()
+
+        if out_steps is not None and len(out_steps) == 0:
+            out_steps = [[0, 0]]
+
+        array.append(
+            {
+                "file": arg.file,
+                "object_path": arg.object_path,
+                "steps": out_steps,
+                "num_entries": num_entries,
+                "uuid": out_uuid,
+                "form": form_json,
+                "form_hash_md5": form_hash,
+            }
+        )
+
+    if len(array) == 0:
+        array = awkward.Array(
+            [
+                {
+                    "file": "junk",
+                    "object_path": "junk",
+                    "steps": [[0, 0]],
+                    "num_entries": 0,
+                    "uuid": "junk",
+                    "form": "junk",
+                    "form_hash_md5": "junk",
+                },
+                None,
+            ]
+        )
+        array = awkward.Array(array.layout.form.length_zero_array(highlevel=False))
+    else:
+        array = awkward.Array(array)
+
+    if nf_backend == "typetracer":
+        array = awkward.Array(
+            array.layout.to_typetracer(forget_length=True),
+        )
+
+    return array
+
+def _preprocess_parquet(
+    fileset: FilesetSpecOptional,
+    step_size: None | int = None,
+    use_row_groups: bool = False,
+    recalculate_steps: bool = False,
+    files_per_batch: int = 1,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = False,
+    scheduler: None | Callable | str = None,
+    parquet_options: dict = {},
+    step_size_safety_factor: float = 0.5,
+    allow_empty_datasets: bool = False,
+) -> tuple[FilesetSpec, FilesetSpecOptional]:
+    """
+    Given a list of normalized files, determine the form, steps, and add the metadata for each file according to the supplied processing options.
+
+    Parameters
+    ----------
+        fileset: FilesetSpecOptional
+            The set of datasets whose files will be preprocessed.
+        step_size: int | None, default None
+            If specified, the size of the steps to make when analyzing the input files.
+        use_row_groups: bool, default False
+            Use the row groups in the parquet files to determine the steps.
+        recalculate_steps: bool, default False
+            If steps are present in the input normed files, force the recalculation of those steps,
+            instead of only recalculating the steps if the uuid has changed.
+        skip_bad_files: bool, False
+            Instead of failing, catch exceptions specified by file_exceptions and return null data.
+        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
+            What exceptions to catch when skipping bad files.
+        save_form: bool, default False
+            Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
+        scheduler: None | Callable | str, default None
+            Specifies the scheduler that dask should use to execute the preprocessing task graph.
+        parquet_options: dict, default {}
+            Options to pass to get_parquet_form_uuid_steps for opening files
+        step_size_safety_factor: float, default 0.5
+            When using use_row_groups, if a resulting step is larger than step_size by this factor
+            warn the user that the resulting steps may be highly irregular.
+        allow_empty_datasets: bool, default False
+            When a dataset query comes back completely empty, this is normally considered a processing error.
+            Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+    Returns
+    -------
+        out_available : FilesetSpec
+            The subset of files in each dataset that were successfully preprocessed, organized by dataset.
+        out_updated : FilesetSpecOptional
+            The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
+    """
+    out_updated = copy.deepcopy(fileset)
+    out_available = copy.deepcopy(fileset)
+
+    all_ak_norm_files = {}
+    files_to_preprocess = {}
+    for name, info in fileset.items():
+        norm_files = _normalize_parquet_file_info(info)
+        fields = ["file", "object_path", "steps", "num_entries", "uuid"]
+        ak_norm_files = awkward.from_iter(norm_files)
+        ak_norm_files = awkward.Array(
+            {field: ak_norm_files[str(ifield)] for ifield, field in enumerate(fields)}
+        )
+        all_ak_norm_files[name] = ak_norm_files
+
+        dak_norm_files = dask_awkward.from_awkward(
+            ak_norm_files, math.ceil(len(ak_norm_files) / files_per_batch)
+        )
+
+        concat_fn = partial(
+            awkward.concatenate,
+            axis=0,
+        )
+
+        split_every = 8
+
+        files_trl_label = f"preprocess-{name}"
+        files_trl_token = dask.base.tokenize(dak_norm_files, concat_fn, split_every)
+        files_trl_name = f"{files_trl_label}-{files_trl_token}"
+        files_trl_tree_node_name = f"{files_trl_label}-tree-node-{files_trl_token}"
+
+        files_part = dask_awkward.map_partitions(
+            get_parquet_form_uuid_steps,
+            dak_norm_files,
+            step_size=step_size,
+            use_row_groups=use_row_groups,
+            recalculate_steps=recalculate_steps,
+            skip_bad_files=skip_bad_files,
+            file_exceptions=file_exceptions,
+            save_form=save_form,
+            step_size_safety_factor=step_size_safety_factor,
+            parquet_options=parquet_options,
+            meta=dask_awkward.lib.core.empty_typetracer(),
+        )
+
+        files_trl = dask_awkward.layers.layers.AwkwardTreeReductionLayer(
+            name=files_trl_name,
+            name_input=files_part.name,
+            npartitions_input=files_part.npartitions,
+            concat_func=concat_fn,
+            tree_node_func=lambda x: x,
+            finalize_func=lambda x: x,
+            split_every=split_every,
+            tree_node_name=files_trl_tree_node_name,
+        )
+
+        files_graph = dask.highlevelgraph.HighLevelGraph.from_collections(
+            files_trl_name, files_trl, dependencies=[files_part]
+        )
+
+        files_to_preprocess[name] = dask_awkward.lib.core.new_array_object(
+            files_graph,
+            files_trl_name,
+            meta=dask_awkward.lib.core.empty_typetracer(),
+            npartitions=len(files_trl.output_partitions),
+        )
+
+    (all_processed_files,) = dask.compute(files_to_preprocess, scheduler=scheduler)
+
+    for name, processed_files in all_processed_files.items():
+
+        if len(awkward.drop_none(processed_files, axis=0)) == 0:
+            ds_empty_msg = (
+                "There was no populated list of files returned from querying your input dataset."
+                "\nPlease check your xrootd endpoints, and avoid redirectors."
+                f"\nInput dataset: {name}"
+                f"\nAs parsed for querying: {awkward.to_list(all_ak_norm_files[name])}"
+            )
+
+            if not allow_empty_datasets:
+                raise Exception(ds_empty_msg)
+
+            warnings.warn(ds_empty_msg)
+            del out_available[name]
+            continue
+
+        processed_files_without_forms = processed_files[
+            ["file", "object_path", "steps", "num_entries", "uuid"]
+        ]
+
+        forms = processed_files[["file", "form", "form_hash_md5", "num_entries"]][
+            ~awkward.is_none(processed_files.form_hash_md5)
+        ]
+
+        _, unique_forms_idx = numpy.unique(
+            forms.form_hash_md5.to_numpy(), return_index=True
+        )
+
+        dataset_forms = []
+        unique_forms = forms[unique_forms_idx]
+        for thefile, formstr, num_entries in zip(
+            unique_forms.file, unique_forms.form, unique_forms.num_entries
+        ):
+            # skip trivially filled or empty files
+            form = awkward.forms.from_json(decompress_form(formstr))
+            if num_entries >= 0 and set(form.fields) != _trivial_file_fields:
+                dataset_forms.append(form)
+            else:
+                warnings.warn(
+                    f"{thefile} has fields {form.fields} and num_entries={num_entries} "
+                    "and has been skipped during form-union determination. You will need "
+                    "to skip this file when processing. You can either manually remove it "
+                    "or, if it is an empty file, dynamically remove it with the function "
+                    "dataset_tools.filter_files which takes the output of preprocess and "
+                    ", by default, removes empty files each dataset in a fileset."
+                )
+
+        union_array = None
+        union_form_jsonstr = None
+        while len(dataset_forms):
+            new_array = awkward.Array(dataset_forms.pop().length_zero_array())
+            if union_array is None:
+                union_array = new_array
+            else:
+                union_array = awkward.to_packed(
+                    awkward.merge_union_of_records(
+                        awkward.concatenate([union_array, new_array]), axis=0
+                    )
+                )
+                union_array.layout.parameters.update(new_array.layout.parameters)
+        if union_array is not None:
+            union_form = union_array.layout.form
+
+            for icontent, content in enumerate(union_form.contents):
+                if isinstance(content, awkward.forms.IndexedOptionForm):
+                    if (
+                        not isinstance(content.content, awkward.forms.NumpyForm)
+                        or content.content.primitive != "bool"
+                    ):
+                        raise ValueError(
+                            "IndexedOptionArrays can only contain NumpyArrays of "
+                            "bools in mergers of flat-tuple-like schemas!"
+                        )
+                    parameters = (
+                        content.content.parameters.copy()
+                        if content.content.parameters is not None
+                        else {}
+                    )
+                    # re-create IndexOptionForm with parameters of lower level array
+                    union_form.contents[icontent] = awkward.forms.IndexedOptionForm(
+                        content.index,
+                        content.content,
+                        parameters=parameters,
+                        form_key=content.form_key,
+                    )
+
+            union_form_jsonstr = union_form.to_json()
+
+        files_available = {
+            item["file"]: {
+                "object_path": item["object_path"],
+                "steps": item["steps"],
+                "num_entries": item["num_entries"],
+                "uuid": item["uuid"],
+            }
+            for item in awkward.drop_none(processed_files_without_forms).to_list()
+        }
+
+        files_out = {}
+        for proc_item, orig_item in zip(
+            processed_files_without_forms.to_list(), all_ak_norm_files[name].to_list()
+        ):
+            item = orig_item if proc_item is None else proc_item
+            files_out[item["file"]] = {
+                "object_path": item["object_path"],
+                "steps": item["steps"],
+                "num_entries": item["num_entries"],
+                "uuid": item["uuid"],
+            }
+
+        if "files" in out_updated[name]:
+            out_updated[name]["files"] = files_out
+            out_available[name]["files"] = files_available
+        else:
+            out_updated[name] = {"files": files_out, "metadata": None, "form": None}
+            out_available[name] = {
+                "files": files_available,
+                "metadata": None,
+                "form": None,
+            }
+
+        compressed_union_form = None
+        if union_form_jsonstr is not None:
+            compressed_union_form = compress_form(union_form_jsonstr)
+            out_updated[name]["form"] = compressed_union_form
+            out_available[name]["form"] = compressed_union_form
+        else:
+            out_updated[name]["form"] = None
+            out_available[name]["form"] = None
+
+        if "metadata" not in out_updated[name]:
+            out_updated[name]["metadata"] = None
+            out_available[name]["metadata"] = None
+
+    return out_available, out_updated

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -189,8 +189,7 @@ def get_steps(
 
 def _normalize_file_info(file_info):
     normed_files = None
-    is_datasetspec = isinstance(file_info, DatasetSpec)
-    if is_datasetspec:
+    if isinstance(file_info, DatasetSpec):
         normed_files = uproot._util.regularize_files(
             ModelFactory.datasetspec_to_dict(file_info, coerce_filespec_to_dict=True)[
                 "files"
@@ -243,33 +242,33 @@ def preprocess_legacy(
 
     Parameters
     ----------
-        fileset: dict
+        fileset : dict
             The set of datasets whose files will be preprocessed.
-        step_size: int | None, default None
+        step_size : int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
-        align_clusters: bool, default False
+        align_clusters : bool, default False
             Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in
             analysis.
-        recalculate_steps: bool, default False
+        recalculate_steps : bool, default False
             If steps are present in the input normed files, force the recalculation of those steps,
             instead of only recalculating the steps if the uuid has changed.
-        files_per_batch: int, default 1
+        files_per_batch : int, default 1
             The number of files to preprocess in a single batch.
             Large values will result in fewer dask tasks but each task will have to do more work.
-        skip_bad_files: bool, False
+        skip_bad_files : bool, False
             Instead of failing, catch exceptions specified by file_exceptions and return null data.
-        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
+        file_exceptions : Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
             What exceptions to catch when skipping bad files.
-        save_form: bool, default False
+        save_form : bool, default False
             Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
-        scheduler: None | Callable | str, default None
+        scheduler : None | Callable | str, default None
             Specifies the scheduler that dask should use to execute the preprocessing task graph.
-        uproot_options: dict, default {}
+        uproot_options : dict, default {}
             Options to pass to get_steps for opening files with uproot.
-        step_size_safety_factor: float, default 0.5
+        step_size_safety_factor : float, default 0.5
             When using align_clusters, if a resulting step is larger than step_size by this factor
             warn the user that the resulting steps may be highly irregular.
-        allow_empty_datasets: bool, default False
+        allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
     Returns
@@ -528,22 +527,22 @@ def get_parquet_form_uuid_steps(
 
     Parameters
     ----------
-        normed_files: awkward.Array | dask_awkward.Array
+        normed_files : awkward.Array | dask_awkward.Array
             The list of normalized file descriptions to process for steps.
-        step_size: int | None, default None
+        step_size : int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
-        use_row_groups: bool, default False
+        use_row_groups : bool, default False
             Calculate steps according to the row_groups in the parquet files.
-        recalculate_steps: bool, default False
+        recalculate_steps : bool, default False
             If steps are present in the input normed files, force the recalculation of those steps, instead
             of only recalculating the steps if the uuid has changed.
-        skip_bad_files: bool, False
+        skip_bad_files : bool, False
             Instead of failing, catch exceptions specified by file_exceptions and return null data.
-        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (OSError,)
+        file_exceptions : Exception | Warning | tuple[Exception | Warning], default (OSError,)
             What exceptions to catch when skipping bad files.
-        save_form: bool, default False
+        save_form : bool, default False
             Extract the form of the TTree from the file so we can skip opening files later.
-        step_size_safety_factor: float, default 0.5
+        step_size_safety_factor : float, default 0.5
             When using align_clusters, if a resulting step is larger than step_size by this factor
             warn the user that the resulting steps may be highly irregular.
 
@@ -760,29 +759,29 @@ def preprocess_parquet(
 
     Parameters
     ----------
-        fileset: DataGroupSpec
+        fileset : DataGroupSpec
             The set of datasets whose files will be preprocessed.
-        step_size: int | None, default None
+        step_size : int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
-        use_row_groups: bool, default False
+        use_row_groups : bool, default False
             Use the row groups in the parquet files to determine the steps.
-        recalculate_steps: bool, default False
+        recalculate_steps : bool, default False
             If steps are present in the input normed files, force the recalculation of those steps,
             instead of only recalculating the steps if the uuid has changed.
-        skip_bad_files: bool, False
+        skip_bad_files : bool, False
             Instead of failing, catch exceptions specified by file_exceptions and return null data.
-        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
+        file_exceptions : Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
             What exceptions to catch when skipping bad files.
-        save_form: bool, default True
+        save_form : bool, default True
             Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
-        scheduler: None | Callable | str, default None
+        scheduler : None | Callable | str, default None
             Specifies the scheduler that dask should use to execute the preprocessing task graph.
-        parquet_options: dict, default {}
+        parquet_options : dict, default {}
             Options to pass to get_parquet_form_uuid_steps for opening files
-        step_size_safety_factor: float, default 0.5
+        step_size_safety_factor : float, default 0.5
             When using use_row_groups, if a resulting step is larger than step_size by this factor
             warn the user that the resulting steps may be highly irregular.
-        allow_empty_datasets: bool, default False
+        allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
     Returns
@@ -1095,7 +1094,7 @@ def preprocess(
         allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
-        preprocess_legacy_root: bool, default False
+        preprocess_legacy_root : bool, default False
             Use the legacy root preprocessing function for all files, even if the fileset is a DataGroupSpec.
             Not compatible with parquet files.
         use_row_groups : bool, default False

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -18,9 +18,7 @@ from uproot._util import no_filter
 from coffea.dataset_tools.filespec import (
     DataGroupSpec,
     DatasetSpec,
-    InputFiles,
     ModelFactory,
-    PreprocessedFiles,
 )
 from coffea.util import _is_interpretable, compress_form, decompress_form
 
@@ -157,7 +155,7 @@ def get_steps(
                 "steps": out_steps,
                 "num_entries": num_entries,
                 "uuid": out_uuid,
-                "compressed_form": form_json,
+                "form": form_json,
                 "form_hash_md5": form_hash,
             }
         )
@@ -171,7 +169,7 @@ def get_steps(
                     "steps": [[0, 0]],
                     "num_entries": 0,
                     "uuid": "junk",
-                    "compressed_form": "junk",
+                    "form": "junk",
                     "form_hash_md5": "junk",
                 },
                 None,
@@ -226,8 +224,8 @@ def _normalize_file_info(file_info):
 _trivial_file_fields = {"run", "luminosityBlock", "event"}
 
 
-def preprocess(
-    fileset: DataGroupSpec | dict,
+def preprocess_legacy(
+    fileset: dict,
     step_size: None | int = None,
     align_clusters: bool = False,
     recalculate_steps: bool = False,
@@ -239,58 +237,55 @@ def preprocess(
     uproot_options: dict = {},
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
-) -> tuple[DataGroupSpec, DataGroupSpec] | tuple[dict, dict]:
+) -> tuple[dict, dict]:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
 
     Parameters
     ----------
-        fileset : DataGroupSpec | dict
+        fileset: dict
             The set of datasets whose files will be preprocessed.
-        step_size : int or None, default None
+        step_size: int | None, default None
             If specified, the size of the steps to make when analyzing the input files.
-        align_clusters : bool, default False
+        align_clusters: bool, default False
             Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in
             analysis.
-        recalculate_steps : bool, default False
+        recalculate_steps: bool, default False
             If steps are present in the input normed files, force the recalculation of those steps,
             instead of only recalculating the steps if the uuid has changed.
-        files_per_batch : int, default 1
+        files_per_batch: int, default 1
             The number of files to preprocess in a single batch.
             Large values will result in fewer dask tasks but each task will have to do more work.
-        skip_bad_files : bool, default False
+        skip_bad_files: bool, False
             Instead of failing, catch exceptions specified by file_exceptions and return null data.
-        file_exceptions : Exception or Warning or tuple[Exception or Warning], default (FileNotFoundError, OSError)
+        file_exceptions: Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
             What exceptions to catch when skipping bad files.
-        save_form : bool, default False
+        save_form: bool, default False
             Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
-        scheduler : None or Callable or str, default None
+        scheduler: None | Callable | str, default None
             Specifies the scheduler that dask should use to execute the preprocessing task graph.
-        uproot_options : dict, default {}
+        uproot_options: dict, default {}
             Options to pass to get_steps for opening files with uproot.
-        step_size_safety_factor : float, default 0.5
+        step_size_safety_factor: float, default 0.5
             When using align_clusters, if a resulting step is larger than step_size by this factor
             warn the user that the resulting steps may be highly irregular.
-        allow_empty_datasets : bool, default False
+        allow_empty_datasets: bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
     Returns
     -------
-        out_available : DataGroupSpec | dict
+        out_available : dict
             The subset of files in each dataset that were successfully preprocessed, organized by dataset.
-        out_updated : DataGroupSpec | dict
+        out_updated : dict
             The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
     """
+
     out_updated = copy.deepcopy(fileset)
     out_available = copy.deepcopy(fileset)
 
     all_ak_norm_files = {}
     files_to_preprocess = {}
-    is_DataGroupSpec = isinstance(fileset, DataGroupSpec)
     for name, info in fileset.items():
-        is_datasetspec = isinstance(info, DatasetSpec)
-        if is_datasetspec:
-            is_DataGroupSpec = True
         norm_files = _normalize_file_info(info)
         fields = ["file", "object_path", "steps", "num_entries", "uuid"]
         ak_norm_files = awkward.from_iter(norm_files)
@@ -374,9 +369,9 @@ def preprocess(
             ["file", "object_path", "steps", "num_entries", "uuid"]
         ]
 
-        forms = processed_files[
-            ["file", "compressed_form", "form_hash_md5", "num_entries"]
-        ][~awkward.is_none(processed_files.form_hash_md5)]
+        forms = processed_files[["file", "form", "form_hash_md5", "num_entries"]][
+            ~awkward.is_none(processed_files.form_hash_md5)
+        ]
 
         _, unique_forms_idx = numpy.unique(
             forms.form_hash_md5.to_numpy(), return_index=True
@@ -385,7 +380,7 @@ def preprocess(
         dataset_forms = []
         unique_forms = forms[unique_forms_idx]
         for thefile, formstr, num_entries in zip(
-            unique_forms.file, unique_forms.compressed_form, unique_forms.num_entries
+            unique_forms.file, unique_forms.form, unique_forms.num_entries
         ):
             # skip trivially filled or empty files
             form = awkward.forms.from_json(decompress_form(formstr))
@@ -464,54 +459,34 @@ def preprocess(
                 "uuid": item["uuid"],
             }
 
-        if is_datasetspec:
-            out_updated[name].files = InputFiles(files_out)
-            out_available[name].files = PreprocessedFiles(files_available)
-        elif "files" in out_updated[name]:
+        if "files" in out_updated[name]:
             out_updated[name]["files"] = files_out
             out_available[name]["files"] = files_available
         else:
-            out_updated[name] = {
-                "files": files_out,
-                "metadata": None,
-                "compressed_form": None,
-            }
+            out_updated[name] = {"files": files_out, "metadata": None, "form": None}
             out_available[name] = {
                 "files": files_available,
                 "metadata": None,
-                "compressed_form": None,
+                "form": None,
             }
 
         compressed_union_form = None
         if union_form_jsonstr is not None:
             compressed_union_form = compress_form(union_form_jsonstr)
-            if is_datasetspec:
-                out_updated[name].compressed_form = compressed_union_form
-                out_available[name].compressed_form = compressed_union_form
-            else:
-                out_updated[name]["compressed_form"] = compressed_union_form
-                out_available[name]["compressed_form"] = compressed_union_form
+            out_updated[name]["form"] = compressed_union_form
+            out_available[name]["form"] = compressed_union_form
         else:
-            if is_datasetspec:
-                out_updated[name].compressed_form = None
-                out_available[name].compressed_form = None
-            else:
-                out_updated[name]["compressed_form"] = None
-                out_available[name]["compressed_form"] = None
+            out_updated[name]["form"] = None
+            out_available[name]["form"] = None
 
-        if is_datasetspec:
-            pass
-        elif "metadata" not in out_updated[name]:
+        if "metadata" not in out_updated[name]:
             out_updated[name]["metadata"] = None
             out_available[name]["metadata"] = None
 
-    if is_DataGroupSpec:
-        out_available = DataGroupSpec(out_available)
-        out_updated = DataGroupSpec(out_updated)
     return out_available, out_updated
 
 
-def _normalize_parquet_file_info(
+def _normalize_pydantic_file_info(
     datasetspec: DatasetSpec, return_compressedform_or_metadata=False
 ):
     """
@@ -519,7 +494,7 @@ def _normalize_parquet_file_info(
     """
     if not isinstance(datasetspec, DatasetSpec):
         raise ValueError(
-            f"_normalize_parquet_file_info expects a DatasetSpec, got {type(datasetspec)}"
+            f"_normalize_pydantic_file_info expects a DatasetSpec, got {type(datasetspec)}"
         )
     normed_files = []
     for filename, fileinfo in datasetspec.files.items():
@@ -695,7 +670,78 @@ def get_parquet_form_uuid_steps(
     return array
 
 
-def _preprocess_parquet(
+def preprocess_root(
+    datagroupspec: DataGroupSpec,
+    step_size: None | int = None,
+    align_clusters: bool = False,
+    recalculate_steps: bool = False,
+    files_per_batch: int = 1,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = True,
+    scheduler: None | Callable | str = None,
+    uproot_options: dict = {},
+    step_size_safety_factor: float = 0.5,
+    allow_empty_datasets: bool = False,
+) -> tuple[DataGroupSpec, DataGroupSpec]:
+    """
+    Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
+
+    Parameters
+    ----------
+        datagroupspec : DataGroupSpec
+            The set of datasets whose files will be preprocessed.
+        step_size : int or None, default None
+            If specified, the size of the steps to make when analyzing the input files.
+        align_clusters : bool, default False
+            Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in
+            analysis.
+        recalculate_steps : bool, default False
+            If steps are present in the input normed files, force the recalculation of those steps,
+            instead of only recalculating the steps if the uuid has changed.
+        files_per_batch : int, default 1
+            The number of files to preprocess in a single batch.
+            Large values will result in fewer dask tasks but each task will have to do more work.
+        skip_bad_files : bool, default False
+            Instead of failing, catch exceptions specified by file_exceptions and return null data.
+        file_exceptions : Exception or Warning or tuple[Exception or Warning], default (FileNotFoundError, OSError)
+            What exceptions to catch when skipping bad files.
+        save_form : bool, default True
+            Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
+        scheduler : None or Callable or str, default None
+            Specifies the scheduler that dask should use to execute the preprocessing task graph.
+        uproot_options : dict, default {}
+            Options to pass to get_steps for opening files with uproot.
+        step_size_safety_factor : float, default 0.5
+            When using align_clusters, if a resulting step is larger than step_size by this factor
+            warn the user that the resulting steps may be highly irregular.
+        allow_empty_datasets : bool, default False
+            When a dataset query comes back completely empty, this is normally considered a processing error.
+            Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+    Returns
+    -------
+        out_available : DataGroupSpec
+            The subset of files in each dataset that were successfully preprocessed, organized by dataset.
+        out_updated : DataGroupSpec
+            The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
+    """
+    return _preprocess_pydantic(
+        datagroupspec=datagroupspec,
+        step_size=step_size,
+        use_alignment_boundaries=align_clusters,
+        recalculate_steps=recalculate_steps,
+        files_per_batch=files_per_batch,
+        skip_bad_files=skip_bad_files,
+        file_exceptions=file_exceptions,
+        save_form=save_form,
+        scheduler=scheduler,
+        filetype_options=uproot_options,
+        step_size_safety_factor=step_size_safety_factor,
+        allow_empty_datasets=allow_empty_datasets,
+    )
+
+
+def preprocess_parquet(
     datagroupspec: DataGroupSpec,
     step_size: None | int = None,
     use_row_groups: bool = False,
@@ -727,7 +773,7 @@ def _preprocess_parquet(
             Instead of failing, catch exceptions specified by file_exceptions and return null data.
         file_exceptions: Exception | Warning | tuple[Exception | Warning], default (FileNotFoundError, OSError)
             What exceptions to catch when skipping bad files.
-        save_form: bool, default False
+        save_form: bool, default True
             Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
         scheduler: None | Callable | str, default None
             Specifies the scheduler that dask should use to execute the preprocessing task graph.
@@ -746,9 +792,44 @@ def _preprocess_parquet(
         out_updated : DataGroupSpec
             The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
     """
+    return _preprocess_pydantic(
+        datagroupspec=datagroupspec,
+        step_size=step_size,
+        use_alignment_boundaries=use_row_groups,
+        recalculate_steps=recalculate_steps,
+        files_per_batch=files_per_batch,
+        skip_bad_files=skip_bad_files,
+        file_exceptions=file_exceptions,
+        save_form=save_form,
+        scheduler=scheduler,
+        filetype_options=parquet_options,
+        step_size_safety_factor=step_size_safety_factor,
+        allow_empty_datasets=allow_empty_datasets,
+    )
+
+
+def _preprocess_pydantic(
+    datagroupspec: DataGroupSpec,
+    step_size: None | int = None,
+    use_alignment_boundaries: bool = False,
+    recalculate_steps: bool = False,
+    files_per_batch: int = 1,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = True,
+    scheduler: None | Callable | str = None,
+    filetype_options: dict = {},
+    step_size_safety_factor: float = 0.5,
+    allow_empty_datasets: bool = False,
+) -> tuple[DataGroupSpec, DataGroupSpec]:
+    """
+    Function to preprocess either root or parquet DatasetSpecs in a DataGroupSpec.
+    ROOT TTrees: Maps align_clusters and uproot_options to use_alignment_boundaries and filetype_options respectively.
+    Parquet: Maps use_row_groups and parquet_options to use_alignment_boundaries and filetype_options respectively
+    """
     if not isinstance(datagroupspec, DataGroupSpec):
         raise ValueError(
-            f"_preprocess_parquet expects a DataGroupSpec, got {type(datagroupspec)}"
+            f"_preprocess_pydantic expects a DataGroupSpec, got {type(datagroupspec)}"
         )
     out_updated = datagroupspec.model_dump()
     out_available = datagroupspec.model_dump()
@@ -756,7 +837,7 @@ def _preprocess_parquet(
     all_ak_norm_files = {}
     files_to_preprocess = {}
     for name, info in datagroupspec.items():
-        norm_files = _normalize_parquet_file_info(info)
+        norm_files = _normalize_pydantic_file_info(info)
         fields = ["file", "object_path", "steps", "num_entries", "uuid"]
         ak_norm_files = awkward.from_iter(norm_files)
         ak_norm_files = awkward.Array(
@@ -780,19 +861,38 @@ def _preprocess_parquet(
         files_trl_name = f"{files_trl_label}-{files_trl_token}"
         files_trl_tree_node_name = f"{files_trl_label}-tree-node-{files_trl_token}"
 
-        files_part = dask_awkward.map_partitions(
-            get_parquet_form_uuid_steps,
-            dak_norm_files,
-            step_size=step_size,
-            use_row_groups=use_row_groups,
-            recalculate_steps=recalculate_steps,
-            skip_bad_files=skip_bad_files,
-            file_exceptions=file_exceptions,
-            save_form=save_form,
-            step_size_safety_factor=step_size_safety_factor,
-            parquet_options=parquet_options,
-            meta=dask_awkward.lib.core.empty_typetracer(),
-        )
+        if info.format == "root":
+            files_part = dask_awkward.map_partitions(
+                get_steps,
+                dak_norm_files,
+                step_size=step_size,
+                align_clusters=use_alignment_boundaries,
+                recalculate_steps=recalculate_steps,
+                skip_bad_files=skip_bad_files,
+                file_exceptions=file_exceptions,
+                save_form=save_form,
+                step_size_safety_factor=step_size_safety_factor,
+                uproot_options=filetype_options,
+                meta=dask_awkward.lib.core.empty_typetracer(),
+            )
+        elif info.format == "parquet":
+            files_part = dask_awkward.map_partitions(
+                get_parquet_form_uuid_steps,
+                dak_norm_files,
+                step_size=step_size,
+                use_row_groups=use_alignment_boundaries,
+                recalculate_steps=recalculate_steps,
+                skip_bad_files=skip_bad_files,
+                file_exceptions=file_exceptions,
+                save_form=save_form,
+                step_size_safety_factor=step_size_safety_factor,
+                parquet_options=filetype_options,
+                meta=dask_awkward.lib.core.empty_typetracer(),
+            )
+        else:
+            raise ValueError(
+                f"Dataset {name} has unsupported format {info.format}, supported formats are 'root' and 'parquet'."
+            )
 
         files_trl = dask_awkward.layers.layers.AwkwardTreeReductionLayer(
             name=files_trl_name,
@@ -942,3 +1042,158 @@ def _preprocess_parquet(
     return DataGroupSpec.model_validate(out_available), DataGroupSpec.model_validate(
         out_updated
     )
+
+
+def preprocess(
+    fileset: DataGroupSpec | dict,
+    step_size: None | int = None,
+    align_clusters: bool = False,
+    recalculate_steps: bool = False,
+    files_per_batch: int = 1,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = True,
+    scheduler: None | Callable | str = None,
+    uproot_options: dict = {},
+    step_size_safety_factor: float = 0.5,
+    allow_empty_datasets: bool = False,
+    preprocess_legacy_root: bool = False,
+    use_row_groups: bool = False,
+    parquet_options: dict = {},
+) -> tuple[DataGroupSpec, DataGroupSpec] | tuple[dict, dict]:
+    """
+    Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
+
+    Parameters
+    ----------
+        fileset : DataGroupSpec | dict
+            The set of datasets whose files will be preprocessed.
+        step_size : int or None, default None
+            If specified, the size of the steps to make when analyzing the input files.
+        align_clusters : bool, default False
+            Round to the cluster size in a root file, when chunks are specified. Reduces data transfer in
+            analysis.
+        recalculate_steps : bool, default False
+            If steps are present in the input normed files, force the recalculation of those steps,
+            instead of only recalculating the steps if the uuid has changed.
+        files_per_batch : int, default 1
+            The number of files to preprocess in a single batch.
+            Large values will result in fewer dask tasks but each task will have to do more work.
+        skip_bad_files : bool, default False
+            Instead of failing, catch exceptions specified by file_exceptions and return null data.
+        file_exceptions : Exception or Warning or tuple[Exception or Warning], default (FileNotFoundError, OSError)
+            What exceptions to catch when skipping bad files.
+        save_form : bool, default False
+            Extract the form of the TTree from each file in each dataset, creating the union of the forms over the dataset.
+        scheduler : None or Callable or str, default None
+            Specifies the scheduler that dask should use to execute the preprocessing task graph.
+        uproot_options : dict, default {}
+            Options to pass to get_steps for opening files with uproot.
+        step_size_safety_factor : float, default 0.5
+            When using align_clusters, if a resulting step is larger than step_size by this factor
+            warn the user that the resulting steps may be highly irregular.
+        allow_empty_datasets : bool, default False
+            When a dataset query comes back completely empty, this is normally considered a processing error.
+            Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+        preprocess_legacy_root: bool, default False
+            Use the legacy root preprocessing function for all files, even if the fileset is a DataGroupSpec.
+            Not compatible with parquet files.
+        use_row_groups : bool, default False
+            Calculate steps according to the row_groups in the parquet files (only applies to DataGroupSpec datasets with parquet files).
+        parquet_options : dict, default {}
+            Options to pass to get_parquet_form_uuid_steps for opening parquet files (only applies to DataGroupSpec datasets with parquet files).
+    Returns
+    -------
+        out_available : DataGroupSpec | dict
+            The subset of files in each dataset that were successfully preprocessed, organized by dataset.
+        out_updated : DataGroupSpec | dict
+            The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
+    """
+    if preprocess_legacy_root:
+        # use the legacy root TTree preprocessing function if requested
+        return preprocess_legacy(
+            fileset.model_dump() if isinstance(fileset, DataGroupSpec) else fileset,
+            step_size=step_size,
+            align_clusters=align_clusters,
+            recalculate_steps=recalculate_steps,
+            files_per_batch=files_per_batch,
+            skip_bad_files=skip_bad_files,
+            file_exceptions=file_exceptions,
+            save_form=save_form,
+            scheduler=scheduler,
+            uproot_options=uproot_options,
+            step_size_safety_factor=step_size_safety_factor,
+            allow_empty_datasets=allow_empty_datasets,
+        )
+    else:
+        if isinstance(fileset, DataGroupSpec):
+            datasetspecs = fileset
+        else:
+            DeprecationWarning(
+                "Passing a dict to preprocess is deprecated. Converting to DataGroupSpec and proceeding."
+                "To remove this warning, pass a DataGroupSpec object instead of a dict."
+                "To use the legacy preprocessing function, set preprocess_legacy_root=True."
+                "If automatic conversion is not possible, please submit your fileset to the coffea team."
+            )
+            datasetspecs = DataGroupSpec.model_validate(fileset)
+        # split datasetspecs into uproot and parquet files, keeping track of original order
+        original_order = list(datasetspecs.keys())
+        formats = [dss.format for dss in datasetspecs.values()]
+        if len(set(formats)) > 1 and align_clusters != use_row_groups:
+            warnings.warn(
+                "When preprocessing a mixed fileset, align_clusters and use_row_groups serve a similar function. If you didn't intend to treat root and parquet files' boundary alignments differently, set both to the same value."
+            )
+        out_available_uproot, out_updated_uproot = preprocess_root(
+            datasetspecs.filter_datasets(
+                filter_callable=lambda ds: ds.format == "root"
+            ),
+            step_size=step_size,
+            align_clusters=align_clusters,
+            recalculate_steps=recalculate_steps,
+            files_per_batch=files_per_batch,
+            skip_bad_files=skip_bad_files,
+            file_exceptions=file_exceptions,
+            save_form=save_form,
+            scheduler=scheduler,
+            uproot_options=uproot_options,
+            step_size_safety_factor=step_size_safety_factor,
+            allow_empty_datasets=allow_empty_datasets,
+        )
+        out_available_parquet, out_updated_parquet = preprocess_parquet(
+            datasetspecs.filter_datasets(
+                filter_callable=lambda ds: ds.format == "parquet"
+            ),
+            step_size=step_size,
+            use_row_groups=use_row_groups,
+            recalculate_steps=recalculate_steps,
+            files_per_batch=files_per_batch,
+            skip_bad_files=skip_bad_files,
+            file_exceptions=file_exceptions,
+            save_form=save_form,
+            scheduler=scheduler,
+            parquet_options=parquet_options,
+            step_size_safety_factor=step_size_safety_factor,
+            allow_empty_datasets=allow_empty_datasets,
+        )
+        # recombine outputs in original order
+        out_available = DataGroupSpec(
+            {
+                k: (
+                    out_available_uproot[k]
+                    if k in out_available_uproot
+                    else out_available_parquet[k]
+                )
+                for k in original_order
+            }
+        )
+        out_updated = DataGroupSpec(
+            {
+                k: (
+                    out_updated_uproot[k]
+                    if k in out_updated_uproot
+                    else out_updated_parquet[k]
+                )
+                for k in original_order
+            }
+        )
+        return out_available, out_updated

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -510,6 +510,7 @@ def preprocess(
         out_updated = DataGroupSpec(out_updated)
     return out_available, out_updated
 
+
 def _normalize_parquet_file_info(file_info, return_form_or_metadata=False):
     """
     Structure file info akin to _normalize_file_info for uproot files, which returns a list of (filename, object_path, steps, num_entries, uuid) tuples.
@@ -519,8 +520,11 @@ def _normalize_parquet_file_info(file_info, return_form_or_metadata=False):
     metadata = None
     if isinstance(file_info, list):
         normed_files = [(file, None, None, None, None) for file in file_info]
-    elif(isinstance(file_info, dict) and "files" not in file_info):
-        normed_files = [(file, object_path, None, None, None) for file, object_path in file_info.items()]
+    elif isinstance(file_info, dict) and "files" not in file_info:
+        normed_files = [
+            (file, object_path, None, None, None)
+            for file, object_path in file_info.items()
+        ]
     elif isinstance(file_info, dict) and "files" in file_info:
         form = file_info.get("form", None)
         metadata = file_info.get("metadata", None)
@@ -541,6 +545,7 @@ def _normalize_parquet_file_info(file_info, return_form_or_metadata=False):
     if return_form_or_metadata:
         return normed_files, form, metadata
     return normed_files
+
 
 def get_parquet_form_uuid_steps(
     normed_files: awkward.Array | dask_awkward.Array,
@@ -596,12 +601,12 @@ def get_parquet_form_uuid_steps(
             else:
                 raise e
 
-        num_entries = the_file['num_rows']
+        num_entries = the_file["num_rows"]
 
         form_json = None
         form_hash = None
         if save_form:
-            form = the_file['form']
+            form = the_file["form"]
             form_str = form.to_json()
             # the function cache needs to be popped if present to prevent memory growth
             if hasattr(dask.base, "function_cache"):
@@ -612,14 +617,14 @@ def get_parquet_form_uuid_steps(
 
         target_step_size = num_entries if step_size is None else step_size
 
-        file_uuid = the_file.get('uuid', None)
+        file_uuid = the_file.get("uuid", None)
 
         out_uuid = arg.uuid
         out_steps = arg.steps
 
         if out_uuid != file_uuid or recalculate_steps:
             if use_row_groups:
-                row_group_entries = the_file['col_counts']
+                row_group_entries = the_file["col_counts"]
                 out = [0]
                 this_offset = 0
                 for c in row_group_entries:
@@ -698,6 +703,7 @@ def get_parquet_form_uuid_steps(
         )
 
     return array
+
 
 def _preprocess_parquet(
     fileset: FilesetSpecOptional,

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -511,7 +511,9 @@ def preprocess(
     return out_available, out_updated
 
 
-def _normalize_parquet_file_info(datasetspec: DatasetSpec, return_compressedform_or_metadata=False):
+def _normalize_parquet_file_info(
+    datasetspec: DatasetSpec, return_compressedform_or_metadata=False
+):
     """
     Structure file info akin to _normalize_file_info for uproot files, which returns a list of (filename, object_path, steps, num_entries, uuid) tuples.
     """
@@ -521,7 +523,15 @@ def _normalize_parquet_file_info(datasetspec: DatasetSpec, return_compressedform
         )
     normed_files = []
     for filename, fileinfo in datasetspec.files.items():
-        normed_files.append((filename, fileinfo.object_path, fileinfo.steps, fileinfo.num_entries, fileinfo.uuid))
+        normed_files.append(
+            (
+                filename,
+                fileinfo.object_path,
+                fileinfo.steps,
+                fileinfo.num_entries,
+                fileinfo.uuid,
+            )
+        )
     if return_compressedform_or_metadata:
         return normed_files, datasetspec.compressed_form, datasetspec.metadata
     return normed_files
@@ -829,9 +839,9 @@ def _preprocess_parquet(
             ["file", "object_path", "steps", "num_entries", "uuid"]
         ]
 
-        compressed_forms = processed_files[["file", "form", "form_hash_md5", "num_entries"]][
-            ~awkward.is_none(processed_files.form_hash_md5)
-        ]
+        compressed_forms = processed_files[
+            ["file", "form", "form_hash_md5", "num_entries"]
+        ][~awkward.is_none(processed_files.form_hash_md5)]
 
         _, unique_forms_idx = numpy.unique(
             compressed_forms.form_hash_md5.to_numpy(), return_index=True
@@ -923,8 +933,12 @@ def _preprocess_parquet(
         out_available[name]["files"] = files_available
 
         compressed_union_form = None
-        compressed_union_form = compress_form(union_form_jsonstr) if union_form_jsonstr else None
+        compressed_union_form = (
+            compress_form(union_form_jsonstr) if union_form_jsonstr else None
+        )
         out_updated[name]["compressed_form"] = compressed_union_form
         out_available[name]["compressed_form"] = compressed_union_form
 
-    return DataGroupSpec.model_validate(out_available), DataGroupSpec.model_validate(out_updated)
+    return DataGroupSpec.model_validate(out_available), DataGroupSpec.model_validate(
+        out_updated
+    )

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -782,7 +782,10 @@ class NanoEventsFactory:
         """
         if self._mode == "dask":
             dask_awkward.lib.core.dak_cache.clear()
-            events = self._mapping(form_mapping=self._schema)
+            try:
+                events = self._mapping(form_mapping=self._schema)
+            except TypeError:
+                events = self._mapping()
             report = None
             if isinstance(events, tuple):
                 events, report = events

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -133,7 +133,7 @@ _runnable_result = {
             }
         },
         "metadata": None,
-        "compressed_form": None,
+        "form": None,
     },
     "Data": {
         "files": {
@@ -152,7 +152,7 @@ _runnable_result = {
             }
         },
         "metadata": None,
-        "compressed_form": None,
+        "form": None,
     },
 }
 
@@ -174,7 +174,7 @@ _updated_result = {
             }
         },
         "metadata": None,
-        "compressed_form": None,
+        "form": None,
     },
     "Data": {
         "files": {
@@ -199,7 +199,7 @@ _updated_result = {
             },
         },
         "metadata": None,
-        "compressed_form": None,
+        "form": None,
     },
 }
 
@@ -353,7 +353,8 @@ def test_apply_to_fileset_hinted_form(the_fileset):
 @pytest.mark.parametrize(
     "the_fileset", [_starting_fileset_list, _starting_fileset_dict, _starting_fileset]
 )
-def test_preprocess(the_fileset):
+@pytest.mark.parametrize("preprocess_legacy_root", [True, False])
+def test_preprocess(the_fileset, preprocess_legacy_root):
     with Client() as _:
         dataset_runnable, dataset_updated = preprocess(
             the_fileset,
@@ -361,15 +362,22 @@ def test_preprocess(the_fileset):
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=True,
+            save_form=False,
+            preprocess_legacy_root=preprocess_legacy_root,
         )
 
-        assert dataset_runnable == _runnable_result
-        assert dataset_updated == _updated_result
+        if preprocess_legacy_root:
+            assert dataset_runnable == _runnable_result
+            assert dataset_updated == _updated_result
+        else:
+            assert dataset_runnable == DataGroupSpec(_runnable_result)
+            assert dataset_updated == DataGroupSpec(_updated_result)
 
 
 @pytest.mark.dask_client
 @pytest.mark.parametrize("the_fileset", [{}, DataGroupSpec({})])
-def test_preprocess_empty(the_fileset):
+@pytest.mark.parametrize("preprocess_legacy_root", [True, False])
+def test_preprocess_empty(the_fileset, preprocess_legacy_root):
     with Client() as _:
         dataset_runnable, dataset_updated = preprocess(
             the_fileset,
@@ -377,13 +385,17 @@ def test_preprocess_empty(the_fileset):
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=True,
+            save_form=False,
+            preprocess_legacy_root=preprocess_legacy_root,
         )
-    if isinstance(the_fileset, DataGroupSpec):
-        assert isinstance(dataset_runnable, DataGroupSpec)
-        assert isinstance(dataset_updated, DataGroupSpec)
-    else:
+    if preprocess_legacy_root:
+        # for both pydantic and classical inputs, preprocess_legacy_root returns an empty dictionary
         assert dataset_runnable == {}
         assert dataset_updated == {}
+    else:
+        # pydantic preprocessing upconverts to DataGroupSpec and so we'll get an empty DataGroupSpec. DatasetSpec doesn't trivially support an empty initialization, so we don't test directly
+        assert dataset_runnable == DataGroupSpec({})
+        assert dataset_updated == DataGroupSpec({})
 
 
 @pytest.mark.dask_client
@@ -393,19 +405,23 @@ def test_preprocess_DataGroupSpec_mixed():
     fileset["Data"] = fileset["Data"].model_dump()
 
     with Client() as _:
-        dataset_runnable, dataset_updated = preprocess(
-            fileset,
-            step_size=7,
-            align_clusters=False,
-            files_per_batch=10,
-            skip_bad_files=True,
-        )
-    assert len(dataset_runnable) == 2
-    assert isinstance(dataset_runnable["Data"], DatasetSpec)
+        with pytest.raises(AttributeError, match="'dict' object has no attribute 'format'"):
+            dataset_runnable, dataset_updated = preprocess(
+                fileset,
+                step_size=7,
+                align_clusters=False,
+                files_per_batch=10,
+                skip_bad_files=True,
+                save_form=False,
+            )
+            # If we update the preprocess function to handle this case again, we can check that it produces the expected output
+            assert len(dataset_runnable) == 2
+            assert isinstance(dataset_runnable["Data"], DatasetSpec)
 
 
 @pytest.mark.dask_client
-def test_preprocess_calculate_form():
+@pytest.mark.parametrize("preprocess_legacy_root", [True, False])
+def test_preprocess_calculate_form(preprocess_legacy_root):
     with Client() as _:
         starting_fileset = _starting_fileset
 
@@ -416,6 +432,7 @@ def test_preprocess_calculate_form():
             files_per_batch=10,
             skip_bad_files=True,
             save_form=True,
+            preprocess_legacy_root=preprocess_legacy_root,
         )
 
         raw_form_dy = uproot.dask(
@@ -429,13 +446,21 @@ def test_preprocess_calculate_form():
             ak_add_doc={"__doc__": "title", "typename": "typename"},
         ).layout.form.to_json()
 
-        assert (
-            decompress_form(dataset_runnable["ZJets"]["compressed_form"]) == raw_form_dy
-        )
-        assert (
-            decompress_form(dataset_runnable["Data"]["compressed_form"])
-            == raw_form_data
-        )
+        if preprocess_legacy_root:
+            assert (
+                decompress_form(dataset_runnable["ZJets"]["form"]) == raw_form_dy
+            )
+            assert (
+                decompress_form(dataset_runnable["Data"]["form"])
+                == raw_form_data
+            )
+        else:
+            assert (
+                decompress_form(dataset_runnable["ZJets"].compressed_form) == raw_form_dy
+            )
+            assert (
+                decompress_form(dataset_runnable["Data"].compressed_form) == raw_form_data
+            )
 
 
 @pytest.mark.dask_client
@@ -449,11 +474,13 @@ def test_preprocess_failed_file():
             align_clusters=False,
             files_per_batch=10,
             skip_bad_files=False,
+            save_form=False,
         )
 
 
 @pytest.mark.dask_client
-def test_preprocess_with_file_exceptions():
+@pytest.mark.parametrize("preprocess_legacy_root", [True, False])
+def test_preprocess_with_file_exceptions(preprocess_legacy_root):
     fileset = {
         "Data": {
             "files": {
@@ -471,31 +498,60 @@ def test_preprocess_with_file_exceptions():
             files_per_batch=10,
             file_exceptions=KeyInFileError,
             skip_bad_files=True,
+            save_form=False,
+            preprocess_legacy_root=preprocess_legacy_root,
         )
 
-    assert dataset_runnable == {
-        "Data": {
-            "files": {
-                "tests/samples/delphes.root": {
-                    "num_entries": 25,
-                    "object_path": "Delphes",
-                    "steps": [
-                        [
-                            0,
-                            13,
+    if preprocess_legacy_root:
+        assert dataset_runnable == {
+            "Data": {
+                "files": {
+                    "tests/samples/delphes.root": {
+                        "num_entries": 25,
+                        "object_path": "Delphes",
+                        "steps": [
+                            [
+                                0,
+                                13,
+                            ],
+                            [
+                                13,
+                                25,
+                            ],
                         ],
-                        [
-                            13,
-                            25,
-                        ],
-                    ],
-                    "uuid": "ad4cd5ec-123e-11ec-92f6-93e3aac0beef",
+                        "uuid": "ad4cd5ec-123e-11ec-92f6-93e3aac0beef",
+                    },
                 },
+                "form": None,
+                "metadata": None,
             },
-            "compressed_form": None,
-            "metadata": None,
-        },
-    }
+        }
+    else:
+        assert dataset_runnable == DataGroupSpec(
+            {
+                "Data": {
+                    "files": {
+                        "tests/samples/delphes.root": {
+                            "num_entries": 25,
+                            "object_path": "Delphes",
+                            "steps": [
+                                [
+                                    0,
+                                    13,
+                                ],
+                                [
+                                    13,
+                                    25,
+                                ],
+                            ],
+                            "uuid": "ad4cd5ec-123e-11ec-92f6-93e3aac0beef",
+                        },
+                    },
+                    "compressed_form": None,
+                    "metadata": None,
+                },
+            }
+        )
 
 
 @pytest.mark.parametrize(
@@ -515,7 +571,7 @@ def test_filter_files(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
         "Data": {
             "files": {
@@ -527,7 +583,7 @@ def test_filter_files(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
     }
     if isinstance(filtered_files, DataGroupSpec):
@@ -553,7 +609,7 @@ def test_max_files(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
         "Data": {
             "files": {
@@ -565,7 +621,7 @@ def test_max_files(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
     }
     if isinstance(the_fileset, DataGroupSpec):
@@ -581,7 +637,7 @@ def test_slice_files(the_fileset):
     sliced_files = slice_files(the_fileset, slice(1, None, 2))
 
     target = {
-        "ZJets": {"files": {}, "metadata": None, "compressed_form": None},
+        "ZJets": {"files": {}, "metadata": None, "form": None},
         "Data": {
             "files": {
                 "tests/samples/nano_dimuon_not_there.root": {
@@ -592,7 +648,7 @@ def test_slice_files(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
     }
     if isinstance(the_fileset, DataGroupSpec):
@@ -619,7 +675,7 @@ def test_max_chunks(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
         "Data": {
             "files": {
@@ -631,7 +687,7 @@ def test_max_chunks(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
     }
 
@@ -751,7 +807,7 @@ def test_slice_chunks(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
         "Data": {
             "files": {
@@ -763,7 +819,7 @@ def test_slice_chunks(the_fileset):
                 }
             },
             "metadata": None,
-            "compressed_form": None,
+            "form": None,
         },
     }
     if isinstance(the_fileset, DataGroupSpec):

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -405,7 +405,9 @@ def test_preprocess_DataGroupSpec_mixed():
     fileset["Data"] = fileset["Data"].model_dump()
 
     with Client() as _:
-        with pytest.raises(AttributeError, match="'dict' object has no attribute 'format'"):
+        with pytest.raises(
+            AttributeError, match="'dict' object has no attribute 'format'"
+        ):
             dataset_runnable, dataset_updated = preprocess(
                 fileset,
                 step_size=7,
@@ -447,19 +449,16 @@ def test_preprocess_calculate_form(preprocess_legacy_root):
         ).layout.form.to_json()
 
         if preprocess_legacy_root:
-            assert (
-                decompress_form(dataset_runnable["ZJets"]["form"]) == raw_form_dy
-            )
-            assert (
-                decompress_form(dataset_runnable["Data"]["form"])
-                == raw_form_data
-            )
+            assert decompress_form(dataset_runnable["ZJets"]["form"]) == raw_form_dy
+            assert decompress_form(dataset_runnable["Data"]["form"]) == raw_form_data
         else:
             assert (
-                decompress_form(dataset_runnable["ZJets"].compressed_form) == raw_form_dy
+                decompress_form(dataset_runnable["ZJets"].compressed_form)
+                == raw_form_dy
             )
             assert (
-                decompress_form(dataset_runnable["Data"].compressed_form) == raw_form_data
+                decompress_form(dataset_runnable["Data"].compressed_form)
+                == raw_form_data
             )
 
 


### PR DESCRIPTION
This continues the series of PRs to make pydantic input models thread through coffea, and specifically enables preprocessing parquet files via this. The old preprocess is renamed preprocess_legacy, and preprocess now attempts to coerce users to pydantic classes (with an escape hatch, `preprocess_legacy_root=True`). The pydantic preprocess is made a nonpublic function, with two user-facing variants for root and parquet which call it appropriately.

This partially pulls in updates from https://github.com/NJManganelli/coffea/tree/datafactory_parquet and some associated prototyping in another branch which did not get incorporated into https://github.com/scikit-hep/coffea/pull/1403

This walks back changes to preprocess, to make the code friendlier and make it easier should we deprecate the dict-based preprocess. 

More to be edited into the description as it evolves.