### PR TITLE
ci: switch to monthly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       # Prefix all commit messages with "npm: "
       prefix: "ci: "


### PR DESCRIPTION
Less PR noise and fewer total bots runs that match the typical update cycle when using major versions of actions.