### PR TITLE
feat: adding split fileset strategies to coffea functionality

### DIFF
--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -12,6 +12,8 @@ import cloudpickle
 import dask_awkward
 import fsspec
 import hist
+import math
+import json
 import numba
 import numpy
 import uproot
@@ -44,8 +46,97 @@ __all__ = [
     "compress_form",
     "decompress_form",
     "coffea_console",
+    "split_fileset",
+    "hash_fileset",
 ]
 
+
+def hash_fileset(chunk):
+    """
+    Return a stable SHA-256 hash for a fileset chunk.
+    The hash considers dataset names, file paths in sorted order.
+
+    Input
+    chunk: fileset dict  {dataset: {"files": {path: treename, ...}, ...}, ...}
+
+    Output
+    hex string uniquely identifying this chunk's file content
+    """
+    canonical = {
+        dataset: dict(sorted(files.get("files", {}).items()))
+        for dataset, files in chunk.items()
+    }
+    serialized = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
+    """
+    Split fileset into chunks to enable getting partial result if one of the filesets(
+    one partial fileset is one chunk here, these are not usual coffea chunks)
+    is failed to produce a result while being processed.
+    
+    Input
+    fileset:    {dataset: {"files": {path: treename, ...}}}
+    strategy:   "by_dataset" — one dataset is one chunk; None — all datasets together
+    percentage: integer that divides 100 evenly (20, 25, 50...).
+                Each chunk gets this percentage of each dataset's files.
+    
+    Output
+    List of fileset dicts
+    If strategy only:
+        chunks = _split_fileset(fileset, "by_dataset") - one chunk per dataset
+    If percentage only:
+        chunks = _split_fileset(fileset, percentage=50) - 2 chunks (50 of each dataset in 1st chunk and 2nd)
+        chunks = _split_fileset(fileset, "by_dataset", percentage=50) - N_datasets * 2 chunks
+    """
+    if strategy is not None and strategy != "by_dataset":
+        raise ValueError(
+            f"Unknown strategy '{strategy}'. Use 'by_dataset' or None."
+        )
+    if percentage is not None:
+        if not isinstance(percentage, int) or not (1 <= percentage <= 100) or 100 % percentage != 0:
+            raise ValueError(
+                "'percentage' must be an int that divides 100 evenly (e.g. 10, 20, 25, 50)."
+            )
+    
+    if datasets is None:
+        pass
+    elif callable(datasets):
+        fileset = {k: v for k, v in fileset.items() if datasets(k)}
+    else:
+        fileset = {k: fileset[k] for k in datasets if k in fileset}
+    
+    
+  
+    if strategy == "by_dataset":
+        groups = [{name: data} for name, data in fileset.items()]
+    else:
+        groups = [fileset]
+
+    if percentage is None:
+        return groups
+
+    n_chunks = 100 // percentage
+    result = []
+    for group in groups:
+        for bin_idx in range(n_chunks):
+            chunk = {}
+            for dataset, data in group.items():
+                files = data.get("files", {})
+                if not files:
+                    continue
+                file_items = list(files.items())
+                n = len(file_items)
+                chunk_size = max(1, math.ceil(n / n_chunks))
+                start = bin_idx * chunk_size
+                end = min(start + chunk_size, n)
+                if start >= n:
+                    continue
+                chunk[dataset] = {**data, "files": dict(file_items[start:end])}
+            if chunk:
+                result.append(chunk)
+    return result
 
 def load(filename, compression="lz4"):
     """Load a coffea file from disk
@@ -92,7 +183,6 @@ def _hash(items):
     x = hashlib.md5(bytes(";".join(str(x) for x in items), "ascii"))
     return int(x.hexdigest()[:16], base=16)
     
-
 def _ensure_flat(array, allow_missing=False):
     """Normalize an array to a flat numpy array, or ensure it is a flat dask-awkward array, or raise ValueError"""
     if not isinstance(array, (dak.Array, ak.Array, numpy.ndarray)):

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -35,7 +35,6 @@ dak = dask_awkward
 np = numpy
 nb = numba
 
-
 __all__ = [
     "load",
     "save",

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -71,23 +71,28 @@ def hash_fileset(chunk):
 
 def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
     """
