### PR TITLE
docs: fix various typos and old links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 
 * Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
 
-* Before submitting, please run `pre-commit run --all-files` and `pytest` to ensure you follow our formatting conventions and do not break any existing code. Furthermore, we prefer that any newly contributed code does not reduce the current code coverage of the repository. Please make sure your test your code as thoroughly as is needed.
+* Before submitting, please run `pre-commit run --all-files` and `pytest` to ensure you follow our formatting conventions and do not break any existing code. Furthermore, we prefer that any newly contributed code does not reduce the current code coverage of the repository. Please make sure you test your code as thoroughly as is needed.
 
 #### **Did you fix whitespace, format code, or make a purely cosmetic patch?**
 
@@ -32,13 +32,13 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 * Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/installation.html#for-developers) to get a development environment
 
-* Edit the ReStructured Text files in `docs/source` or the docstrings in the python source code as appropriate
+* Edit the reStructuredText files in `docs/source` or the docstrings in the Python source code as appropriate
 
 * Run `pushd docs && make html && popd` to compile, and open `docs/build/html/index.html` in a browser to see your local changes
 
 coffea is a HEP community and volunteer effort. We encourage you to pitch in and [join the team](mailto:cms-coffea@cern.ch)!
 
-* Fixes, changes, and documentation updates will be released in a timely manner. Coffea follows [CalVer](https://calver.org/) practices. Repository maintainers will generate new releases as necessary, and releases are made using the github release pages.
+* Fixes, changes, and documentation updates will be released in a timely manner. Coffea follows [CalVer](https://calver.org/) practices. Repository maintainers will generate new releases as necessary, and releases are made using the GitHub release pages.
 
 Thanks! :coffee: :coffee: :coffee:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 * Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/getting_started/installation.html#for-developers) to get a development environment
 
-* Edit the reStructuredText files in `docs/source` or the docstrings in the Python source code as appropriate
+* Edit the Markdown (MyST) files in `docs/source` or the docstrings in the Python source code as appropriate
 
 * Run `pushd docs && make html && popd` to compile, and open `docs/build/html/index.html` in a browser to see your local changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 #### **Do you want to write a patch that fixes a bug?**
 
-* Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/installation.html#for-developers) to get a development environment
+* Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/getting_started/installation.html#for-developers) to get a development environment
 
 * Open a new GitHub pull request with the patch.
 
@@ -30,7 +30,7 @@ Changes that are cosmetic in nature and do not add anything substantial to the s
 
 #### **Do you want to contribute to the coffea documentation?**
 
-* Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/installation.html#for-developers) to get a development environment
+* Follow the [setup instructions for developers](https://coffea-hep.readthedocs.io/en/latest/getting_started/installation.html#for-developers) to get a development environment
 
 * Edit the reStructuredText files in `docs/source` or the docstrings in the Python source code as appropriate
 

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ coffea - Columnar Object Framework For Effective Analysis
     :target: https://github.com/scikit-hep/coffea/actions?query=workflow%3ACI%2FCD+event%3Aschedule+branch%3Amaster
 
 .. image:: https://codecov.io/gh/scikit-hep/coffea/branch/master/graph/badge.svg?event=schedule
-    :target: https://codecov.io/gh/scikit-hep/coffea
+    :target: https://app.codecov.io/gh/scikit-hep/coffea
 
 .. image:: https://badge.fury.io/py/coffea.svg
-    :target: https://badge.fury.io/py/coffea
+    :target: https://pypi.org/project/coffea
 
 .. image:: https://img.shields.io/pypi/dm/coffea.svg
     :target: https://img.shields.io/pypi/dm/coffea
@@ -28,7 +28,7 @@ coffea - Columnar Object Framework For Effective Analysis
 .. image:: https://badges.gitter.im/scikit-hep/coffea.svg
     :target: https://matrix.to/#/#coffea-hep_community:gitter.im
 
-.. image:: https://mybinder.org/badge_logo.svg
+.. image:: https://static.mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder/
 
 .. inclusion-marker-1-do-not-remove
@@ -39,8 +39,8 @@ Basic tools and wrappers for enabling not-too-alien syntax when running columnar
 
 coffea is a prototype package for pulling together all the typical needs
 of a high-energy collider physics (HEP) experiment analysis using the scientific
-Python ecosystem. It makes use of `uproot <https://github.com/scikit-hep/uproot4>`_
-and `awkward-array <https://github.com/scikit-hep/awkward-1.0>`_ to provide an
+Python ecosystem. It makes use of `uproot <https://github.com/scikit-hep/uproot5>`_
+and `awkward-array <https://github.com/scikit-hep/awkward>`_ to provide an
 array-based syntax for manipulating HEP event data in an efficient and numpythonic
 way. There are sub-packages that implement histogramming, plotting, and look-up
 table functionalities that are needed to convey scientific insight, apply transformations
@@ -49,13 +49,13 @@ to data, and correct for discrepancies in Monte Carlo simulations compared to da
 coffea also supplies facilities for horizontally scaling an analysis in order to reduce
 time-to-insight in a way that is largely independent of the resource the analysis
 is being executed on. By making use of modern *big-data* technologies like
-`parsl <https://github.com/Parsl/parsl>`_, `Dask <https://dask.org>`_ ,
+`parsl <https://github.com/Parsl/parsl>`_, `Dask <https://www.dask.org/>`_ ,
 and `TaskVine <https://ccl.cse.nd.edu/software/taskvine>`_,
 it is possible with coffea to scale a HEP analysis from a testing
 on a laptop to: a large multi-core server, computing clusters, and super-computers without
 the need to alter or otherwise adapt the analysis code itself.
 
-coffea is a HEP community project collaborating with `iris-hep <http://iris-hep.org/>`_
+coffea is a HEP community project collaborating with `iris-hep <https://iris-hep.org/>`_
 and is currently a prototype. We welcome input to improve its quality as we progress towards
 a sensible refactorization into the scientific python ecosystem and a first release. Please
 feel free to contribute at our `GitHub repo <https://github.com/scikit-hep/coffea>`_!
@@ -72,12 +72,12 @@ Install coffea like any other Python package:
     pip install coffea
 
 or similar (use ``sudo``, ``--user``, ``virtualenv``, or pip-in-conda if you wish).
-For more details, see the `Installing coffea <https://coffea-hep.readthedocs.io/en/latest/installation.html>`_ section of the documentation.
+For more details, see the `Installing coffea <https://coffea-hep.readthedocs.io/en/latest/getting_started/installation.html>`_ section of the documentation.
 
 Strict dependencies
 ===================
 
-- `Python <http://docs.python-guide.org/en/latest/starting/installation/>`__ (3.9+)
+- `Python <https://docs.python-guide.org/starting/installation/>`__ (3.9+)
 
 The following are installed automatically when you install coffea with pip:
 
@@ -85,7 +85,7 @@ The following are installed automatically when you install coffea with pip:
 - `uproot <https://github.com/scikit-hep/uproot5>`__ for interacting with ROOT files and handling their data transparently;
 - `awkward-array <https://github.com/scikit-hep/awkward>`__ to manipulate complex-structured columnar data, such as jagged arrays;
 - `numba <https://numba.pydata.org/>`__ just-in-time compilation of python functions;
-- `scipy <https://scipy.org/scipylib/index.html>`__ for many statistical functions;
+- `scipy <https://docs.scipy.org/doc/scipy/>`__ for many statistical functions;
 - `matplotlib <https://matplotlib.org/>`__ as a plotting backend;
 - and other utility packages, as enumerated in ``pyproject.toml``.
 
@@ -93,7 +93,7 @@ The following are installed automatically when you install coffea with pip:
 
 Documentation
 =============
-All documentation is hosted at https://coffea-hep.readthedocs.io/
+All documentation is hosted at https://coffea-hep.readthedocs.io/en/latest/
 
 Citation
 ========

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Basic tools and wrappers for enabling not-too-alien syntax when running columnar
 
 coffea is a prototype package for pulling together all the typical needs
 of a high-energy collider physics (HEP) experiment analysis using the scientific
-python ecosystem. It makes use of `uproot <https://github.com/scikit-hep/uproot4>`_
+Python ecosystem. It makes use of `uproot <https://github.com/scikit-hep/uproot4>`_
 and `awkward-array <https://github.com/scikit-hep/awkward-1.0>`_ to provide an
 array-based syntax for manipulating HEP event data in an efficient and numpythonic
 way. There are sub-packages that implement histogramming, plotting, and look-up
@@ -58,7 +58,7 @@ the need to alter or otherwise adapt the analysis code itself.
 coffea is a HEP community project collaborating with `iris-hep <http://iris-hep.org/>`_
 and is currently a prototype. We welcome input to improve its quality as we progress towards
 a sensible refactorization into the scientific python ecosystem and a first release. Please
-feel free to contribute at our `github repo <https://github.com/scikit-hep/coffea>`_!
+feel free to contribute at our `GitHub repo <https://github.com/scikit-hep/coffea>`_!
 
 .. inclusion-marker-2-do-not-remove
 

--- a/binder/advanced_numba.ipynb
+++ b/binder/advanced_numba.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Jit compilation with Numba\n",
     "\n",
-    "This is a rendered copy of [advanced_numba.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/advanced_numba.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fadvanced_numba.ipynb)\n",
+    "This is a rendered copy of [advanced_numba.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/advanced_numba.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fadvanced_numba.ipynb)\n",
     "\n",
     "The purpose of this notebook is to teach you how to express operations that are hard to express in an array-oriented way in an imperative way and then jit compile them using numba and execute them as part of your coffea workflow.\n",
     "\n",

--- a/binder/analysis_tools.ipynb
+++ b/binder/analysis_tools.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Analysis tools\n",
     "\n",
-    "This is a rendered copy of [analysis_tools.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/analysis_tools.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fanalysis_tools.ipynb)\n",
+    "This is a rendered copy of [analysis_tools.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/analysis_tools.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fanalysis_tools.ipynb)\n",
     "\n",
     "Now that we know how to access data with NanoEvents and apply corrections, let's go through some useful columnar analysis tools and idioms for building collections of results, namely, the eventual output of a coffea callable (or processor). The most familiar type of output may be the histogram (one type of accumulator).\n",
     "\n",

--- a/binder/applying_corrections.ipynb
+++ b/binder/applying_corrections.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Applying corrections to columnar data\n",
     "\n",
-    "This is a rendered copy of [applying_corrections.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/applying_corrections.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fapplying_corrections.ipynb)\n",
+    "This is a rendered copy of [applying_corrections.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/applying_corrections.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fapplying_corrections.ipynb)\n",
     "\n",
     "Here we will show how to apply corrections to columnar data using:\n",
     "\n",
@@ -88,7 +88,7 @@
     "# download some sample correction sources\n",
     "mkdir -p data\n",
     "pushd data\n",
-    "PREFIX=https://raw.githubusercontent.com/CoffeaTeam/coffea/master/tests/samples\n",
+    "PREFIX=https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples\n",
     "curl -Os $PREFIX/testSF2d.histo.root\n",
     "curl -Os $PREFIX/Fall17_17Nov2017_V32_MC_L2Relative_AK4PFPuppi.jec.txt\n",
     "curl -Os $PREFIX/Fall17_17Nov2017_V32_MC_Uncertainty_AK4PFPuppi.junc.txt\n",
@@ -102,7 +102,7 @@
    "source": [
     "### Opening a root file and using it as a lookup table\n",
     "\n",
-    "In [tests/samples](https://github.com/CoffeaTeam/coffea/tree/master/tests/samples), there is an example file with a `TH2F` histogram named `scalefactors_Tight_Electron`. The following code reads that histogram into an [evaluator](https://coffea-hep.readthedocs.io/en/latest/api/coffea.lookup_tools.evaluator.html#coffea.lookup_tools.evaluator) instance, under the key `testSF2d` and applies it to some electrons."
+    "In [tests/samples](https://github.com/scikit-hep/coffea/tree/master/tests/samples), there is an example file with a `TH2F` histogram named `scalefactors_Tight_Electron`. The following code reads that histogram into an [evaluator](https://coffea-hep.readthedocs.io/en/latest/api/coffea.lookup_tools.evaluator.html#coffea.lookup_tools.evaluator) instance, under the key `testSF2d` and applies it to some electrons."
    ]
   },
   {
@@ -363,7 +363,7 @@
     "\n",
     "### Applying energy scale transformations with jetmet_tools\n",
     "\n",
-    "The `coffea.jetmet_tools` package provides a convenience class [JetTransformer](https://coffea-hep.readthedocs.io/en/latest/api/coffea.jetmet_tools.JetTransformer.html#coffea.jetmet_tools.JetTransformer) which applies specified corrections and computes uncertainties in one call. First we build the desired jet correction stack to apply. This will usually be some set of the various JEC and JER correction text files that depends on the jet cone size (AK4, AK8) and the pileup mitigation algorithm, as well as the data-taking year they are associated with."
+    "The `coffea.jetmet_tools` package provides a convenience class [CorrectedJetsFactory](https://coffea-hep.readthedocs.io/en/latest/api/coffea.jetmet_tools.CorrectedJetsFactory.html#coffea.jetmet_tools.CorrectedJetsFactory) which applies specified corrections and computes uncertainties in one call. First we build the desired jet correction stack to apply. This will usually be some set of the various JEC and JER correction text files that depends on the jet cone size (AK4, AK8) and the pileup mitigation algorithm, as well as the data-taking year they are associated with."
    ]
   },
   {

--- a/binder/dataset_discovery.ipynb
+++ b/binder/dataset_discovery.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Dataset discovery tools\n",
     "\n",
-    "This is a rendered copy of [dataset_discovery.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/dataset_discovery.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fdataset_discovery.ipynb)\n",
+    "This is a rendered copy of [dataset_discovery.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/dataset_discovery.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fdataset_discovery.ipynb)\n",
     "\n",
     "This notebook shows some features to make the dataset discovery for CMS analysis easier. \n",
     "The rucio sytem is queried to look for dataset and access to the list of all available file replicas.\n",

--- a/binder/filespec.ipynb
+++ b/binder/filespec.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Dataset specification with FileSpec classes\n",
     "\n",
-    "This is a rendered copy of [filespec.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/filespec.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Ffilespec.ipynb)\n",
+    "This is a rendered copy of [filespec.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/filespec.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Ffilespec.ipynb)\n",
     "\n",
     "This notebook provides a comprehensive guide to using the new Pydantic-based FileSpec classes in Coffea's dataset tools. These classes provide type-safe, validated data structures for managing file specifications, datasets, and filesets in high-energy physics data analysis workflows.\n",
     "\n",

--- a/binder/mltools.ipynb
+++ b/binder/mltools.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Running inference tools\n",
     "\n",
-    "This is a rendered copy of [ml_tools.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/ml_tools.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fml_tools.ipynb)\n",
+    "This is a rendered copy of [mltools.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/mltools.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fmltools.ipynb)\n",
     "\n",
     "As machine learning (ML) becomes more popular in HEP analysis, `coffea` also\n",
     "provide tools to assist with using ML tools within the `coffea` framework. For\n",
@@ -48,7 +48,7 @@
     "the HEP community with a common interface to reduce the verbosity of the code on\n",
     "the analysis side.\n",
     "\n",
-    "[dask_awkward]: https://dask-awkward.readthedocs.io/en/stable/gs-limitations.html\n"
+    "[dask_awkward]: https://dask-awkward.readthedocs.io/en/stable/getting-started/limitations.html\n"
    ]
   },
   {
@@ -68,7 +68,7 @@
     "dask.\n",
     "\n",
     "[pytorch]: https://pytorch.org/\n",
-    "[pytorch_jit]: https://pytorch.org/tutorials/beginner/saving_loading_models.html#export-load-model-in-torchscript-format\n"
+    "[pytorch_jit]: https://docs.pytorch.org/docs/stable/jit.html\n"
    ]
   },
   {

--- a/binder/mltools.ipynb
+++ b/binder/mltools.ipynb
@@ -61,14 +61,14 @@
     "The example given in this notebook be using [`pytorch`][pytorch] to calculate a\n",
     "jet-level discriminant using its constituent particles. An example for how to\n",
     "construct such a `pytorch` network can be found in the docs file, but for\n",
-    "`mltools` in coffea, we only support the [TorchScript][pytorch] format files to\n",
+    "`mltools` in coffea, we only support the [TorchScript][pytorch_save_load] format files to\n",
     "load models to ensure operability when scaling to clusters. Let us first start\n",
     "by downloading the example ParticleNet model file and a small `PFNano`\n",
     "compatible file, and a simple function to open the `PFNano` with and without\n",
     "dask.\n",
     "\n",
     "[pytorch]: https://pytorch.org/\n",
-    "[pytorch_jit]: https://docs.pytorch.org/docs/stable/jit.html\n"
+    "[pytorch_save_load]: https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference\n"
    ]
   },
   {

--- a/binder/nanoevents.ipynb
+++ b/binder/nanoevents.ipynb
@@ -15,7 +15,7 @@
     "   - `PFNanoAODSchema`, which builds a double-jagged particle flow candidate colllection `events.jet.constituents` from compatible PFNanoAOD input files;\n",
     "   - `TreeMakerSchema` which is designed to read TTrees made by [TreeMaker](https://github.com/TreeMaker/TreeMaker), an alternative CMS nTuplization format;\n",
     "   - `PHYSLITESchema`, for the ATLAS DAOD_PHYSLITE derivation, a compact centrally-produced data format similar to CMS NanoAOD; and\n",
-    "   - `DelphesSchema`, for reading Delphes fast simulation [nTuples](https://delphes.github.io/).\n",
+    "   - `DelphesSchema`, for reading Delphes fast simulation [nTuples](https://delphes.github.io/workbook/root-tree-description/).\n",
     "\n",
     "We welcome contributions for new schemas, and can assist with the design of them.\n",
     "\n",

--- a/binder/nanoevents.ipynb
+++ b/binder/nanoevents.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Reading data with coffea NanoEvents\n",
     "\n",
-    "This is a rendered copy of [nanoevents.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/nanoevents.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fnanoevents.ipynb)\n",
+    "This is a rendered copy of [nanoevents.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/nanoevents.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fnanoevents.ipynb)\n",
     "\n",
     "NanoEvents is a Coffea utility to wrap flat nTuple structures (such as the CMS [NanoAOD](https://www.epj-conferences.org/articles/epjconf/pdf/2019/19/epjconf_chep2018_06021.pdf) format) into a single awkward array with appropriate object methods (such as Lorentz vector methods$^*$), cross references, and nested objects, all accessed in delayed$^\\dagger$ mode from the source ROOT TTree via uproot. The interpretation of the TTree data is configurable via [schema objects](https://coffea-hep.readthedocs.io/en/latest/modules/coffea.nanoevents.html#classes), which are community-supplied  for various source file types. These schema objects allow a richer interpretation of the file contents than the `uproot` methods. Currently available schemas include:\n",
     "\n",
@@ -15,7 +15,7 @@
     "   - `PFNanoAODSchema`, which builds a double-jagged particle flow candidate colllection `events.jet.constituents` from compatible PFNanoAOD input files;\n",
     "   - `TreeMakerSchema` which is designed to read TTrees made by [TreeMaker](https://github.com/TreeMaker/TreeMaker), an alternative CMS nTuplization format;\n",
     "   - `PHYSLITESchema`, for the ATLAS DAOD_PHYSLITE derivation, a compact centrally-produced data format similar to CMS NanoAOD; and\n",
-    "   - `DelphesSchema`, for reading Delphes fast simulation [nTuples](https://cp3.irmp.ucl.ac.be/projects/delphes/wiki/WorkBook/RootTreeDescription).\n",
+    "   - `DelphesSchema`, for reading Delphes fast simulation [nTuples](https://delphes.github.io/).\n",
     "\n",
     "We welcome contributions for new schemas, and can assist with the design of them.\n",
     "\n",
@@ -293,7 +293,7 @@
        "Numba\n",
        "*****\n",
        "\n",
-       "Arrays can be used in [Numba](http://numba.pydata.org/): they can be\n",
+       "Arrays can be used in [Numba](https://numba.pydata.org/): they can be\n",
        "passed as arguments to a Numba-compiled function or returned as return\n",
        "values. The only limitation is that Awkward Arrays cannot be *created*\n",
        "inside the Numba-compiled function; to make outputs, consider\n",
@@ -584,7 +584,7 @@
    "source": [
     "The assignment of methods classes to collections is done inside the schema object during the initial creation of the array, governed by the awkward array's `__record__` parameter and the associated behavior. See [ak.behavior](https://awkward-array.readthedocs.io/en/latest/ak.behavior.html) for a more detailed explanation of array behaviors.\n",
     "\n",
-    "Additional methods provide convenience functions for interpreting some branches, e.g. CMS NanoAOD packs several jet identification flag bits into a single integer, `jetId`. By implementing the bit-twiddling in the [Jet mixin](https://github.com/CoffeaTeam/coffea/blob/7045c06b9448d2be4315e65d432e6d8bd117d6d7/coffea/nanoevents/methods/nanoaod.py#L279-L282), the analsyis code becomes more clear:"
+    "Additional methods provide convenience functions for interpreting some branches, e.g. CMS NanoAOD packs several jet identification flag bits into a single integer, `jetId`. By implementing the bit-twiddling in the [Jet mixin](https://github.com/scikit-hep/coffea/blob/master/src/coffea/nanoevents/methods/nanoaod.py), the analysis code becomes more clear:"
    ]
   },
   {

--- a/binder/packedselection.ipynb
+++ b/binder/packedselection.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Packed Selection\n",
     "\n",
-    "This is a rendered copy of [packedselection.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/packedselection.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fpackedselection.ipynb)\n",
+    "This is a rendered copy of [packedselection.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/packedselection.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fpackedselection.ipynb)\n",
     "\n",
     "In `coffea`, `PackedSelection` is a class that can store several boolean arrays in a memory-efficient manner and evaluate arbitrary combinations of boolean requirements in an CPU-efficient way. Supported inputs include 1D numpy or awkward arrays and it has built-in functionalities to form analysis in signal and control regions, and to implement cutflow or \"N-1\" plots.\n",
     "\n",

--- a/binder/processing.ipynb
+++ b/binder/processing.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "# Processing and Scaling\n",
     "\n",
-    "This is a rendered copy of [processing.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/processing.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fprocessing.ipynb)\n",
+    "This is a rendered copy of [processing.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/processing.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fprocessing.ipynb)\n",
     "\n",
-    "Coffea relies mainly on [uproot](https://github.com/scikit-hep/uproot) to provide access to ROOT files for analysis.\n",
+    "Coffea relies mainly on [uproot](https://github.com/scikit-hep/uproot5) to provide access to ROOT files for analysis.\n",
     "As a usual analysis will involve processing tens to thousands of files, totalling gigabytes to terabytes of data, there is a certain amount of work to be done to build a parallelized framework to process the data in a reasonable amount of time. \n",
     "\n",
     "Since the beginning a `coffea.processor` module was provided to encapsulate the core functionality of the analysis, which could be run locally or distributed via a number of Executors. This allowed users to worry just about the actual analysis code and not about how to implement efficient parallelization, assuming that the parallization is a trivial map-reduce operation (e.g. filling histograms and adding them together). This API ceased to exist for some time but we brought it back.\n",

--- a/binder/systematics.ipynb
+++ b/binder/systematics.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Object systematics\n",
-    "This is a rendered copy of [systematics.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/systematics.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/coffeateam/coffea/master?filepath=binder%2Fsystematics.ipynb)\n",
+    "This is a rendered copy of [systematics.ipynb](https://github.com/scikit-hep/coffea/blob/master/binder/systematics.ipynb). You can optionally run it interactively on [binder at this link](https://mybinder.org/v2/gh/scikit-hep/coffea/master?filepath=binder%2Fsystematics.ipynb)\n",
     "\n",
     "This notebook presents how to add systematics to objects in coffea.\\\n",
     "Coffea currently implements two types of object systematics. `UpDownSystematic` which varies one field on the object it is applied on and `UpDownMultiSystematic` which varies multiple fields on the object it is applied on.\\\n",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,7 +2,7 @@
 #
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
 
@@ -89,7 +89,7 @@ def linkcode_resolve(domain, info: dict):
     except TypeError:
         # skip property or other type that inspect doesn't like
         return None
-    url = f"http://github.com/scikit-hep/coffea/blob/{githash}/src/coffea/{relpath}#L{lineno}"
+    url = f"https://github.com/scikit-hep/coffea/blob/{githash}/src/coffea/{relpath}#L{lineno}"
     return url
 
 
@@ -104,6 +104,10 @@ intersphinx_mapping = {
 }
 
 napoleon_preprocess_types = True
+
+autodoc_type_aliases = {
+    "awkward.Array": "ak.Array",
+}
 
 napoleon_type_aliases = {
     "awkward.Array": ":class:`awkward.Array <ak.Array>`",
@@ -238,6 +242,27 @@ texinfo_documents = [
         "Miscellaneous",
     ),
 ]
+
+
+def _fix_awkward_intersphinx_aliases(app):
+    """Point Awkward's legacy inventory aliases at their canonical anchors."""
+    inventories = [app.env.intersphinx_inventory]
+    inventories.extend(app.env.intersphinx_named_inventory.values())
+    for inventory in inventories:
+        for entries in inventory.values():
+            for name, (project, version, uri, display_name) in entries.items():
+                if uri.startswith("https://awkward-array.org/doc/main/"):
+                    entries[name] = (
+                        project,
+                        version,
+                        uri.replace("#awkward.", "#ak."),
+                        display_name,
+                    )
+
+
+def setup(app):
+    app.connect("builder-inited", _fix_awkward_intersphinx_aliases, priority=600)
+
 
 # Documents to append as an appendix to all manuals.
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -246,8 +246,8 @@ texinfo_documents = [
 
 def _fix_awkward_intersphinx_aliases(app):
     """Point Awkward's legacy inventory aliases at their canonical anchors."""
-    inventories = [app.env.intersphinx_inventory]
-    inventories.extend(app.env.intersphinx_named_inventory.values())
+    inventories = [getattr(app.env, "intersphinx_inventory", {})]
+    inventories.extend(getattr(app.env, "intersphinx_named_inventory", {}).values())
     for inventory in inventories:
         for entries in inventory.values():
             for name, (project, version, uri, display_name) in entries.items():

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -20,7 +20,7 @@ experience level.
    you created in the previous step.
 
 If you are new to contributing on GitHub, the
-[GitHub quickstart guide](https://docs.github.com/get-started/quickstart/set-up-git)
+[GitHub quickstart guide](https://docs.github.com/en/get-started/git-basics/set-up-git)
 walks through the basics of configuring git, forking, and cloning a project.
 
 ## Reporting issues and asking questions

--- a/docs/source/getting_started/concepts.md
+++ b/docs/source/getting_started/concepts.md
@@ -22,7 +22,7 @@ that were reconstructed in a collision event. The analysis code manipulates this
 quantities or summary statistics in the form of histograms. In contrast, columnar analysis operates on individual
 columns of data spanning a *chunk* (partition, batch) of rows using [array programming](https://en.wikipedia.org/wiki/Array_programming)
 primitives in turn, to compute derived quantities and summary statistics. Array programming is widely used within
-the [scientific python ecosystem](https://www.scipy.org/about.html), supported by the [numpy](https://numpy.org/) library.
+the [scientific python ecosystem](https://scipy.org/about/), supported by the [numpy](https://numpy.org/) library.
 However, although the existing scientific python stack is fully capable of analyzing rectangular arrays (i.e.
 no variable-length array dimensions), HEP data is very irregular, and manipulating it can become awkward without
 first generalizing array structure a bit. The [awkward](https://awkward-array.org) package does this,
@@ -91,7 +91,7 @@ You can swap between these executors by adjusting the `executor` argument passed
 Coffea supports three distributed schedulers out of the box:
 
 - {class}`~coffea.processor.DaskExecutor` integrates with a running [Dask Distributed](https://distributed.dask.org/en/latest/) cluster via a `distributed.Client`.
-- {class}`~coffea.processor.ParslExecutor` uses [Parsl](http://parsl-project.org/) to target a wide range of HPC and batch backends.
+- {class}`~coffea.processor.ParslExecutor` uses [Parsl](https://parsl-project.org/) to target a wide range of HPC and batch backends.
 - {class}`~coffea.processor.TaskVineExecutor` leverages [TaskVine](https://cctools.readthedocs.io/en/latest/taskvine/) for opportunistic and heterogeneous workers.
 
 Each executor shares the same `Runner` interface, making it easy to start locally and later connect to a remote resource manager.

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -34,9 +34,9 @@ or, in some cases, if both python 2 and 3 are available, you can find the python
 python3 --version
 ```
 
-coffea core functionality is routinely tested on Windows, Linux and MacOS.
-All [](./concepts.md#local-executors) are tested against all three platforms,
-however the [](./concepts.md#distributed-executors) are not routinely tested on Windows.
+coffea core functionality is routinely tested on Windows, Linux and macOS.
+All [local executors](./concepts.md#local-executors) are tested against all three platforms,
+however the [distributed executors](./concepts.md#distributed-executors) are not routinely tested on Windows.
 
 Coffea starts from v0.5.0 in the PyPI repository since before v0.5.0 it was hosted as [fnal-column-analysis-tools](https://pypi.org/project/fnal-column-analysis-tools/). If you are still using fnal-column-analysis-tools, please move to [coffea](https://pypi.org/project/coffea/)!
 
@@ -48,7 +48,7 @@ To install coffea, there are several mostly-equivalent options:
    - if you do not have administrator permissions, install as local user with `pip install --user coffea`;
    - if you prefer to not place coffea in your global environment, you can set up a `Virtual environment`;
    - if you use [Conda](https://docs.conda.io/projects/conda/en/latest/index.html), simply `conda install coffea`;
-   - or, if you like to use containers, see [](#pre-build-images) below.
+   - or, if you like to use containers, see [pre-built images](#pre-built-images) below.
 
 To update a previously installed coffea to a newer version, use: `pip install --upgrade coffea`
 Although not required, it is recommended to also [install Jupyter](https://jupyter.org/install), as it provides a more interactive development environment.
@@ -59,7 +59,7 @@ In rare cases, you may find that the `pip` executable in your path does not corr
 ## Install optional dependencies
 
 Coffea supports several optional components that require additional package installations.
-In particular, all of the [](./concepts.md#distributed-executors) require additional packages.
+In particular, all of the [distributed executors](./concepts.md#distributed-executors) require additional packages.
 The necessary dependencies can be installed easily via ``pip`` using the setuptools [extras](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) facility:
 
    - [parsl](http://parsl-project.org/) distributed executor: ``pip install coffea[parsl]``
@@ -80,7 +80,7 @@ source my_env/bin/activate
 pip install coffea
 ```
 
-(pre-build-images)=
+(pre-built-images)=
 ## Pre-built images
 
 Official Docker images are maintained at the [CoffeaTeam/af-images](https://github.com/CoffeaTeam/af-images) repository and available on DockerHub.
@@ -164,7 +164,7 @@ ls /cvmfs/unpacked.cern.ch/registry.hub.docker.com/coffeateam/
 ## Install via cvmfs
 
 Although the local installation can work anywhere, if the base environment does not already have most of the coffea dependencies, then the user-local package directory can become quite bloated.
-An option to avoid this bloat is to use a base python environment provided via [CERN LCG](https://ep-dep-sft.web.cern.ch/document/lcg-releases), which is available on any system that has the [cvmfs](https://cernvm.cern.ch/portal/filesystem) directory `/cvmfs/sft.cern.ch/` mounted.
+An option to avoid this bloat is to use a base Python environment provided via [CERN LCG](https://ep-dep-sft.web.cern.ch/document/lcg-releases), which is available on any system that has the [cvmfs](https://cernvm.cern.ch/portal/filesystem) directory `/cvmfs/sft.cern.ch/` mounted.
 Simply source a LCG release (shown here: 98python3) and install:
 
 ```bash
@@ -179,10 +179,10 @@ This method can be fragile, since the LCG-distributed packages may conflict with
 
 In some instances, it may be useful to have a self-contained environment that can be relocated.
 One use case is for users of coffea that do not have access to a distributed compute cluster that is compatible with
-one of the coffea [](./concepts.md#distributed-executors). Here, a fallback solution can be found by creating traditional batch jobs (e.g. condor)
-which then use coffea [](./concepts.md#local-executors), possibly multi-threaded. In this case, often the user-local python package directory
+one of the coffea [distributed executors](./concepts.md#distributed-executors). Here, a fallback solution can be found by creating traditional batch jobs (e.g. HTCondor)
+which then use coffea [local executors](./concepts.md#local-executors), possibly multi-threaded. In this case, often the user-local Python package directory
 is not available from batch workers, so a portable python environment needs to be created.
-Annoyingly, python virtual environments are not portable by default due to several hardcoded paths in specific locations, however
+Annoyingly, Python virtual environments are not portable by default due to several hardcoded paths in specific locations, however
 there are two workarounds presented below. In both cases, we make a virtual environment that starts from a non-system base
 python environment to lower the amount of needed installations in the virtual environment. One can always start a venv from scratch,
 but the number of coffea dependencies makes the installation rather large, up to a few hundred MB.
@@ -190,7 +190,7 @@ but the number of coffea dependencies makes the installation rather large, up to
 
 ### Container-based
 
-If we start from one of the singularity containers from the [](#pre-build-images) section, we don't have to install nearly as much
+If we start from one of the Singularity containers from the [pre-built images](#pre-built-images) section, we don't have to install nearly as much
 software in our virtual environment, letting the container image take care of the majority of the codebase. For example, the following
 code starts from the `coffea-dask-almalinux8` image and adds a special python module that is not included in the base image:
 
@@ -203,7 +203,7 @@ python -m pip install --ignore-installed h5py
 ```
 
 This creates a virtual environment `myenv` and a directory with the same name where the extra python module `h5py` will be
-installed. At this point, the terminal prompt will look like `(myenv) Singularity>`, indicating you are inside a singularity
+installed. At this point, the terminal prompt will look like `(myenv) Singularity>`, indicating you are inside a Singularity
 image and have `myenv` activated. Next time you log in, only lines 1, 2, and 4 need to be re-executed.
 
 If using HTCondor for job submission, you can create a tarball of the virtual environment directory and then submit condor

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -60,9 +60,9 @@ In rare cases, you may find that the `pip` executable in your path does not corr
 
 Coffea supports several optional components that require additional package installations.
 In particular, all of the [distributed executors](./concepts.md#distributed-executors) require additional packages.
-The necessary dependencies can be installed easily via ``pip`` using the setuptools [extras](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies) facility:
+The necessary dependencies can be installed easily via ``pip`` using the setuptools [optional dependencies](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) facility:
 
-   - [parsl](http://parsl-project.org/) distributed executor: ``pip install coffea[parsl]``
+   - [parsl](https://parsl-project.org/) distributed executor: ``pip install coffea[parsl]``
    - [dask](https://distributed.dask.org/en/latest/) distributed executor: ``pip install coffea[dask]``
    - [dask-awkward](https://dask-awkward.readthedocs.io/en/stable/) and [dask-histogram](https://dask-histogram.readthedocs.io/en/stable/) support: ``pip install coffea[dask-awkward]``
    - [TaskVine](https://ccl.cse.nd.edu/software/taskvine/) distributed executor: see the installation guide in their docs and use the `TaskVineExecutor` in coffea.
@@ -164,7 +164,7 @@ ls /cvmfs/unpacked.cern.ch/registry.hub.docker.com/coffeateam/
 ## Install via cvmfs
 
 Although the local installation can work anywhere, if the base environment does not already have most of the coffea dependencies, then the user-local package directory can become quite bloated.
-An option to avoid this bloat is to use a base Python environment provided via [CERN LCG](https://ep-dep-sft.web.cern.ch/document/lcg-releases), which is available on any system that has the [cvmfs](https://cernvm.cern.ch/portal/filesystem) directory `/cvmfs/sft.cern.ch/` mounted.
+An option to avoid this bloat is to use a base Python environment provided via [CERN LCG](https://lcginfo.cern.ch/), which is available on any system that has the [CVMFS](https://cvmfs.readthedocs.io/en/stable/) directory `/cvmfs/sft.cern.ch/` mounted.
 Simply source a LCG release (shown here: 98python3) and install:
 
 ```bash
@@ -207,7 +207,7 @@ installed. At this point, the terminal prompt will look like `(myenv) Singularit
 image and have `myenv` activated. Next time you log in, only lines 1, 2, and 4 need to be re-executed.
 
 If using HTCondor for job submission, you can create a tarball of the virtual environment directory and then submit condor
-jobs using the `+SingularityImage` [HTCondor option](https://htcondor.readthedocs.io/en/latest/admin-manual/singularity-support.html).
+jobs using the `+SingularityImage` [HTCondor option](https://htcondor.readthedocs.io/en/latest/admin-manual/ep-policy-configuration.html#container-vm-support-docker-apptainer-singularity-and-xen-vmware).
 Note that this option is not enabled by default in HTCondor installations, so you may need to talk to your site administrator to be
 able to use this option. You will also need to create a small wrapper script to re-source the environment to have the job use the
 same environment as your interactive container.
@@ -226,7 +226,7 @@ NAME=coffeaenv
 LCG=/cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc9-opt
 
 source $LCG/setup.sh
-# following https://aarongorka.com/blog/portable-virtualenv/, an alternative is https://github.com/pantsbuild/pex
+# following https://aarongorka.com/blog/portable-virtualenv/, an alternative is https://github.com/pex-tool/pex
 python -m venv --copies $NAME
 source $NAME/bin/activate
 LOCALPATH=$NAME$(python -c 'import sys; print(f"/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages")')

--- a/docs/source/user_guide/executors.md
+++ b/docs/source/user_guide/executors.md
@@ -16,7 +16,7 @@ Each executor implements the same interface and is consumed by {class}`coffea.pr
 - `IterativeExecutor`: the simplest option for debugging and unit tests; executes chunks in one thread.
 - `FuturesExecutor`: uses `concurrent.futures` pools to fan out work across local CPU cores.
 - `DaskExecutor`: connects to a [Dask Distributed](https://distributed.dask.org/en/latest/) cluster for interactive or batch workloads.
-- `ParslExecutor`: targets HPC facilities via [Parsl](http://parsl-project.org/).
+- `ParslExecutor`: targets HPC facilities via [Parsl](https://parsl-project.org/).
 - `TaskVineExecutor`: dispatches work to opportunistic and heterogeneous resources managed by [TaskVine](https://cctools.readthedocs.io/en/latest/taskvine/).
 
 All executors accept the same arguments when invoked by {class}`~coffea.processor.Runner`, making it easy to prototype locally and scale out later. The snippets below assume that `fileset` and `my_processor`

--- a/src/coffea/analysis_tools.py
+++ b/src/coffea/analysis_tools.py
@@ -441,7 +441,7 @@ class Weights:
                 name of correction
             weight : numpy.ndarray
                 the nominal event weight associated with the correction
-            modifierNames: list of str
+            modifierNames : list of str
                 list of modifiers for each set of weights variation
             weightsUp : list of numpy.ndarray
                 weight with correction uncertainty shifted up (if available)
@@ -1306,7 +1306,7 @@ class NminusOne:
             weighted : bool, optional
                 Whether to fill the histograms with weights. Default is None, which applies the weights
                 if the nminusone was instantiated with weights and unweighted distributions otherwise.
-            scale: float, optional
+            scale : float, optional
                 A scalar value by which all weights will be scaled, works with both weighted and unweighted methods.
             categorical : dict, optional
                 A dictionary with the following keys:
@@ -1514,7 +1514,7 @@ class Cutflow:
                 maskscutflow : list of boolean numpy.ndarray or dask_awkward.lib.core.Array objects
                     The boolean mask vectors of which events pass the cumulative cutflow a list of materialized or delayed boolean arrays
 
-            result: ExtendedCutflowResult
+            result : ExtendedCutflowResult
                 A namedtuple with the CutflowResult properties and additionally the following:
 
                 commonmask : boolean numpy.ndarray or dask_awkward.lib.core.Array object, or None if no common mask was provided
@@ -1724,7 +1724,7 @@ class Cutflow:
             weighted : bool, optional
                 Whether to fill the histograms with weights. Default is None, which applies the weights
                 if the cutflow was instantiated with weights and unweighted statistics otherwise.
-            scale: float, optional
+            scale : float, optional
                 A scalar value by which all weights will be scaled, works with both weighted and unweighted methods.
             categorical : dict, optional
                 A dictionary with the following keys:
@@ -1943,7 +1943,7 @@ class Cutflow:
             weighted : bool, optional
                 Whether to fill the histograms with weights. Default is None, which applies the weights
                 if the cutflow was instantiated with weights and unweighted distributions otherwise.
-            scale: float, optional
+            scale : float, optional
                 A scalar value by which all weights will be scaled, works with both weighted and unweighted methods.
             categorical : dict, optional
                 A dictionary with the following keys:

--- a/src/coffea/dataset_tools/apply_processor.py
+++ b/src/coffea/dataset_tools/apply_processor.py
@@ -42,7 +42,7 @@ def apply_to_dataset(
     ----------
         data_manipulation : ProcessorABC or GenericHEPAnalysis
             The user analysis code to run on the input dataset
-        dataset: DatasetSpec | dict
+        dataset : DatasetSpec | dict
             The data to be acted upon by the data manipulation passed in.
         schemaclass : BaseSchema, default NanoAODSchema
             The nanoevents schema to interpret the input dataset with.
@@ -101,7 +101,7 @@ def apply_to_fileset(
     ----------
         data_manipulation : ProcessorABC or GenericHEPAnalysis
             The user analysis code to run on the input dataset
-        fileset: DataGroupSpec | dict
+        fileset : DataGroupSpec | dict
             The data to be acted upon by the data manipulation passed in. Metadata within the fileset should be dask-serializable.
         schemaclass : BaseSchema, default NanoAODSchema
             The nanoevents schema to interpret the input dataset with.

--- a/src/coffea/dataset_tools/manipulations.py
+++ b/src/coffea/dataset_tools/manipulations.py
@@ -255,7 +255,7 @@ def filter_files(
     ----------
         fileset : DataGroupSpec
             The set of datasets to be sliced.
-        thefilter: Callable[[tuple[str, CoffeaROOTFileSpec | CoffeaParquetFileSpec] | InputFiles | PreprocessedFiles], bool], default filters empty files
+        thefilter : Callable[[tuple[str, CoffeaROOTFileSpec | CoffeaParquetFileSpec] | InputFiles | PreprocessedFiles], bool], default filters empty files
             How to filter the files in the each dataset.
 
     Returns
@@ -283,7 +283,7 @@ def get_failed_steps_for_dataset(
 
     Parameters
     ----------
-        dataset: DatasetSpec | dict
+        dataset : DatasetSpec | dict
             The dataset to be reduced to only contain files and row-ranges that have previously encountered failed file access.
         report : awkward.Array
             The computed file-access error report from dask-awkward.

--- a/src/coffea/dataset_tools/rucio_utils.py
+++ b/src/coffea/dataset_tools/rucio_utils.py
@@ -22,7 +22,7 @@ def get_proxy_path() -> str:
         subprocess.run("voms-proxy-info -exists -hours 1", shell=True, check=True)
     except subprocess.CalledProcessError:
         raise Exception(
-            "VOMS proxy expirend or non-existing: please run `voms-proxy-init -voms cms -rfc --valid 168:0`"
+            "VOMS proxy expired or nonexistent: please run `voms-proxy-init -voms cms -rfc --valid 168:0`"
         )
 
     # Now get the path of the certificate

--- a/src/coffea/lumi_tools/lumi_tools.py
+++ b/src/coffea/lumi_tools/lumi_tools.py
@@ -61,7 +61,7 @@ class LumiData:
     ----------
         lumi_csv : str
             The path to the luminosity csv file to read from. Generally, this is the output file from brilcalc.
-        is_inst_lumi: bool, default False
+        is_inst_lumi : bool, default False
             If True, treats the values read in from ``lumi_csv`` as average instantaneous luminosities, instead of integrated luminosities.
 
     The values are extracted from the csv output as returned by brilcalc_, e.g. with a command such as::
@@ -349,7 +349,7 @@ class LumiList:
             Vectorized list of run numbers
         lumis : numpy.ndarray, dask_awkward.Array
             Vectorized list of lumiSection values
-        delayed: bool
+        delayed : bool
             Is this LumiList in delayed mode or not.
     """
 

--- a/src/coffea/ml_tools/torch_wrapper.py
+++ b/src/coffea/ml_tools/torch_wrapper.py
@@ -37,7 +37,7 @@ class torch_wrapper(nonserializable_attribute, numpy_call_wrapper):
     converted via a to_awkward().to_numpy() call.
 
     [1]
-    https://docs.pytorch.org/docs/stable/jit.html
+    https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference
 
     Parameters
     ----------

--- a/src/coffea/ml_tools/torch_wrapper.py
+++ b/src/coffea/ml_tools/torch_wrapper.py
@@ -37,7 +37,7 @@ class torch_wrapper(nonserializable_attribute, numpy_call_wrapper):
     converted via a to_awkward().to_numpy() call.
 
     [1]
-    https://pytorch.org/tutorials/beginner/saving_loading_models.html#export-load-model-in-torchscript-format
+    https://docs.pytorch.org/docs/stable/jit.html
 
     Parameters
     ----------

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -307,7 +307,7 @@ class NanoEventsFactory:
                 https://uproot.readthedocs.io/en/latest/uproot._dask.dask.html.
             interpretation_executor : Any, optional
                 Executor with a ``submit`` method used for interpretation tasks. See
-                https://github.com/scikit-hep/uproot5/blob/main/src/uproot/_dask.py#L113.
+                https://uproot.readthedocs.io/en/latest/uproot._dask.dask.html.
 
         Returns
         -------

--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -270,7 +270,7 @@ class NanoEventsFactory:
             file : a string or dict input to ``uproot.open()`` or ``uproot.dask()`` or a ``uproot.reading.ReadOnlyDirectory``
                 The filename or dict of filenames including the treepath (as it would be passed directly to ``uproot.open()``
                 or ``uproot.dask()``) already opened file using e.g. ``uproot.open()``.
-            mode:
+            mode : str
                 Nanoevents will use "eager", "virtual", or "dask" as a backend.
             treepath : str, optional
                 Name of the tree to read in the file. Used only if ``file`` is a ``uproot.reading.ReadOnlyDirectory``
@@ -279,9 +279,9 @@ class NanoEventsFactory:
                 Start at this entry offset in the tree (default 0)
             entry_stop : int, optional (eager and virtual mode only)
                 Stop at this entry offset in the tree (default end of tree)
-            steps_per_file: int, optional
+            steps_per_file : int, optional
                 Partition files into this many steps (previously "chunks")
-            preload (None, Callable, or Iterable[str]):
+            preload : Callable or Iterable[str] or None
                 Specifies which branches/columns to preload in bulk. Only works in eager and virtual mode.
                 Can be a callable passed to ``tree.arrays`` as the ``filter_branch`` argument,
                 or an iterable of branch name strings to preload.
@@ -709,7 +709,7 @@ class NanoEventsFactory:
                 A schema class deriving from `BaseSchema` and implementing the desired view of the file
             metadata : dict
                 Arbitrary metadata to add to the `base.NanoEvents` object
-            mode:
+            mode : str
                 Nanoevents will use "eager", "virtual", or "dask" as a backend.
 
         """

--- a/src/coffea/nanoevents/mapping/buffer_cache.py
+++ b/src/coffea/nanoevents/mapping/buffer_cache.py
@@ -124,20 +124,20 @@ def BufferCache(
     Buffer caches give you more fine-grained control over internal
     memory management of an awkward Array (here: NanoEvents). One powerful
     feature is for example to compress the buffers in-memory to reduce
-    the total memory footprint. Buffers are decompressed upon use (`__getitem__`)
-    and compressed upon `__setitem__`. In a scenario where you have many buffers in
+    the total memory footprint. Buffers are decompressed upon use (``__getitem__``)
+    and compressed upon ``__setitem__``. In a scenario where you have many buffers in
     an awkward Array this can be highly beneficial because most arrays are then
     compressed in RAM, while only a few at a time will be decompressed for a specific
     operation.
 
     Example (in-memory no compression)
-    -------
+    ----------------------------------
     >>> buffer_cache=BufferCache(cache=None, codec=None) # or `NoCompressionCodec()`
     >>> NanoEventsFactory.from_root(..., buffer_cache=buffer_cache)
 
 
     Example (in-memory compressed)
-    -------
+    ------------------------------
     >>> from numcodecs import Blosc
     >>> codec = Blosc("zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
     >>> buffer_cache=BufferCache(cache=None, codec=codec)
@@ -145,7 +145,7 @@ def BufferCache(
 
 
     Example (LRU-backed compressed in-memory)
-    -------
+    -----------------------------------------
     >>> from numcodecs import Blosc
     >>> import zict
     >>> codec = Blosc("zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
@@ -162,7 +162,7 @@ def BufferCache(
     A simple on-disk buffer cache example is as follows:
 
     Example (on-disk compressed)
-    -------
+    ----------------------------
     >>> from numcodecs import Blosc
     >>> import zict
     >>> codec = Blosc("zstd", clevel=1, shuffle=Blosc.BITSHUFFLE)
@@ -171,14 +171,14 @@ def BufferCache(
 
     .. caution::
 
-        The comes with some caveats though:
+        This comes with some caveats though:
 
         1. The directory for the on-disk cache should be chosen to be as close as possible
-        to the CPU. That means that NFS backed paths (e.g. `/afs/` or `/eos/` at CERN) are
-        highly disouraged for this cache. A better choice would be `/tmp/...` on the worker.
+        to the CPU. That means that NFS-backed paths (e.g. ``/afs/`` or ``/eos/`` at CERN) are
+        highly discouraged for this cache. A better choice would be ``/tmp/...`` on the worker.
 
-        2. It's probably good to cleanup this cache once it isn't needed anymore. For dask usage
-        with the coffea Executors one can use the `cachestrategy` argument of the Executor class
+        2. It's probably good to clean up this cache once it isn't needed anymore. For dask usage
+        with the coffea Executors one can use the ``cachestrategy`` argument of the Executor class
         to make sure the on-disk cache is created in the local temp directory of the dask worker itself.
         (see: https://distributed.dask.org/en/stable/worker.html#api-documentation)
 
@@ -186,7 +186,7 @@ def BufferCache(
     ## Other examples
 
     Example (hierarchical)
-    -------
+    ----------------------
     >>> import zict
     >>> cache = zict.Buffer(
     >>>     fast={},

--- a/src/coffea/nanoevents/methods/candidate.py
+++ b/src/coffea/nanoevents/methods/candidate.py
@@ -63,7 +63,7 @@ class Candidate(vector.LorentzVector):
 class PtEtaPhiMCandidate(Candidate, vector.PtEtaPhiMLorentzVector):
     """A Lorentz vector in eta, mass coordinates with charge
 
-    This mixin class requires the parent class to provide items ``pt``, ``eta``, ``phi``, `mass`, and ``charge``.
+    This mixin class requires the parent class to provide items ``pt``, ``eta``, ``phi``, ``mass``, and ``charge``.
     """
 
     pass

--- a/src/coffea/nanoevents/methods/delphes.py
+++ b/src/coffea/nanoevents/methods/delphes.py
@@ -1,6 +1,6 @@
 """Mixins for the Delphes schema
 
-See https://cp3.irmp.ucl.ac.be/projects/delphes/wiki/WorkBook/RootTreeDescription for details.
+See https://delphes.github.io/ for details.
 """
 
 import awkward

--- a/src/coffea/nanoevents/methods/delphes.py
+++ b/src/coffea/nanoevents/methods/delphes.py
@@ -1,6 +1,6 @@
 """Mixins for the Delphes schema
 
-See https://delphes.github.io/ for details.
+See https://delphes.github.io/workbook/root-tree-description/ for details.
 """
 
 import awkward

--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -404,7 +404,7 @@ class LorentzVector(MomentumAwkward4D):
     def absolute(self):
         """Magnitude of this Lorentz vector
 
-        Alias for `mass`
+        Alias for ``mass``
         """
         return self.mass
 
@@ -580,7 +580,7 @@ class LorentzVector(MomentumAwkward4D):
 class PtEtaPhiMLorentzVector(LorentzVector):
     """A Lorentz vector using pseudorapidity and mass
 
-    This mixin class requires the parent class to provide items ``pt``, ``eta``, ``phi``, and `mass`.
+    This mixin class requires the parent class to provide items ``pt``, ``eta``, ``phi``, and ``mass``.
     Some additional properties are overridden for performance
     """
 
@@ -588,7 +588,7 @@ class PtEtaPhiMLorentzVector(LorentzVector):
     def multiply(self, other):
         """Multiply this vector by a scalar elementwise using ``x``, ``y``, ``z``, and ``t`` components
 
-        In reality, this directly adjusts ``pt``, ``eta``, ``phi`` and `mass` for performance
+        In reality, this directly adjusts ``pt``, ``eta``, ``phi`` and ``mass`` for performance
         """
         absother = abs(other)
         return awkward.zip(

--- a/src/coffea/nanoevents/schemas/auto.py
+++ b/src/coffea/nanoevents/schemas/auto.py
@@ -46,7 +46,7 @@ class auto_schema(BaseSchema):
             - There is a recursiveness to this definition, as there is to any data structure,
               that is not matched with this. This should be made much more flexible. Perhaps
               with something like python type-hints so editors can also take advantage of this.
-            - Any `_` is inerpreted as going down a level in the structure.
+            - Any ``_`` is interpreted as going down a level in the structure.
 
         Args:
             base_form (Dict[str, Any]): The base form of what we are going to generate a new schema (form) for.

--- a/src/coffea/nanoevents/schemas/physlite.py
+++ b/src/coffea/nanoevents/schemas/physlite.py
@@ -12,7 +12,7 @@ class PHYSLITESchema(BaseSchema):
 
     This is a schema for the `ATLAS DAOD_PHYSLITE derivation
     <https://gitlab.cern.ch/atlas/athena/-/blob/release/21.2.108.0/PhysicsAnalysis/DerivationFramework/DerivationFrameworkPhys/share/PHYSLITE.py>`_.
-    Closely following `schemas.nanoaod.NanoAODSchema`, it is mainly build from
+    Closely following ``schemas.nanoaod.NanoAODSchema``, it is mainly built from
     naming patterns where the "Analysis" prefix has been removed, so the
     collections will be named Electrons, Muons, instead of AnalysisElectrons,
     AnalysisMunos, etc. The collection fields correspond to the "Aux" and
@@ -21,7 +21,7 @@ class PHYSLITESchema(BaseSchema):
     Collections are assigned mixin types according to the `mixins` mapping.
     All collections are then zipped into one `base.NanoEvents` record and returned.
 
-    Cross references are build from ElementLink columns. Global indices are
+    Cross references are built from ElementLink columns. Global indices are
     created dynamically, using an ``_eventindex`` field that is attached to
     each collection.
     """

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -833,7 +833,7 @@ class DaskExecutor(ExecutorBase):
 
         if self.heavy_input is not None:
             # client.scatter is not robust against adaptive clusters
-            # https://github.com/CoffeaTeam/coffea/issues/465
+            # https://github.com/scikit-hep/coffea/issues/465
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", "Large object of size")
                 items = list(

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -778,7 +778,7 @@ class DaskExecutor(ExecutorBase):
             items in a tuple (item, heavy_input) that is passed to function.
         function_name : str, optional
             Name of the function being passed
-        use_dataframes: bool, optional
+        use_dataframes : bool, optional
             Retrieve output as a distributed Dask DataFrame (default: False).
             The outputs of individual tasks must be Pandas DataFrames.
 

--- a/src/coffea/util.py
+++ b/src/coffea/util.py
@@ -231,7 +231,7 @@ class SpeedColumn(ProgressColumn):
 
 coffea_console = Console()
 coffea_console.__doc__ += """
-\nA `rich.console.Console` for coffea. Used through-out coffea for consistent logging and
+\nA `rich.console.Console` for coffea. Used throughout coffea for consistent logging and
 progress bars. May be used by users for their own logging. Using the same console
 ensures that output is nicely integrated with coffea's progress bars.
 """


### PR DESCRIPTION
I noticed that there are multiple places in the docs where there are typos that cause the docs to be rendered weirdly. For example, look at the `preload` parameter [here](https://coffea-hep.readthedocs.io/en/latest/api/coffea.nanoevents.NanoEventsFactory.html#coffea.nanoevents.NanoEventsFactory.from_root).

I used Codex to go through it and fix typos and links. But I still need to go through the changes to make sure that they are correct (especially for links). I'll mark it as ready for review when I'm done.