### PR TITLE
chore: fix treemaker schema uproot writing test to write TTree

### DIFF
--- a/tests/test_nanoevents_treemaker.py
+++ b/tests/test_nanoevents_treemaker.py
@@ -90,7 +90,7 @@ def test_uproot_write():
     ).events()
 
     with uproot.recreate("treemaker_write_test.root") as f:
-        f["PreSelection"] = TreeMakerSchema.uproot_writeable(orig_events)
+        f.mktree("PreSelection", TreeMakerSchema.uproot_writeable(orig_events))
 
     test_events = NanoEventsFactory.from_root(
         {"treemaker_write_test.root": "PreSelection"},


### PR DESCRIPTION
Uproot switched to writing RNTuples by default, so this test needed to be updated since the `TTreeMakerSchema` doesn't work for RNTuples.