### PR TITLE
fix: add better error message when zero chunks survive preprocessing

### DIFF
--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1745,6 +1745,11 @@ class Runner:
             )
 
         chunks = list(chunks)
+        if len(chunks) == 0:
+            raise ValueError(
+                "No chunks survived preprocessing.\n"
+                "If you used skipbadfiles=True or similar, it is possible all your files are bad."
+            )
 
         exe_args = {
             "unit": "chunk",
@@ -1762,8 +1767,8 @@ class Runner:
         wrapped_out, e = executor(chunks, closure, None)
         if wrapped_out is None:
             raise ValueError(
-                "No chunks returned results, verify ``processor`` instance structure.\n\
-                if you used skipbadfiles=True or similar, it is possible all your files are bad."
+                "No chunks returned results, verify ``processor`` instance structure.\n"
+                "If you used skipbadfiles=True or similar, it is possible all your files are bad."
             )
         wrapped_out["exception"] = e
 


### PR DESCRIPTION
The error message now is this
```
  File "/usr/local/lib/python3.11/site-packages/coffea/processor/executor.py", line 1762, in run
    wrapped_out, e = executor(chunks, closure, None)
    ^^^^^^^^^^^^^^
TypeError: cannot unpack non-iterable NoneType object
```
Because it's being raised during proper execution as we try to run the processor over a length zero list of chunks.
The output of preprocessing is never checked if it's empty. That's what this PR adds.