### PR TITLE
fix: handle empty arrays for buffer cache

### DIFF
--- a/src/coffea/nanoevents/mapping/buffer_cache.py
+++ b/src/coffea/nanoevents/mapping/buffer_cache.py
@@ -10,6 +10,7 @@ class ShapeDTypeStruct:
     dtype: np.dtype
     shape: tuple[int, ...]
     strides: tuple[int, ...]
+    compressed: bool
 
 
 ByteBuffer: tp.TypeAlias = bytes
@@ -23,7 +24,8 @@ class Codec(tp.Protocol):
 
 class NoCompressionCodec(Codec):
     def encode(self, arr: np.ndarray) -> tuple[ByteBuffer, ShapeDTypeStruct]:
-        struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides)
+        struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
+                                  compressed=False)
         return arr.tobytes(), struct
 
     def decode(self, buffer: ByteBuffer, struct: ShapeDTypeStruct) -> np.ndarray:
@@ -38,12 +40,21 @@ class NumCodecsWrapper:
         self._codec = codec
 
     def encode(self, arr: np.ndarray) -> tuple[ByteBuffer, ShapeDTypeStruct]:
-        struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides)
-        encoded = self._codec.encode(arr.tobytes())
+        if arr.nbytes > 16:
+            encoded = self._codec.encode(arr.tobytes())
+            struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
+                                      compressed=True)
+        else:
+            encoded = arr.tobytes()
+            struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
+                                      compressed=False)
         return encoded, struct
 
     def decode(self, buffer: ByteBuffer, struct: ShapeDTypeStruct) -> np.ndarray:
-        decoded = self._codec.decode(buffer)
+        if struct.compressed:
+            decoded = self._codec.decode(buffer)
+        else:
+            decoded = buffer
         arr = np.frombuffer(decoded, struct.dtype)
         return np.lib.stride_tricks.as_strided(arr, struct.shape, struct.strides)
 

--- a/src/coffea/nanoevents/mapping/buffer_cache.py
+++ b/src/coffea/nanoevents/mapping/buffer_cache.py
@@ -24,8 +24,9 @@ class Codec(tp.Protocol):
 
 class NoCompressionCodec(Codec):
     def encode(self, arr: np.ndarray) -> tuple[ByteBuffer, ShapeDTypeStruct]:
-        struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
-                                  compressed=False)
+        struct = ShapeDTypeStruct(
+            dtype=arr.dtype, shape=arr.shape, strides=arr.strides, compressed=False
+        )
         return arr.tobytes(), struct
 
     def decode(self, buffer: ByteBuffer, struct: ShapeDTypeStruct) -> np.ndarray:
@@ -42,12 +43,14 @@ class NumCodecsWrapper:
     def encode(self, arr: np.ndarray) -> tuple[ByteBuffer, ShapeDTypeStruct]:
         if arr.nbytes > 16:
             encoded = self._codec.encode(arr.tobytes())
-            struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
-                                      compressed=True)
+            struct = ShapeDTypeStruct(
+                dtype=arr.dtype, shape=arr.shape, strides=arr.strides, compressed=True
+            )
         else:
             encoded = arr.tobytes()
-            struct = ShapeDTypeStruct(dtype=arr.dtype, shape=arr.shape, strides=arr.strides,
-                                      compressed=False)
+            struct = ShapeDTypeStruct(
+                dtype=arr.dtype, shape=arr.shape, strides=arr.strides, compressed=False
+            )
         return encoded, struct
 
     def decode(self, buffer: ByteBuffer, struct: ShapeDTypeStruct) -> np.ndarray:

--- a/tests/test_buffer_cache.py
+++ b/tests/test_buffer_cache.py
@@ -1,6 +1,7 @@
 from collections.abc import MutableMapping
 
 import awkward as ak
+import numpy as np
 import pytest
 
 from coffea.nanoevents import NanoAODSchema, NanoEventsFactory
@@ -132,3 +133,22 @@ def test_buffer_cache_hierarchical(tests_directory):
 
     hierarchical_cache.clear()  # rm's all files in mycache
     os.rmdir(f"{tests_directory}/mycache")
+
+
+def test_buffer_cache_small_and_empty_array_compression():
+    pytest.importorskip("numcodecs")
+    pytest.importorskip("zict")
+
+    from numcodecs import Blosc
+
+    codec = Blosc("zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
+    cache = BufferCache(cache=None, codec=codec)
+
+    for arr in [
+        np.array([], dtype=np.float32),  # 0 bytes
+        np.array([1, 2], dtype=np.int32),  # 8 bytes
+        np.array([1, 2, 3, 4], dtype=np.int32),  # 16 bytes
+    ]:
+        cache["key"] = arr
+        result = cache["key"]
+        np.testing.assert_array_equal(result, arr)


### PR DESCRIPTION
This implements a workaround for an error observed in `numcodecs` by @pfackeldey , https://github.com/zarr-developers/numcodecs/issues/831 . When compressing and decompressing empty numpy arrays, an error is thrown for unknown reasons. This works around the issue by only compressing arrays with more than 16 bytes (proposed by @pfackeldey ).