### PR TITLE
feat: Schema updates to run on PHYSLITE processed through ServiceX + link improvements

### DIFF
--- a/src/coffea/nanoevents/mapping/preloaded.py
+++ b/src/coffea/nanoevents/mapping/preloaded.py
@@ -5,9 +5,9 @@ import awkward
 import numpy
 
 from coffea.nanoevents.mapping.base import BaseSourceMapping, UUIDOpener
-from coffea.nanoevents.util import quote, tuple_to_key
+from coffea.nanoevents.util import tuple_to_key
 
-from .uproot import _lazify_form, CannotBeNanoEvents
+from .uproot import CannotBeNanoEvents, _lazify_form
 
 
 class SimplePreloadedColumnSource(dict):

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -44,6 +44,8 @@ def _element_link(target_collection, eventindex, index, key):
             "element linking must be done on two dask_awkward arrays or two awkward arrays not a mix of the two"
         )
 
+    if isinstance(key, Number):
+        key = numpy.array([key])
     global_index = _get_global_index(target_collection, eventindex, index)
     global_index = awkward.where(key != 0, global_index, -1)
     return target_collection._apply_global_index(global_index)
@@ -255,7 +257,7 @@ class Muon(Particle):
         return _element_link_method(
             self,
             "extrapolatedMuonSpectrometerTrackParticleLink",
-            "ExtrapolatedMuonSpectrometerTrackParticles",
+            "ExtrapolatedMuonTrackParticles",
             None,
         )
 
@@ -264,7 +266,7 @@ class Muon(Particle):
         return _element_link_method(
             self,
             "extrapolatedMuonSpectrometerTrackParticleLink",
-            "ExtrapolatedMuonSpectrometerTrackParticles",
+            "ExtrapolatedMuonTrackParticles",
             dask_array,
         )
 

