### PR TITLE
chore: # fmt: skip no longer needed for ProcessPoolExecutor

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -564,9 +564,9 @@ class FuturesExecutor(ExecutorBase):
             Number of retries for failed tasks (default: 3)
     """
 
-    pool: (
-        Callable[..., concurrent.futures.Executor] | concurrent.futures.Executor
-    ) = loky.ProcessPoolExecutor  # fmt: skip
+    pool: Callable[..., concurrent.futures.Executor] | concurrent.futures.Executor = (
+        loky.ProcessPoolExecutor
+    )
     mergepool: None | (
         Callable[..., concurrent.futures.Executor] | concurrent.futures.Executor | bool
     ) = None


### PR DESCRIPTION
Small typing nitpick.