### PR TITLE
feat: counter-based RNG for deterministic JER smearing

### DIFF
--- a/src/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/src/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -49,8 +49,7 @@ def rand_gauss(event_number, phi, eta, rng):
     # Build 128-bit counter: [event_number(64), phi_bits(32) << 32 | eta_bits(32)]
     counter = numpy.empty((len(phi_arr), 2), dtype=numpy.uint64)
     counter[:, 0] = event_number
-    counter[:, 1] = numpy.round(phi_arr, 3).view(numpy.uint32).astype(numpy.uint64)
-    counter[:, 1] <<= 32
+    counter[:, 1] = numpy.round(phi_arr, 3).view(numpy.uint32).astype(numpy.uint64).byteswap()
     counter[:, 1] |= numpy.round(eta_arr, 3).view(numpy.uint32).astype(numpy.uint64)
 
     rand = rng.normal(counter).astype(numpy.float32)

--- a/src/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/src/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -49,7 +49,9 @@ def rand_gauss(event_number, phi, eta, rng):
     # Build 128-bit counter: [event_number(64), phi_bits(32) << 32 | eta_bits(32)]
     counter = numpy.empty((len(phi_arr), 2), dtype=numpy.uint64)
     counter[:, 0] = event_number
-    counter[:, 1] = numpy.round(phi_arr, 3).view(numpy.uint32).astype(numpy.uint64).byteswap()
+    counter[:, 1] = (
+        numpy.round(phi_arr, 3).view(numpy.uint32).astype(numpy.uint64).byteswap()
+    )
     counter[:, 1] |= numpy.round(eta_arr, 3).view(numpy.uint32).astype(numpy.uint64)
 
     rand = rng.normal(counter).astype(numpy.float32)