--- a/src/coffea/nanoevents/methods/physlite.py
+++ b/src/coffea/nanoevents/methods/physlite.py
@@ -194,6 +194,8 @@ class Muon(Particle):
     <https://gitlab.cern.ch/atlas/athena/-/blob/21.2/Event/xAOD/xAODMuon/Root/Muon_v1.cxx>`_.
     """
 
+    # trackParticle does not behave like Muon::trackParticle, which determines which of the various collections
+    # to use on the fly (e.g. calotagged muons do not have combined tracks). Fix in future?
     @dask_property
     def trackParticle(self):
         return _element_link_method(
@@ -209,6 +211,60 @@ class Muon(Particle):
             self,
             "combinedTrackParticleLink",
             "CombinedMuonTrackParticles",
+            dask_array,
+        )
+
+    @dask_property
+    def combinedTrackParticle(self):
+        return _element_link_method(
+            self,
+            "combinedTrackParticleLink",
+            "CombinedMuonTrackParticles",
+            None,
+        )
+
+    @combinedTrackParticle.dask
+    def combinedTrackParticle(self, dask_array):
+        return _element_link_method(
+            self,
+            "combinedTrackParticleLink",
+            "CombinedMuonTrackParticles",
+            dask_array,
+        )
+
+    @dask_property
+    def inDetTrackParticle(self):
+        return _element_link_method(
+            self,
+            "inDetTrackParticleLink",
+            "InDetTrackParticles",
+            None,
+        )
+
+    @inDetTrackParticle.dask
+    def inDetTrackParticle(self, dask_array):
+        return _element_link_method(
+            self,
+            "inDetTrackParticleLink",
+            "InDetTrackParticles",
+            dask_array,
+        )
+
+    @dask_property
+    def extrapolatedMuonSpectrometerTrackParticle(self):
+        return _element_link_method(
+            self,
+            "extrapolatedMuonSpectrometerTrackParticleLink",
+            "ExtrapolatedMuonSpectrometerTrackParticles",
+            None,
+        )
+
+    @extrapolatedMuonSpectrometerTrackParticle.dask
+    def extrapolatedMuonSpectrometerTrackParticle(self, dask_array):
+        return _element_link_method(
+            self,
+            "extrapolatedMuonSpectrometerTrackParticleLink",
+            "ExtrapolatedMuonSpectrometerTrackParticles",
             dask_array,
         )
 

--- a/src/coffea/nanoevents/schemas/physlite.py
+++ b/src/coffea/nanoevents/schemas/physlite.py
@@ -127,8 +127,12 @@ class PHYSLITESchema(BaseSchema):
                         else:
                             to_collect[(topkey, skleft)].append((skright, form))
             for (topkey, skleft), info in to_collect.items():
-                keys_and_form.append(((topkey, skleft), zip_forms({key: form for key, form in info},
-                                                              skleft)))
+                keys_and_form.append(
+                    (
+                        (topkey, skleft),
+                        zip_forms({key: form for key, form in info}, skleft),
+                    )
+                )
 
             to_zip = {}
             for (key, sub_key), form in keys_and_form:
@@ -153,10 +157,12 @@ class PHYSLITESchema(BaseSchema):
                     to_zip["tau"] = transforms.full_like_from_content_form(
                         to_zip["theta"], 139.570
                     )
-                if mixin == 'Muon':
+                if mixin == "Muon":
                     # at least as of p7019 we need to add in the muon mass for four-vectors to work
                     if "m" not in to_zip:
-                        to_zip["m"] = transforms.full_like_from_content_form(to_zip["pt"], 105.658)
+                        to_zip["m"] = transforms.full_like_from_content_form(
+                            to_zip["pt"], 105.658
+                        )
                 contents[objname] = zip_forms(
                     to_zip,
                     objname,

--- a/src/coffea/nanoevents/schemas/physlite.py
+++ b/src/coffea/nanoevents/schemas/physlite.py
@@ -109,10 +109,31 @@ class PHYSLITESchema(BaseSchema):
                 # don't zip if there is only one item
                 contents[objname] = keys_and_form[0][1]
                 continue
+            keys_and_form_dict = dict(keys_and_form)
+
+            # special handling for cases where the ElementLink splitting has left us without
+            # a "parent" key. Reconstitute a parent object if none exists
+            to_collect = {}
+            for (key, sub_key), form in keys_and_form:
+                if "." in sub_key:
+                    # if the "parent" field is not available, create it
+                    skleft, skright = sub_key.split(".", 1)
+                    topkey = key.split(".", 1)[0]
+                    if (key, skleft) in keys_and_form_dict:
+                        continue
+                    else:
+                        if (topkey, skleft) not in to_collect:
+                            to_collect[(topkey, skleft)] = [(skright, form)]
+                        else:
+                            to_collect[(topkey, skleft)].append((skright, form))
+            for (topkey, skleft), info in to_collect.items():
+                keys_and_form.append(((topkey, skleft), zip_forms({key: form for key, form in info},
+                                                              skleft)))
+
             to_zip = {}
             for (key, sub_key), form in keys_and_form:
                 if "." in sub_key:
-                    # we can skip fields with '.' in the name since they will come again as records
+                    # now, we can skip fields with '.' in the name since they will come again as records
                     # e.g. truthParticleLink.m_persKey will also appear in truthParticleLink
                     # (record with fields m_persKey and m_persIndex)
                     continue
@@ -132,6 +153,10 @@ class PHYSLITESchema(BaseSchema):
                     to_zip["tau"] = transforms.full_like_from_content_form(
                         to_zip["theta"], 139.570
                     )
+                if mixin == 'Muon':
+                    # at least as of p7019 we need to add in the muon mass for four-vectors to work
+                    if "m" not in to_zip:
+                        to_zip["m"] = transforms.full_like_from_content_form(to_zip["pt"], 105.658)
                 contents[objname] = zip_forms(
                     to_zip,
                     objname,

--- a/tests/test_nanoevents_physlite.py
+++ b/tests/test_nanoevents_physlite.py
@@ -1,11 +1,11 @@
 import json
 import os
+from uuid import uuid4
 
 import awkward as ak
 import dask
 import pytest
 import uproot
-from uuid import uuid4
 
 from coffea.nanoevents import NanoEventsFactory, PHYSLITESchema
 from coffea.nanoevents.mapping import SimplePreloadedColumnSource
@@ -61,16 +61,17 @@ def test_electron_track_links(do_slice, mode):
     if do_slice:
         events = events[::2]
     trackParticles = unwrapper(events.Electrons.trackParticles, mode)
-    for i, event in enumerate(unwrapper(events[["Electrons", "GSFTrackParticles"]], mode)):
+    for i, event in enumerate(
+        unwrapper(events[["Electrons", "GSFTrackParticles"]], mode)
+    ):
         for j, electron in enumerate(event.Electrons):
             for link_index, link in enumerate(electron.trackParticleLinks):
                 track_index = link.m_persIndex
                 assert (
-                    ( trackParticles[i][j][link_index] is None 
-                     and link.m_persKey == 0 )
-                    or
-                    ( event.GSFTrackParticles[track_index].z0
-                      == trackParticles[i][j][link_index].z0 )
+                    trackParticles[i][j][link_index] is None and link.m_persKey == 0
+                ) or (
+                    event.GSFTrackParticles[track_index].z0
+                    == trackParticles[i][j][link_index].z0
                 )
 
 
@@ -80,48 +81,65 @@ def test_muon_track_links(do_slice, mode):
     events = _events(mode=mode)
     if do_slice:
         events = events[::2]
-    for tpobj, tplinkname, tpcollection in [("trackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
-                                            ("combinedTrackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
-                                            ("inDetTrackParticle", "inDetTrackParticleLink", "InDetTrackParticles"),
-                                            ("extrapolatedMuonSpectrometerTrackParticle", "extrapolatedMuonSpectrometerTrackParticleLink",
-                                             "ExtrapolatedMuonTrackParticles")]:
+    for tpobj, tplinkname, tpcollection in [
+        ("trackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
+        (
+            "combinedTrackParticle",
+            "combinedTrackParticleLink",
+            "CombinedMuonTrackParticles",
+        ),
+        ("inDetTrackParticle", "inDetTrackParticleLink", "InDetTrackParticles"),
+        (
+            "extrapolatedMuonSpectrometerTrackParticle",
+            "extrapolatedMuonSpectrometerTrackParticleLink",
+            "ExtrapolatedMuonTrackParticles",
+        ),
+    ]:
         trackParticles = unwrapper(getattr(events.Muons, tpobj), mode)
         for i, event in enumerate(unwrapper(events[["Muons", tpcollection]], mode)):
             for j, muon in enumerate(event.Muons):
                 link = getattr(muon, tplinkname)
                 track_index = link.m_persIndex
-                assert (
-                    ( trackParticles[i][j] is None 
-                     and link.m_persKey == 0 ) or
-                    ( event[tpcollection][track_index].z0
-                    == trackParticles[i][j].z0 )
+                assert (trackParticles[i][j] is None and link.m_persKey == 0) or (
+                    event[tpcollection][track_index].z0 == trackParticles[i][j].z0
                 )
 
 
-@pytest.mark.parametrize("filt", [['*AuxDyn*'],
-                                  [
-                                                    r'/AnalysisMuonsAuxDyn\..*/i',
-                                                                    '/InDetTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i',
-                                                                   '/CombinedMuonTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i',
-                                                                   '/ExtrapolatedMuonTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i',
-                                                                   ]])
+@pytest.mark.parametrize(
+    "filt",
+    [
+        ["*AuxDyn*"],
+        [
+            r"/AnalysisMuonsAuxDyn\..*/i",
+            "/InDetTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i",
+            "/CombinedMuonTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i",
+            "/ExtrapolatedMuonTrackParticlesAuxDyn.(d0|z0|qOverP|theta)/i",
+        ],
+    ],
+)
 def test_muon_track_links_preloaded(filt):
     events = _awkward_events_stripped(filter=filt)
-    for tpobj, tplinkname, tpcollection in [("trackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
-                                            ("combinedTrackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
-                                            ("inDetTrackParticle", "inDetTrackParticleLink", "InDetTrackParticles"),
-                                            ("extrapolatedMuonSpectrometerTrackParticle", "extrapolatedMuonSpectrometerTrackParticleLink",
-                                             "ExtrapolatedMuonTrackParticles")]:
+    for tpobj, tplinkname, tpcollection in [
+        ("trackParticle", "combinedTrackParticleLink", "CombinedMuonTrackParticles"),
+        (
+            "combinedTrackParticle",
+            "combinedTrackParticleLink",
+            "CombinedMuonTrackParticles",
+        ),
+        ("inDetTrackParticle", "inDetTrackParticleLink", "InDetTrackParticles"),
+        (
+            "extrapolatedMuonSpectrometerTrackParticle",
+            "extrapolatedMuonSpectrometerTrackParticleLink",
+            "ExtrapolatedMuonTrackParticles",
+        ),
+    ]:
         trackParticle = getattr(events.Muons, tpobj)
         for i, event in enumerate(events[["Muons", tpcollection]]):
             for j, muon in enumerate(event.Muons):
                 link = getattr(muon, tplinkname)
                 track_index = link.m_persIndex
-                assert (
-                                        ( trackParticle[i][j] is None 
-                     and link.m_persKey == 0 ) or
-                    ( event[tpcollection][track_index].z0
-                    == trackParticle[i][j].z0 )
+                assert (trackParticle[i][j] is None and link.m_persKey == 0) or (
+                    event[tpcollection][track_index].z0 == trackParticle[i][j].z0
                 )
 
 


### PR DESCRIPTION
Tweaks to support handling of `ElementLinks` when processed through ServiceX (will still work with standard PHYSLITE). Give muons minimum four-vector functionality and improve set of linked objects.