### PR TITLE
ci: move dask client parametrization inside the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macOS-latest, windows-latest]
         python-version: ["3.10", "3.14", "3.14t"]
-        dask-client: ["with", "without"]
         include:
           - python-version: "3.10"
             python-conda-pkg: "python=3.10"
@@ -49,7 +48,7 @@ jobs:
           - python-version: "3.14t"
             python-conda-pkg: "python-freethreading=3.14"
 
-    name: Test (${{ matrix.os }}) - py ${{ matrix.python-version }}, ${{ matrix.dask-client }} dask
+    name: Test (${{ matrix.os }}) - py ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v6
@@ -94,12 +93,10 @@ jobs:
       run: |
         docker run -d --rm -p 8000:8000 -p 8001:8001 -p 8002:8002 -v ${{ github.workspace }}/tests/samples/triton_models_test:/models nvcr.io/nvidia/tritonserver:25.11-pyt-python-py3 tritonserver --model-repository=/models
 
-    - name: Test with pytest (${{ matrix.dask-client }} dask Client - run in parallel)
-      if: matrix.dask-client == 'without'
+    - name: Test with pytest (without dask Client - run in parallel)
       run: |
         python -m pytest --cov-report=xml --cov=coffea --deselect=test_taskvine -m "not dask_client" -n 4
-    - name: Test with pytest (${{ matrix.dask-client }} dask Client)
-      if: matrix.dask-client == 'with'
+    - name: Test with pytest (with dask Client)
       run: |
         python -m pytest --cov-report=xml --cov=coffea --deselect=test_taskvine -m "dask_client"
     - name: Upload codecov


### PR DESCRIPTION
I think we can benefit from having less jobs for the github runners to run as the runners are limited.