### PR TITLE
fix: new location of the vendored `array_api_extra` from scipy in version 1.18

### DIFF
--- a/src/coffea/lookup_tools/doublecrystalball.py
+++ b/src/coffea/lookup_tools/doublecrystalball.py
@@ -2,7 +2,10 @@ import numpy as np
 
 _old_style_where = False
 try:
-    from scipy._lib.array_api_extra import apply_where
+    try:
+        from scipy._lib.array_api_extra import apply_where
+    except ImportError as _:
+        from scipy._external.array_api_extra import apply_where
     from scipy.stats._continuous_distns import (
         _norm_cdf,
         _norm_pdf_C,


### PR DESCRIPTION
Related to https://github.com/scikit-hep/coffea/issues/1355
Scipy moved the vendored array api extra under `_external` in v1.18