### PR TITLE
feat: add the access log as an attribute of the events factory

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -750,6 +750,11 @@ class NanoEventsFactory:
         start, stop = (int(x) for x in entryrange.split("-"))
         return stop - start
 
+    @property
+    def access_log(self):
+        """List of accessed branches, populated when columns are lazily loaded."""
+        return getattr(self._mapping, "_access_log", None)
+
     def events(self):
         """
         Build events


### PR DESCRIPTION
This very small change exposes the `access_log` of columns to the events factory, which can in turn be accessed by an interested user inside their coffea processor. This provides a granular handle to the quantity that shows up in the coffea report if `savemetrics=True`, so that user can investigate what they are reading from each file, and they can compute quantities such as the (compressed/uncimpressed) bytes read per file. 

I tested the PR with the followign small example:

```
from coffea import processor
from coffea.nanoevents import NanoEventsFactory, NanoAODSchema
import hist
import awkward as ak


class SimpleProcessor(processor.ProcessorABC):
    def process(self, events):
        # Get access_log from factory
        factory = events.attrs["@events_factory"]
        access_log = factory.access_log

        print(f"Accessed branches before: {len(access_log)}")

        jets = events.Jet[events.Jet.pt > 30]
        print(f"Accessed branches after Jet.pt: {len(access_log)}")

        muons = events.Muon[events.Muon.pt > 10]
        print(f"Accessed branches after Muon.pt: {len(access_log)}")

        print("Access log:")
        for entry in access_log:
            print(f"  - {entry.branch}")

        h = hist.Hist.new.Reg(50, 0., 500., name="pt").Double()
        h.fill(pt=ak.flatten(jets.pt))

        return {"hist": h, "nevents": len(events)}

    def postprocess(self, accumulator):
        return accumulator


if __name__ == "__main__":
    fileset = {
        "ZJets": {
            "files": {
                "root://eospublic.cern.ch//eos/opendata/cms/mc/RunIISummer20UL16NanoAODv9/ZprimeToTT_M2000_W20_TuneCP2_PSweights_13TeV-madgraph-pythiaMLM-pythia8/NANOAODSIM/106X_mcRun2_asymptotic_v17-v1/270000/22BAB5D2-9E3F-E440-AB30-AE6DBFDF6C83.root": "Events"
            }
        }
    }

    itexec = processor.IterativeExecutor()
    run = processor.Runner(executor=itexec, schema=NanoAODSchema, savemetrics=True, chunksize=5_000)

    output, metrics = run(fileset, processor_instance=SimpleProcessor())

    print(f"Processed {output['nevents']} events")
    print(f"Histogram entries: {output['hist'].sum()}")

```