@@ -334,7 +336,9 @@ class CorrectedJetsFactory:
             if event_number is not None:
                 # Counter-based RNG: deterministic per-jet, partition-independent
                 flat_event = awkward.flatten(
-                    awkward.broadcast_arrays(event_number, jets[self.name_map["JetPt"]])[0]
+                    awkward.broadcast_arrays(
+                        event_number, jets[self.name_map["JetPt"]]
+                    )[0]
                 )
                 rng = Squares(*seeds)
                 out_dict["jet_resolution_rand_gauss"] = maybe_map_partitions(

--- a/src/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/src/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -5,6 +5,7 @@ import awkward
 import dask_awkward
 import numpy
 
+from coffea.jetmet_tools.cbrng import Squares
 from coffea.util import awkward_rewrap, maybe_map_partitions, rewrap_recordarray
 
 _stack_parts = ["jec", "junc", "jer", "jersf"]
@@ -29,7 +30,41 @@ class _AwkwardRewrapFn:
         return awkward.transform(func, like_what, behavior=like_what.behavior)
 
 
-def rand_gauss(item):
+def rand_gauss(event_number, phi, eta, rng):
+    """Generate per-jet Gaussian random numbers using a counter-based RNG.
+
+    Each jet gets a deterministic random number derived from its event number,
+    phi, and eta, making the result independent of data partitioning.
+    """
+    event_number = numpy.asarray(
+        awkward.typetracer.length_zero_if_typetracer(event_number), dtype=numpy.uint64
+    )
+    phi_arr = numpy.asarray(
+        awkward.typetracer.length_zero_if_typetracer(phi), dtype=numpy.float32
+    )
+    eta_arr = numpy.asarray(
+        awkward.typetracer.length_zero_if_typetracer(eta), dtype=numpy.float32
+    )
+
+    # Build 128-bit counter: [event_number(64), phi_bits(32) << 32 | eta_bits(32)]
+    counter = numpy.empty((len(phi_arr), 2), dtype=numpy.uint64)
+    counter[:, 0] = event_number
+    counter[:, 1] = numpy.round(phi_arr, 3).view(numpy.uint32).astype(numpy.uint64)
+    counter[:, 1] <<= 32
+    counter[:, 1] |= numpy.round(eta_arr, 3).view(numpy.uint32).astype(numpy.uint64)
+
+    rand = rng.normal(counter).astype(numpy.float32)
+
+    out = awkward.Array(rand)
+    if awkward.backend(phi) == "typetracer":
+        out = awkward.Array(
+            out.layout.to_typetracer(forget_length=True), behavior=out.behavior
+        )
+    return out
+
+
+def _legacy_rand_gauss(item):
+    """Legacy partition-dependent random number generator (kept for backwards compatibility)."""
     seeds = (
         awkward.typetracer.length_one_if_typetracer(item).to_numpy()[[0, -1]].view("i4")
     )
@@ -198,7 +233,7 @@ class CorrectedJetsFactory:
             out.extend([f"JES_{unc}" for unc in self.jec_stack.junc.levels])
         return out
 
-    def build(self, injets):
+    def build(self, injets, event_number=None, seeds=("JER",)):
         """
         Apply the corrections to the array of jets, returning an array of corrected
         jets.
@@ -207,6 +242,14 @@ class CorrectedJetsFactory:
         ----------
             injets : awkward.Array or dask_awkward.Array
                 An array of uncorrected jets, to which we want to apply corrections.
+            event_number : awkward.Array or dask_awkward.Array, optional
+                Per-event event numbers (1D, one per event, same length as
+                ``injets``).  Automatically broadcast to per-jet.
+                When provided, uses a counter-based RNG seeded from per-jet
+                (event_number, phi, eta) for partition-independent reproducibility.
+                If ``None``, falls back to the legacy partition-dependent RNG.
+            seeds : tuple of str or int, optional
+                Seeds for the counter-based RNG.  Default is ``("JER",)``.
 
         Returns
         -------
@@ -289,10 +332,25 @@ class CorrectedJetsFactory:
                 self.jec_stack.jersf.getScaleFactor(**jersfargs)
             )
 
-            out_dict["jet_resolution_rand_gauss"] = maybe_map_partitions(
-                rand_gauss,
-                out_dict[self.name_map["JetPt"] + "_orig"],
-            )
+            if event_number is not None:
+                # Counter-based RNG: deterministic per-jet, partition-independent
+                flat_event = awkward.flatten(
+                    awkward.broadcast_arrays(event_number, jets[self.name_map["JetPt"]])[0]
+                )
+                rng = Squares(*seeds)
+                out_dict["jet_resolution_rand_gauss"] = maybe_map_partitions(
+                    rand_gauss,
+                    flat_event,
+                    out_dict[self.name_map["JetPhi"]],
+                    out_dict[self.name_map["JetEta"]],
+                    rng,
+                )
+            else:
+                # Legacy RNG: partition-dependent (for backwards compatibility)
+                out_dict["jet_resolution_rand_gauss"] = maybe_map_partitions(
+                    _legacy_rand_gauss,
+                    out_dict[self.name_map["JetPt"] + "_orig"],
+                )
 
             init_jerc = maybe_map_partitions(
                 jer_smear,

--- a/src/coffea/jetmet_tools/cbrng.py
+++ b/src/coffea/jetmet_tools/cbrng.py
@@ -1,0 +1,175 @@
+"""Counter-based random number generator (CBRNG) using the Squares algorithm.
+
+Provides partition-independent, reproducible random numbers for JER smearing
+by constructing per-jet counters from physics coordinates (event number, phi, eta).
+
+Based on the Squares algorithm: https://arxiv.org/abs/2004.06278
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable
+
+import numpy as np
+import numpy.typing as npt
+
+_2_PI = 2 * np.pi
+_UINT64_11 = np.uint64(11)
+_UINT64_32 = np.uint64(32)
+_BIT52_COUNT = np.float64(1 << 53)
+
+SeedLike = int | str | Iterable[int | str]
+
+
+def _str_to_entropy(__str: str) -> list[np.uint64]:
+    return np.frombuffer(hashlib.md5(__str.encode()).digest(), dtype=np.uint64).tolist()
+
+
+def _seed(*entropy: SeedLike) -> tuple[int, ...]:
+    seeds = []
+    for e in entropy:
+        if isinstance(e, str):
+            seeds.extend(_str_to_entropy(e))
+        elif isinstance(e, Iterable):
+            seeds.extend(_seed(*e))
+        else:
+            seeds.append(e)
+    return (*seeds,)
+
+
+class Squares:
+    """Counter-based RNG using the Squares algorithm.
+
+    Unlike standard PRNGs, Squares maps a counter (derived from per-jet physics
+    quantities) to a random number.  This makes outputs deterministic regardless
+    of how the data is partitioned.
+
+    Parameters
+    ----------
+    seed : SeedLike
+        One or more ints/strings used to derive the key.
+
+    Examples
+    --------
+    >>> rng = Squares("JER")
+    >>> counters = np.array([[1, 2], [3, 4]], dtype=np.uint64)
+    >>> rng.normal(counters)  # returns one float per row
+    """
+
+    def __init__(self, *seed: SeedLike):
+        self._seed = _seed(seed)
+        self._keys: dict[int | None, np.uint64] = {}
+        self._offset: int | None = None
+
+    def _make_key(self, gen: np.random.Generator) -> np.uint64:
+        bits = np.arange(1, 16, dtype=np.uint64)
+        offsets = np.arange(0, 29, 4, dtype=np.uint64)
+        lower8 = gen.choice(bits, 8, replace=False)
+        for i in range(16):
+            if lower8[i] % 2 == 1:
+                lower8 = np.roll(lower8, -i)
+                break
+        higher8 = np.zeros(8, dtype=np.uint64)
+        higher8[0:1] = gen.choice(np.delete(bits, int(lower8[-1]) - 1), 1)
+        higher8[1:] = gen.choice(
+            np.delete(bits, int(higher8[0]) - 1), 7, replace=False
+        )
+        return np.sum(lower8 << offsets) + (np.sum(higher8 << offsets) << _UINT64_32)
+
+    @property
+    def _key(self) -> np.uint64:
+        k, o = self._keys, self._offset
+        if o not in k:
+            s = self._seed
+            if o is not None:
+                s += (o,)
+            k[o] = self._make_key(np.random.Generator(np.random.PCG64(s)))
+        return k[o]
+
+    def _shift(self, offset: int | None = None) -> Squares:
+        new = Squares.__new__(Squares)
+        new._seed = self._seed
+        new._keys = self._keys
+        new._offset = offset
+        return new
+
+    # -- Core bit generators --------------------------------------------------
+
+    def _round(self, lr: npt.NDArray, shift: npt.NDArray, last: bool = False):
+        lr *= lr
+        lr += shift
+        if last:
+            yield lr.copy()
+        l = lr >> _UINT64_32
+        lr <<= _UINT64_32
+        lr |= l
+        yield lr
+
+    def bit32(self, ctrs: npt.NDArray[np.uint64]) -> npt.NDArray[np.uint32]:
+        x = ctrs * self._key
+        y = x.copy()
+        z = y + self._key
+        for i in [y, z, y]:
+            (_,) = self._round(x, i)
+        x *= x
+        x += z
+        x >>= _UINT64_32
+        return x.astype(np.uint32)
+
+    def bit64(self, ctrs: npt.NDArray[np.uint64]) -> npt.NDArray[np.uint64]:
+        x = ctrs * self._key
+        y = x.copy()
+        z = y + self._key
+        for i in [y, z, y]:
+            (_,) = self._round(x, i)
+        (t, _) = self._round(x, z, last=True)
+        x *= x
+        x += y
+        x >>= _UINT64_32
+        x ^= t
+        return x
+
+    # -- Reduction & distributions --------------------------------------------
+
+    def uint64(self, counters: npt.ArrayLike) -> npt.NDArray[np.uint64]:
+        """Reduce the last dimension of counters to a single uint64 per row."""
+        counters = np.asarray(counters, dtype=np.uint64)
+        if counters.ndim == 1:
+            return self.bit64(counters)
+        while True:
+            shape = counters.shape[-1]
+            if shape == 1:
+                return self.bit64(counters).reshape(counters.shape[:-1])
+            elif shape % 2 == 0:
+                counters = self.bit32(counters).view(np.uint64)
+            else:
+                counters = np.concatenate(
+                    [
+                        counters[..., -1:],
+                        self.bit32(counters[..., :-1]).view(np.uint64),
+                    ],
+                    axis=-1,
+                )
+
+    def float64(self, counters: npt.ArrayLike) -> npt.NDArray[np.float64]:
+        """Uniform [0, 1) from counters."""
+        x = self.uint64(counters)
+        x >>= _UINT64_11
+        return x / _BIT52_COUNT
+
+    def normal(
+        self,
+        counters: npt.ArrayLike,
+        loc: float = 0.0,
+        scale: float = 1.0,
+    ) -> npt.NDArray[np.float64]:
+        """Normal distribution via Box-Muller transform."""
+        o = self._offset
+        o = 0 if o is None else o + 1
+        x = self.float64(counters)
+        y = self._shift(o).float64(counters)
+        x = np.sqrt(-2.0 * np.log(x)) * np.cos(_2_PI * y)
+        x *= scale
+        x += loc
+        return x

--- a/src/coffea/jetmet_tools/cbrng.py
+++ b/src/coffea/jetmet_tools/cbrng.py
@@ -101,9 +101,9 @@ class Squares:
         lr += shift
         if last:
             yield lr.copy()
-        l = lr >> _UINT64_32
+        low = lr >> _UINT64_32
         lr <<= _UINT64_32
-        lr |= l
+        lr |= low
         yield lr
 
     def bit32(self, ctrs: npt.NDArray[np.uint64]) -> npt.NDArray[np.uint32]:

--- a/src/coffea/jetmet_tools/cbrng.py
+++ b/src/coffea/jetmet_tools/cbrng.py
@@ -9,7 +9,7 @@ Based on the Squares algorithm: https://arxiv.org/abs/2004.06278
 from __future__ import annotations
 
 import hashlib
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import numpy.typing as npt
@@ -72,9 +72,7 @@ class Squares:
                 break
         higher8 = np.zeros(8, dtype=np.uint64)
         higher8[0:1] = gen.choice(np.delete(bits, int(lower8[-1]) - 1), 1)
-        higher8[1:] = gen.choice(
-            np.delete(bits, int(higher8[0]) - 1), 7, replace=False
-        )
+        higher8[1:] = gen.choice(np.delete(bits, int(higher8[0]) - 1), 7, replace=False)
         return np.sum(lower8 << offsets) + (np.sum(higher8 << offsets) << _UINT64_32)
 
     @property
@@ -123,7 +121,7 @@ class Squares:
         z = y + self._key
         for i in [y, z, y]:
             (_,) = self._round(x, i)
-        (t, _) = self._round(x, z, last=True)
+        t, _ = self._round(x, z, last=True)
         x *= x
         x += y
         x >>= _UINT64_32

--- a/tests/test_jetmet_correctionlib_adapters.py
+++ b/tests/test_jetmet_correctionlib_adapters.py
@@ -362,10 +362,12 @@ def test_corrected_jets_factory_cbrng(clib_stack):
 
     corrected_a = factory.build(jets_a, event_number=events_a)
     corrected_b = factory.build(jets_b, event_number=events_b)
-    rejoined_pt = np.concatenate([
-        np.asarray(ak.flatten(corrected_a)["pt"]),
-        np.asarray(ak.flatten(corrected_b)["pt"]),
-    ])
+    rejoined_pt = np.concatenate(
+        [
+            np.asarray(ak.flatten(corrected_a)["pt"]),
+            np.asarray(ak.flatten(corrected_b)["pt"]),
+        ]
+    )
     assert np.allclose(
         np.asarray(flat_corrected["pt"]),
         rejoined_pt,

--- a/tests/test_jetmet_correctionlib_adapters.py
+++ b/tests/test_jetmet_correctionlib_adapters.py
@@ -300,6 +300,79 @@ def test_corrected_jets_factory_with_correctionlib(clib_stack):
         assert "down" in ak.fields(flat_corrected[unc])
 
 
+def test_corrected_jets_factory_cbrng(clib_stack):
+    """Test that counter-based RNG (event_number) produces partition-independent results."""
+    from coffea.jetmet_tools import CorrectedJetsFactory
+
+    name_map = clib_stack.blank_name_map
+    name_map["JetPt"] = "pt"
+    name_map["JetMass"] = "mass"
+    name_map["JetEta"] = "eta"
+    name_map["JetA"] = "area"
+    name_map["ptRaw"] = "pt_raw"
+    name_map["massRaw"] = "mass_raw"
+    name_map["Rho"] = "rho"
+    name_map["ptGenJet"] = "pt_gen"
+    name_map["METpt"] = "met_pt"
+    name_map["METphi"] = "met_phi"
+    name_map["JetPhi"] = "phi"
+    name_map["UnClusteredEnergyDeltaX"] = "ue_dx"
+    name_map["UnClusteredEnergyDeltaY"] = "ue_dy"
+
+    factory = CorrectedJetsFactory(name_map, clib_stack)
+
+    counts, test_eta, test_pt = dummy_jagged_eta_pt()
+    n_flat = len(test_eta)
+    n_events = len(counts)
+
+    jets_dict = {
+        "pt": test_pt.astype(np.float32),
+        "mass": (test_pt * 0.1).astype(np.float32),
+        "eta": test_eta.astype(np.float32),
+        "phi": np.linspace(-np.pi, np.pi, n_flat, dtype=np.float32),
+        "area": np.full(n_flat, 0.5, dtype=np.float32),
+        "pt_raw": test_pt.astype(np.float32),
+        "mass_raw": (test_pt * 0.1).astype(np.float32),
+        "rho": np.full(n_flat, 30.0, dtype=np.float32),
+        "pt_gen": (test_pt * 0.95).astype(np.float32),
+    }
+    jets_jag = ak.unflatten(ak.zip(jets_dict), counts)
+    event_nums = ak.Array(np.arange(n_events, dtype=np.uint64))
+
+    corrected = factory.build(jets_jag, event_number=event_nums)
+    flat_corrected = ak.flatten(corrected)
+    assert len(flat_corrected) == n_flat
+    assert "JER" in factory.uncertainties()
+
+    # Verify reproducibility: same input => same output
+    corrected2 = factory.build(jets_jag, event_number=event_nums)
+    flat_corrected2 = ak.flatten(corrected2)
+    assert np.allclose(
+        np.asarray(flat_corrected["pt"]),
+        np.asarray(flat_corrected2["pt"]),
+        rtol=1e-7,
+    )
+
+    # Verify partition-independence: split jets into two halves and rejoin
+    mid = n_events // 2
+    jets_a = jets_jag[:mid]
+    jets_b = jets_jag[mid:]
+    events_a = event_nums[:mid]
+    events_b = event_nums[mid:]
+
+    corrected_a = factory.build(jets_a, event_number=events_a)
+    corrected_b = factory.build(jets_b, event_number=events_b)
+    rejoined_pt = np.concatenate([
+        np.asarray(ak.flatten(corrected_a)["pt"]),
+        np.asarray(ak.flatten(corrected_b)["pt"]),
+    ])
+    assert np.allclose(
+        np.asarray(flat_corrected["pt"]),
+        rejoined_pt,
+        rtol=1e-7,
+    ), "CBRNG results should be identical regardless of partitioning"
+
+
 def test_corrected_jets_factory_with_correctionlib_dask(clib_stack):
     """Full integration test with dask arrays."""
     from coffea.jetmet_tools import CorrectedJetsFactory


### PR DESCRIPTION
## Summary

The current JER smearing in `CorrectedJetsFactory` uses `numpy.random`, which produces different random numbers depending on how events are partitioned across chunks. This means the same jet can get different smearing corrections depending on the processing setup, making results non-reproducible.

This PR adds an **opt-in** counter-based RNG (CBRNG) using the Squares algorithm ([arXiv:2004.06278](https://arxiv.org/abs/2004.06278)) that generates deterministic random numbers based on per-jet physics quantities (event number, phi, eta). The same jet always gets the same random number regardless of partitioning, chunk size, or parallelization strategy. 

This developement was created by @chuyuanliu in our framework, and I am just putting it in the central coffea because I consider it important for other users.

**Key points:**
- New `event_number` parameter on `build()` — when provided, uses CBRNG; when omitted (`None`), falls back to the legacy RNG. Fully backwards compatible.
- Per-jet 128-bit counter: `[event_number(64), phi_bits(32) << 32 | eta_bits(32)]`
- Works with both eager awkward arrays and dask-awkward

## Files changed
- `src/coffea/jetmet_tools/CorrectedJetsFactory.py` — added `event_number`/`seeds` parameters to `build()`, CBRNG path alongside legacy RNG
- `src/coffea/jetmet_tools/cbrng.py` — new module implementing the Squares CBRNG algorithm
- `tests/test_jetmet_correctionlib_adapters.py` — added `test_corrected_jets_factory_cbrng` verifying determinism and partition independence

## Test plan
- [x] `test_corrected_jets_factory_cbrng` — verifies same jets produce same smearing across calls
- [x] All 17 existing tests pass unchanged (no regressions)