-    Split fileset into chunks to enable getting partial result if one of the filesets(
-    one partial fileset is one chunk here, these are not usual coffea chunks)
-    is failed to produce a result while being processed.
+    Split the fileset into chunks to enable getting a partial result if one or several
+    of the chunks failed to produce a result while being processed.
+    One chunk is one partial fileset(unique combination of files), these are not usual coffea chunks.
+    
     
     Input
     fileset:    {dataset: {"files": {path: treename, ...}}}
     strategy:   "by_dataset" — one dataset is one chunk; None — all datasets together
     percentage: integer that divides 100 evenly (20, 25, 50...).
                 Each chunk gets this percentage of each dataset's files.
+    datasets: list, callable or tuple of datasets' names
     
     Output
     List of fileset dicts
     If strategy only:
         chunks = _split_fileset(fileset, "by_dataset") - one chunk per dataset
     If percentage only:
-        chunks = _split_fileset(fileset, percentage=50) - 2 chunks (50 of each dataset in 1st chunk and 2nd)
-        chunks = _split_fileset(fileset, "by_dataset", percentage=50) - N_datasets * 2 chunks
+        chunks = _split_fileset(fileset, percentage=50) - 2 chunks (50 of each dataset in 1st chunk and 2nd, mixed chunks
+    If strategy and percentage:
+        chunks = _split_fileset(fileset, "by_dataset", percentage=50) - N_datasets * 2 chunks, not mixed chunks
+    If datasets + any/nothing:
+        strategies are only applied to chosen datasets
     """
     if strategy is not None and strategy != "by_dataset":
         raise ValueError(

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -12,6 +12,8 @@ import cloudpickle
 import dask_awkward
 import fsspec
 import hist
+import math
+import json
 import numba
 import numpy
 import uproot
@@ -44,8 +46,97 @@ __all__ = [
     "compress_form",
     "decompress_form",
     "coffea_console",
+    "split_fileset",
+    "hash_fileset",
 ]
 
+
+def hash_fileset(chunk):
+    """
+    Return a stable SHA-256 hash for a fileset chunk.
+    The hash considers dataset names, file paths in sorted order.
+
+    Input
+    chunk: fileset dict  {dataset: {"files": {path: treename, ...}, ...}, ...}
+
+    Output
+    hex string uniquely identifying this chunk's file content
+    """
+    canonical = {
+        dataset: dict(sorted(files.get("files", {}).items()))
+        for dataset, files in chunk.items()
+    }
+    serialized = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
+    """
+    Split fileset into chunks to enable getting partial result if one of the filesets(
+    one partial fileset is one chunk here, these are not usual coffea chunks)
+    is failed to produce a result while being processed.
+    
+    Input
+    fileset:    {dataset: {"files": {path: treename, ...}}}
+    strategy:   "by_dataset" — one dataset is one chunk; None — all datasets together
+    percentage: integer that divides 100 evenly (20, 25, 50...).
+                Each chunk gets this percentage of each dataset's files.
+    
+    Output
+    List of fileset dicts
+    If strategy only:
+        chunks = _split_fileset(fileset, "by_dataset") - one chunk per dataset
+    If percentage only:
+        chunks = _split_fileset(fileset, percentage=50) - 2 chunks (50 of each dataset in 1st chunk and 2nd)
+        chunks = _split_fileset(fileset, "by_dataset", percentage=50) - N_datasets * 2 chunks
+    """
+    if strategy is not None and strategy != "by_dataset":
+        raise ValueError(
+            f"Unknown strategy '{strategy}'. Use 'by_dataset' or None."
+        )
+    if percentage is not None:
+        if not isinstance(percentage, int) or not (1 <= percentage <= 100) or 100 % percentage != 0:
+            raise ValueError(
+                "'percentage' must be an int that divides 100 evenly (e.g. 10, 20, 25, 50)."
+            )
+    
+    if datasets is None:
+        pass
+    elif callable(datasets):
+        fileset = {k: v for k, v in fileset.items() if datasets(k)}
+    else:
+        fileset = {k: fileset[k] for k in datasets if k in fileset}
+    
+    
+  
+    if strategy == "by_dataset":
+        groups = [{name: data} for name, data in fileset.items()]
+    else:
+        groups = [fileset]
+
+    if percentage is None:
+        return groups
+
+    n_chunks = 100 // percentage
+    result = []
+    for group in groups:
+        for bin_idx in range(n_chunks):
+            chunk = {}
+            for dataset, data in group.items():
+                files = data.get("files", {})
+                if not files:
+                    continue
+                file_items = list(files.items())
+                n = len(file_items)
+                chunk_size = max(1, math.ceil(n / n_chunks))
+                start = bin_idx * chunk_size
+                end = min(start + chunk_size, n)
+                if start >= n:
+                    continue
+                chunk[dataset] = {**data, "files": dict(file_items[start:end])}
+            if chunk:
+                result.append(chunk)
+    return result
 
 def load(filename, compression="lz4"):
     """Load a coffea file from disk
@@ -91,8 +182,7 @@ def _hash(items):
     # python 3.3 salts hash(), we want it to persist across processes
     x = hashlib.md5(bytes(";".join(str(x) for x in items), "ascii"))
     return int(x.hexdigest()[:16], base=16)
-
-
+    
 def _ensure_flat(array, allow_missing=False):
     """Normalize an array to a flat numpy array, or ensure it is a flat dask-awkward array, or raise ValueError"""
     if not isinstance(array, (dak.Array, ak.Array, numpy.ndarray)):

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -12,8 +12,6 @@ import cloudpickle
 import dask_awkward
 import fsspec
 import hist
-import math
-import json
 import numba
 import numpy
 import uproot
@@ -46,97 +44,8 @@ __all__ = [
     "compress_form",
     "decompress_form",
     "coffea_console",
-    "split_fileset",
-    "hash_fileset",
 ]
 
-
-def hash_fileset(chunk):
-    """
-    Return a stable SHA-256 hash for a fileset chunk.
-    The hash considers dataset names, file paths in sorted order.
-
-    Input
-    chunk: fileset dict  {dataset: {"files": {path: treename, ...}, ...}, ...}
-
-    Output
-    hex string uniquely identifying this chunk's file content
-    """
-    canonical = {
-        dataset: dict(sorted(files.get("files", {}).items()))
-        for dataset, files in chunk.items()
-    }
-    serialized = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.sha256(serialized).hexdigest()
-
-
-def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
-    """
-    Split fileset into chunks to enable getting partial result if one of the filesets(
-    one partial fileset is one chunk here, these are not usual coffea chunks)
-    is failed to produce a result while being processed.
-    
-    Input
-    fileset:    {dataset: {"files": {path: treename, ...}}}
-    strategy:   "by_dataset" — one dataset is one chunk; None — all datasets together
-    percentage: integer that divides 100 evenly (20, 25, 50...).
-                Each chunk gets this percentage of each dataset's files.
-    
-    Output
-    List of fileset dicts
-    If strategy only:
-        chunks = _split_fileset(fileset, "by_dataset") - one chunk per dataset
-    If percentage only:
-        chunks = _split_fileset(fileset, percentage=50) - 2 chunks (50 of each dataset in 1st chunk and 2nd)
-        chunks = _split_fileset(fileset, "by_dataset", percentage=50) - N_datasets * 2 chunks
-    """
-    if strategy is not None and strategy != "by_dataset":
-        raise ValueError(
-            f"Unknown strategy '{strategy}'. Use 'by_dataset' or None."
-        )
-    if percentage is not None:
-        if not isinstance(percentage, int) or not (1 <= percentage <= 100) or 100 % percentage != 0:
-            raise ValueError(
-                "'percentage' must be an int that divides 100 evenly (e.g. 10, 20, 25, 50)."
-            )
-    
-    if datasets is None:
-        pass
-    elif callable(datasets):
-        fileset = {k: v for k, v in fileset.items() if datasets(k)}
-    else:
-        fileset = {k: fileset[k] for k in datasets if k in fileset}
-    
-    
-  
-    if strategy == "by_dataset":
-        groups = [{name: data} for name, data in fileset.items()]
-    else:
-        groups = [fileset]
-
-    if percentage is None:
-        return groups
-
-    n_chunks = 100 // percentage
-    result = []
-    for group in groups:
-        for bin_idx in range(n_chunks):
-            chunk = {}
-            for dataset, data in group.items():
-                files = data.get("files", {})
-                if not files:
-                    continue
-                file_items = list(files.items())
-                n = len(file_items)
-                chunk_size = max(1, math.ceil(n / n_chunks))
-                start = bin_idx * chunk_size
-                end = min(start + chunk_size, n)
-                if start >= n:
-                    continue
-                chunk[dataset] = {**data, "files": dict(file_items[start:end])}
-            if chunk:
-                result.append(chunk)
-    return result
 
 def load(filename, compression="lz4"):
     """Load a coffea file from disk
@@ -183,6 +92,7 @@ def _hash(items):
     x = hashlib.md5(bytes(";".join(str(x) for x in items), "ascii"))
     return int(x.hexdigest()[:16], base=16)
     
+
 def _ensure_flat(array, allow_missing=False):
     """Normalize an array to a flat numpy array, or ensure it is a flat dask-awkward array, or raise ValueError"""
     if not isinstance(array, (dak.Array, ak.Array, numpy.ndarray)):

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -3,6 +3,8 @@
 import base64
 import gzip
 import hashlib
+import json
+import math
 import warnings
 from functools import partial
 from typing import Any
@@ -12,8 +14,6 @@ import cloudpickle
 import dask_awkward
 import fsspec
 import hist
-import math
-import json
 import numba
 import numpy
 import uproot
@@ -74,15 +74,15 @@ def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
     Split the fileset into chunks to enable getting a partial result if one or several
     of the chunks failed to produce a result while being processed.
     One chunk is one partial fileset(unique combination of files), these are not usual coffea chunks.
-    
-    
+
+
     Input
     fileset:    {dataset: {"files": {path: treename, ...}}}
     strategy:   "by_dataset" — one dataset is one chunk; None — all datasets together
     percentage: integer that divides 100 evenly (20, 25, 50...).
                 Each chunk gets this percentage of each dataset's files.
     datasets: list, callable or tuple of datasets' names
-    
+
     Output
     List of fileset dicts
     If strategy only:
@@ -95,24 +95,24 @@ def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
         strategies are only applied to chosen datasets
     """
     if strategy is not None and strategy != "by_dataset":
-        raise ValueError(
-            f"Unknown strategy '{strategy}'. Use 'by_dataset' or None."
-        )
+        raise ValueError(f"Unknown strategy '{strategy}'. Use 'by_dataset' or None.")
     if percentage is not None:
-        if not isinstance(percentage, int) or not (1 <= percentage <= 100) or 100 % percentage != 0:
+        if (
+            not isinstance(percentage, int)
+            or not (1 <= percentage <= 100)
+            or 100 % percentage != 0
+        ):
             raise ValueError(
                 "'percentage' must be an int that divides 100 evenly (e.g. 10, 20, 25, 50)."
             )
-    
+
     if datasets is None:
         pass
     elif callable(datasets):
         fileset = {k: v for k, v in fileset.items() if datasets(k)}
     else:
         fileset = {k: fileset[k] for k in datasets if k in fileset}
-    
-    
-  
+
     if strategy == "by_dataset":
         groups = [{name: data} for name, data in fileset.items()]
     else:
@@ -141,6 +141,7 @@ def split_fileset(fileset, strategy=None, datasets=None, percentage=None):
             if chunk:
                 result.append(chunk)
     return result
+
 
 def load(filename, compression="lz4"):
     """Load a coffea file from disk
@@ -186,7 +187,8 @@ def _hash(items):
     # python 3.3 salts hash(), we want it to persist across processes
     x = hashlib.md5(bytes(";".join(str(x) for x in items), "ascii"))
     return int(x.hexdigest()[:16], base=16)
-    
+
+
 def _ensure_flat(array, allow_missing=False):
     """Normalize an array to a flat numpy array, or ensure it is a flat dask-awkward array, or raise ValueError"""
     if not isinstance(array, (dak.Array, ak.Array, numpy.ndarray)):


### PR DESCRIPTION
Closes #1532

This PR adds two simple functions to the `coffea.util` module: `split_fileset` and `hash_fileset.`
The idea is to give users more control over how they execute analysis on a fileset, and to get a partial result instead of nothing if something breaks (e.g., one file is broken). If this PR is accepted and merged (or the alternative one I'm going to open next), I'll write documentation with a kind of "Best practices" guide on how to use it, with the examples below.

1. `split_fileset()` allows choosing a strategy for how to split the fileset into parts (~chunks, but higher-level chunks — not the usual coffea chunks; one chunk will be a unique subset of files from the fileset). It returns a list of partial filesets. This function accepts:
- `fileset`:    {dataset: {"files": {path: treename, ...}}}
- `strategy`:   "by_dataset" — one dataset per one chunk; None — all datasets together
- `percentage`: an integer that divides 100 evenly (20, 25, 50...). If `strategy="by_dataset"`, each dataset is split into `100/percentage` chunks; otherwise the whole fileset is split into `100/percentage` chunks where each chunk gets that percentage of each dataset's files
 - `datasets`: list, callable or tuple of dataset names
 
 This gives users the ability to write analysis like this:
 ```python
 chunks = split_fileset(fileset, strategy="by_dataset", percentage=20)
result = None
for chunk in chunks:
    try:
        output, metrics = run(chunk, processor_instance=Processor())
        if result is None:
            result = output
        else:
            result += output
    except BaseException as e:
        print(f"Error: {e}")
        continue
 ```
If one or several chunks contained a broken file etc., a partial result will still be returned.
 
 2. `hash_fileset` allows creating a unique filename for a processed chunk based on its file paths and dataset names. This is useful when you want to preserve partial results and only rerun analysis on missing chunks. The recommended approach in a Jupyter notebook, for example, would be:
 ```python
 # concept example
chunks = split_fileset(fileset, strategy="by_dataset", percentage=20)

import os

result = None
cache_dir = "./chunk_cache"
os.makedirs(cache_dir, exist_ok=True)
```
After the first run, partial result will be saved. Then user can just rerun the same cell and partial result will be extracted from cache, while processor run will be only applied to missing chunks.

```python
for chunk in chunks:
    chunk_hash = hash_fileset(chunk)
    cache_path = os.path.join(cache_dir, f"{chunk_hash}.coffea")

    if os.path.exists(cache_path):
        print(f"Loading cached result for chunk {chunk_hash}")
        output = load(cache_path)
    else:
        try:
            output, metrics = run(chunk, processor_instance=Processor())
            save(output, cache_path)
            print(f"Saved result for chunk {chunk_hash}")
        except BaseException as e:
            print(f"Error processing chunk {chunk_hash}: {e}")
            continue

    if result is None:
        result = output
    else:
        result += output
```

Usage examples with full analysis can be found [here](https://github.com/hooloobooroodkoo/demo-split/tree/master).
Thanks, @pfackeldey and @alexander-held for the idea!
 