### PR TITLE
fix: send tensors to GPU if using it in `torch_wrapper`

### DIFF
--- a/src/coffea/ml_tools/torch_wrapper.py
+++ b/src/coffea/ml_tools/torch_wrapper.py
@@ -126,5 +126,10 @@ class torch_wrapper(nonserializable_attribute, numpy_call_wrapper):
             )
             for key, arr in kwargs.items()
         }
+
+        if self.device.type == "cuda":
+            args = [arr.cuda() for arr in args]
+            kwargs = {key: arr.cuda() for key, arr in kwargs.items()}
+
         with torch.no_grad():
             return self.model(*args, **kwargs).detach().numpy()


### PR DESCRIPTION
This PR addresses issue #1568 

Currently, the `torch_wrapper` class in `ml_tools` initializes Torch models on the GPU when loading them, but doesn't send input tensors there at inference time (see the issue). This PR simply sends the tensors to the GPU if the current device type is `"cuda"`.

Opening as a draft initially, until I fully test everything :)