### PR TITLE
feat: Pydantic RNTuple extension and Iterative/FuturesBackends

### DIFF
--- a/binder/filespec.ipynb
+++ b/binder/filespec.ipynb
@@ -15,7 +15,8 @@
     "\n",
     "The FileSpec system provides:\n",
     "- **Type-safe data structures** with automatic validation\n",
-    "- **Automatic format detection** for ROOT and Parquet files\n",
+    "- **Automatic format detection** for ROOT (TTree and RNTuple) and Parquet files\n",
+    "- **Switchable execution backends** (`dask`, `iterative`, `futures`) for preprocessing\n",
     "- **Seamless integration** with existing Coffea functions\n",
     "- **JSON serialization/deserialization** for data persistence\n",
     "- **Automatic promotion** between optional and concrete specifications\n",
@@ -69,6 +70,9 @@
     "    \n",
     "    # Dataset manipulation functions\n",
     "    preprocess,\n",
+    "    preprocess_parquet,\n",
+    "    preprocess_rntuple,\n",
+    "    FuturesBackend,\n",
     "    apply_to_fileset,\n",
     "    max_chunks,\n",
     "    max_chunks_per_file,\n",
@@ -2331,6 +2335,258 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c6525825",
+   "metadata": {},
+   "source": [
+    "### 5.2 Switchable execution backends\n",
+    "\n",
+    "`preprocess` (and the format-specific `preprocess_root` / `preprocess_rntuple` / `preprocess_parquet`) accept a `backend=` argument that selects how the per-file work is executed:\n",
+    "\n",
+    "- `\"dask\"` (default): builds a dask-awkward task graph, which scales out to a cluster via the `scheduler` argument.\n",
+    "- `\"iterative\"`: immediate, synchronous, single-process execution. **No dask required.**\n",
+    "- `\"futures\"`: a `concurrent.futures` pool — threads by default (preprocessing is I/O-bound). Pass a `FuturesBackend(workers=N)` or `FuturesBackend(use_processes=True)` instance for finer control. **No dask required.**\n",
+    "\n",
+    "The dask-free backends produce results identical to the dask backend for both ROOT and Parquet inputs. TTree/RNTuple form extraction uses uproot's own (non-dask) form builder, so `save_form=True` also works without dask."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "2e8b6aa5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "iterative and futures backends agree: True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">{</span>\n",
+       "    <span style=\"color: #008000; text-decoration-color: #008000\">'ZJets'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'files'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "            <span style=\"color: #008000; text-decoration-color: #008000\">'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.root'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'steps'</span>: <span style=\"font-weight: bold\">[[</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">20</span><span style=\"font-weight: bold\">]</span>, <span style=\"font-weight: bold\">[</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">20</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span><span style=\"font-weight: bold\">]]</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'root'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'lfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'pfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'uuid'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'a9490124-3648-11ea-89e9-f5b55c90beef'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_selected_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>\n",
+       "            <span style=\"font-weight: bold\">}</span>\n",
+       "        <span style=\"font-weight: bold\">}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'metadata'</span>: <span style=\"font-weight: bold\">{}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'root'</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'did'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
+       "    <span style=\"font-weight: bold\">}</span>\n",
+       "<span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m{\u001b[0m\n",
+       "    \u001b[32m'ZJets'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "        \u001b[32m'files'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "            \u001b[32m'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.root'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "                \u001b[32m'object_path'\u001b[0m: \u001b[32m'Events'\u001b[0m,\n",
+       "                \u001b[32m'steps'\u001b[0m: \u001b[1m[\u001b[0m\u001b[1m[\u001b[0m\u001b[1;36m0\u001b[0m, \u001b[1;36m20\u001b[0m\u001b[1m]\u001b[0m, \u001b[1m[\u001b[0m\u001b[1;36m20\u001b[0m, \u001b[1;36m40\u001b[0m\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m,\n",
+       "                \u001b[32m'num_entries'\u001b[0m: \u001b[1;36m40\u001b[0m,\n",
+       "                \u001b[32m'format'\u001b[0m: \u001b[32m'root'\u001b[0m,\n",
+       "                \u001b[32m'lfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'pfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'uuid'\u001b[0m: \u001b[32m'a9490124-3648-11ea-89e9-f5b55c90beef'\u001b[0m,\n",
+       "                \u001b[32m'num_selected_entries'\u001b[0m: \u001b[1;36m40\u001b[0m\n",
+       "            \u001b[1m}\u001b[0m\n",
+       "        \u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'metadata'\u001b[0m: \u001b[1m{\u001b[0m\u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'format'\u001b[0m: \u001b[32m'root'\u001b[0m,\n",
+       "        \u001b[32m'did'\u001b[0m: \u001b[3;35mNone\u001b[0m\n",
+       "    \u001b[1m}\u001b[0m\n",
+       "\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 5.2 The same preprocessing, run with different backends\n",
+    "root_fileset = DataGroupSpec({\n",
+    "    \"ZJets\": {\"files\": [\"https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.root:Events\"]},\n",
+    "})\n",
+    "\n",
+    "available_iterative, _ = preprocess(root_fileset, step_size=20, save_form=True, backend=\"iterative\")\n",
+    "available_futures, _ = preprocess(root_fileset, step_size=20, save_form=True, backend=FuturesBackend(workers=2))\n",
+    "\n",
+    "print(\"iterative and futures backends agree:\", available_iterative == available_futures)\n",
+    "rich.print({k: v.model_dump(exclude=\"compressed_form\") for k, v in available_iterative.items()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2071c3f",
+   "metadata": {},
+   "source": [
+    "### 5.3 Preprocessing Parquet datasets\n",
+    "\n",
+    "The file format is detected automatically from the filename, so `preprocess` handles Parquet datasets transparently; `preprocess_parquet` is the format-specific entry point. Unlike ROOT, Parquet files do not take an `object_path`, and steps can optionally follow the Parquet row groups with `use_row_groups=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "a60ff4e0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Detected format: parquet\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">{</span>\n",
+       "    <span style=\"color: #008000; text-decoration-color: #008000\">'ZJets'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'files'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "            <span style=\"color: #008000; text-decoration-color: #008000\">'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.parquet'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'steps'</span>: <span style=\"font-weight: bold\">[[</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span><span style=\"font-weight: bold\">]]</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'parquet'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'lfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'pfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'uuid'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'24be1d49dc0e1cc4ae4a0ee765e3d17c27662d075bf923aeaade5fbec7e29fca'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_selected_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>\n",
+       "            <span style=\"font-weight: bold\">}</span>\n",
+       "        <span style=\"font-weight: bold\">}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'metadata'</span>: <span style=\"font-weight: bold\">{}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'parquet'</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'did'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
+       "    <span style=\"font-weight: bold\">}</span>\n",
+       "<span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m{\u001b[0m\n",
+       "    \u001b[32m'ZJets'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "        \u001b[32m'files'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "            \u001b[32m'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.parquet'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "                \u001b[32m'object_path'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'steps'\u001b[0m: \u001b[1m[\u001b[0m\u001b[1m[\u001b[0m\u001b[1;36m0\u001b[0m, \u001b[1;36m40\u001b[0m\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m,\n",
+       "                \u001b[32m'num_entries'\u001b[0m: \u001b[1;36m40\u001b[0m,\n",
+       "                \u001b[32m'format'\u001b[0m: \u001b[32m'parquet'\u001b[0m,\n",
+       "                \u001b[32m'lfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'pfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'uuid'\u001b[0m: \u001b[32m'24be1d49dc0e1cc4ae4a0ee765e3d17c27662d075bf923aeaade5fbec7e29fca'\u001b[0m,\n",
+       "                \u001b[32m'num_selected_entries'\u001b[0m: \u001b[1;36m40\u001b[0m\n",
+       "            \u001b[1m}\u001b[0m\n",
+       "        \u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'metadata'\u001b[0m: \u001b[1m{\u001b[0m\u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'format'\u001b[0m: \u001b[32m'parquet'\u001b[0m,\n",
+       "        \u001b[32m'did'\u001b[0m: \u001b[3;35mNone\u001b[0m\n",
+       "    \u001b[1m}\u001b[0m\n",
+       "\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 5.3 Preprocessing a Parquet dataset (note: parquet files have no object_path)\n",
+    "parquet_fileset = DataGroupSpec({\n",
+    "    \"ZJets\": {\"files\": [\"https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy.parquet\"]},\n",
+    "})\n",
+    "\n",
+    "parquet_available, _ = preprocess_parquet(parquet_fileset, step_size=20000, save_form=True, backend=\"iterative\")\n",
+    "print(\"Detected format:\", parquet_available[\"ZJets\"].format)\n",
+    "rich.print({k: v.model_dump(exclude=\"compressed_form\") for k, v in parquet_available.items()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86c1f41a",
+   "metadata": {},
+   "source": [
+    "### 5.4 Preprocessing RNTuple datasets\n",
+    "\n",
+    "RNTuple-backed ROOT files are auto-detected: `preprocess` and `preprocess_root` transparently handle both TTrees and RNTuples. Use `preprocess_rntuple` when you want to *assert* that every object is an RNTuple — it raises a `ValueError` if it encounters a TTree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c54655a5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">{</span>\n",
+       "    <span style=\"color: #008000; text-decoration-color: #008000\">'ZJets'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'files'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "            <span style=\"color: #008000; text-decoration-color: #008000\">'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy_rntuple.root'</span>: <span style=\"font-weight: bold\">{</span>\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'steps'</span>: <span style=\"font-weight: bold\">[[</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">20</span><span style=\"font-weight: bold\">]</span>, <span style=\"font-weight: bold\">[</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">20</span>, <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span><span style=\"font-weight: bold\">]]</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'root'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'lfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'pfn'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'uuid'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'5aa41eba-a9f5-11f0-ba63-0f00a8c0beef'</span>,\n",
+       "                <span style=\"color: #008000; text-decoration-color: #008000\">'num_selected_entries'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">40</span>\n",
+       "            <span style=\"font-weight: bold\">}</span>\n",
+       "        <span style=\"font-weight: bold\">}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'metadata'</span>: <span style=\"font-weight: bold\">{}</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'format'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'root'</span>,\n",
+       "        <span style=\"color: #008000; text-decoration-color: #008000\">'did'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
+       "    <span style=\"font-weight: bold\">}</span>\n",
+       "<span style=\"font-weight: bold\">}</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[1m{\u001b[0m\n",
+       "    \u001b[32m'ZJets'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "        \u001b[32m'files'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "            \u001b[32m'https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy_rntuple.root'\u001b[0m: \u001b[1m{\u001b[0m\n",
+       "                \u001b[32m'object_path'\u001b[0m: \u001b[32m'Events'\u001b[0m,\n",
+       "                \u001b[32m'steps'\u001b[0m: \u001b[1m[\u001b[0m\u001b[1m[\u001b[0m\u001b[1;36m0\u001b[0m, \u001b[1;36m20\u001b[0m\u001b[1m]\u001b[0m, \u001b[1m[\u001b[0m\u001b[1;36m20\u001b[0m, \u001b[1;36m40\u001b[0m\u001b[1m]\u001b[0m\u001b[1m]\u001b[0m,\n",
+       "                \u001b[32m'num_entries'\u001b[0m: \u001b[1;36m40\u001b[0m,\n",
+       "                \u001b[32m'format'\u001b[0m: \u001b[32m'root'\u001b[0m,\n",
+       "                \u001b[32m'lfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'pfn'\u001b[0m: \u001b[3;35mNone\u001b[0m,\n",
+       "                \u001b[32m'uuid'\u001b[0m: \u001b[32m'5aa41eba-a9f5-11f0-ba63-0f00a8c0beef'\u001b[0m,\n",
+       "                \u001b[32m'num_selected_entries'\u001b[0m: \u001b[1;36m40\u001b[0m\n",
+       "            \u001b[1m}\u001b[0m\n",
+       "        \u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'metadata'\u001b[0m: \u001b[1m{\u001b[0m\u001b[1m}\u001b[0m,\n",
+       "        \u001b[32m'format'\u001b[0m: \u001b[32m'root'\u001b[0m,\n",
+       "        \u001b[32m'did'\u001b[0m: \u001b[3;35mNone\u001b[0m\n",
+       "    \u001b[1m}\u001b[0m\n",
+       "\u001b[1m}\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# 5.4 Preprocessing an RNTuple dataset (auto-detected; preprocess_rntuple enforces RNTuple-only)\n",
+    "rntuple_fileset = DataGroupSpec({\n",
+    "    \"ZJets\": {\"files\": [\"https://raw.githubusercontent.com/scikit-hep/coffea/master/tests/samples/nano_dy_rntuple.root:Events\"]},\n",
+    "})\n",
+    "\n",
+    "rntuple_available, _ = preprocess_rntuple(rntuple_fileset, step_size=20, save_form=True, backend=\"iterative\")\n",
+    "rich.print({k: v.model_dump(exclude=\"compressed_form\") for k, v in rntuple_available.items()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6b974346",
    "metadata": {},
    "source": [
@@ -2341,7 +2597,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "39a43fa8",
    "metadata": {},
    "outputs": [
@@ -2453,7 +2709,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "e7919395",
    "metadata": {},
    "outputs": [
@@ -2509,7 +2765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "d860f60a",
    "metadata": {},
    "outputs": [
@@ -2554,7 +2810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "01044461",
    "metadata": {},
    "outputs": [
@@ -2590,7 +2846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "ee931c3e",
    "metadata": {},
    "outputs": [
@@ -2655,7 +2911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "bc8ca29a",
    "metadata": {},
    "outputs": [
@@ -2753,7 +3009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "id": "a6237760",
    "metadata": {},
    "outputs": [
@@ -2811,7 +3067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "60f065ea",
    "metadata": {},
    "outputs": [
@@ -2873,7 +3129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "f22002f4",
    "metadata": {},
    "outputs": [
@@ -3051,7 +3307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "id": "b5c82c85",
    "metadata": {},
    "outputs": [
@@ -3115,7 +3371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "id": "f6f4842c",
    "metadata": {},
    "outputs": [
@@ -4096,7 +4352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "id": "aeb145d5",
    "metadata": {},
    "outputs": [

--- a/binder/filespec.ipynb
+++ b/binder/filespec.ipynb
@@ -38,7 +38,14 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "f6c75a47",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:31:42.715172Z",
+     "iopub.status.busy": "2026-07-02T23:31:42.714932Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.577593Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.577053Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -113,7 +120,14 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "2ecaf55b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.579034Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.578839Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.586602Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.586149Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -216,7 +230,14 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "d59e690c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.587784Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.587711Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.592336Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.591877Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -318,7 +339,14 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "85d98abf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.593469Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.593381Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.599317Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.598796Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -469,7 +497,14 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "38ee2f96",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.600473Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.600391Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.605639Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.605231Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -523,26 +558,26 @@
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span> validation errors for CoffeaROOTFileSpec\n",
        "steps\n",
        "  Field required <span style=\"font-weight: bold\">[</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">missing</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_value</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span><span style=\"font-weight: bold\">}</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">dict</span><span style=\"font-weight: bold\">]</span>\n",
-       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.11/v/missing</span>\n",
+       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.12/v/missing</span>\n",
        "num_entries\n",
        "  Field required <span style=\"font-weight: bold\">[</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">missing</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_value</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span><span style=\"font-weight: bold\">}</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">dict</span><span style=\"font-weight: bold\">]</span>\n",
-       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.11/v/missing</span>\n",
+       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.12/v/missing</span>\n",
        "uuid\n",
        "  Field required <span style=\"font-weight: bold\">[</span><span style=\"color: #808000; text-decoration-color: #808000\">type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">missing</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_value</span>=<span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'object_path'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span><span style=\"font-weight: bold\">}</span>, <span style=\"color: #808000; text-decoration-color: #808000\">input_type</span>=<span style=\"color: #800080; text-decoration-color: #800080\">dict</span><span style=\"font-weight: bold\">]</span>\n",
-       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.11/v/missing</span>\n",
+       "    For further information visit <span style=\"color: #0000ff; text-decoration-color: #0000ff; text-decoration: underline\">https://errors.pydantic.dev/2.12/v/missing</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[1;36m3\u001b[0m validation errors for CoffeaROOTFileSpec\n",
        "steps\n",
        "  Field required \u001b[1m[\u001b[0m\u001b[33mtype\u001b[0m=\u001b[35mmissing\u001b[0m, \u001b[33minput_value\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'object_path'\u001b[0m: \u001b[32m'Events'\u001b[0m\u001b[1m}\u001b[0m, \u001b[33minput_type\u001b[0m=\u001b[35mdict\u001b[0m\u001b[1m]\u001b[0m\n",
-       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.11/v/missing\u001b[0m\n",
+       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.12/v/missing\u001b[0m\n",
        "num_entries\n",
        "  Field required \u001b[1m[\u001b[0m\u001b[33mtype\u001b[0m=\u001b[35mmissing\u001b[0m, \u001b[33minput_value\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'object_path'\u001b[0m: \u001b[32m'Events'\u001b[0m\u001b[1m}\u001b[0m, \u001b[33minput_type\u001b[0m=\u001b[35mdict\u001b[0m\u001b[1m]\u001b[0m\n",
-       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.11/v/missing\u001b[0m\n",
+       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.12/v/missing\u001b[0m\n",
        "uuid\n",
        "  Field required \u001b[1m[\u001b[0m\u001b[33mtype\u001b[0m=\u001b[35mmissing\u001b[0m, \u001b[33minput_value\u001b[0m=\u001b[1m{\u001b[0m\u001b[32m'object_path'\u001b[0m: \u001b[32m'Events'\u001b[0m\u001b[1m}\u001b[0m, \u001b[33minput_type\u001b[0m=\u001b[35mdict\u001b[0m\u001b[1m]\u001b[0m\n",
-       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.11/v/missing\u001b[0m\n"
+       "    For further information visit \u001b[4;94mhttps://errors.pydantic.dev/2.12/v/missing\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -579,7 +614,14 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "694daed3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.606724Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.606660Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.611162Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.610766Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -703,7 +745,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "3cfd0d6a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.612312Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.612256Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.621771Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.621231Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -972,7 +1021,14 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "b2db2dcd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.622914Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.622852Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.627539Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.627196Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1111,7 +1167,14 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "b31c13f5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.628785Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.628726Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.633925Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.633595Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1247,7 +1310,14 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "76aa5992",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.635068Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.635001Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.640202Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.639734Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1261,7 +1331,7 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">DatasetSpec</span><span style=\"font-weight: bold\">(</span>\n",
-       "    <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">InputFiles</span><span style=\"font-weight: bold\">(</span>\n",
+       "    <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">PreprocessedFiles</span><span style=\"font-weight: bold\">(</span>\n",
        "        <span style=\"color: #808000; text-decoration-color: #808000\">root</span>=<span style=\"font-weight: bold\">{</span>\n",
        "            <span style=\"color: #008000; text-decoration-color: #008000\">'processed_data_1.root'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">CoffeaROOTFileSpec</span><span style=\"font-weight: bold\">(</span>\n",
        "                <span style=\"color: #808000; text-decoration-color: #808000\">object_path</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span>,\n",
@@ -1294,7 +1364,7 @@
       ],
       "text/plain": [
        "\u001b[1;35mDatasetSpec\u001b[0m\u001b[1m(\u001b[0m\n",
-       "    \u001b[33mfiles\u001b[0m=\u001b[1;35mInputFiles\u001b[0m\u001b[1m(\u001b[0m\n",
+       "    \u001b[33mfiles\u001b[0m=\u001b[1;35mPreprocessedFiles\u001b[0m\u001b[1m(\u001b[0m\n",
        "        \u001b[33mroot\u001b[0m=\u001b[1m{\u001b[0m\n",
        "            \u001b[32m'processed_data_1.root'\u001b[0m: \u001b[1;35mCoffeaROOTFileSpec\u001b[0m\u001b[1m(\u001b[0m\n",
        "                \u001b[33mobject_path\u001b[0m=\u001b[32m'Events'\u001b[0m,\n",
@@ -1377,7 +1447,14 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "6af14880",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.641291Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.641225Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.643911Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.643466Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1386,7 +1463,7 @@
       "=== Mixed Format Datasets ===\n",
       "Validation error for mixed format dataset: 1 validation error for DatasetSpec\n",
       "  Value error, format: format must be one of {'root', 'parquet'} [type=value_error, input_value={'files': {'data.root': C...selected_entries=2000)}}, input_type=dict]\n",
-      "    For further information visit https://errors.pydantic.dev/2.11/v/value_error\n"
+      "    For further information visit https://errors.pydantic.dev/2.12/v/value_error\n"
      ]
     }
    ],
@@ -1425,7 +1502,14 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "98564dea",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.644963Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.644901Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.650382Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.650042Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1593,7 +1677,14 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "7109b611",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.651575Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.651517Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.660381Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.659975Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1852,7 +1943,14 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "376a6765",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.661499Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.661424Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.664025Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.663682Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1898,7 +1996,14 @@
    "cell_type": "code",
    "execution_count": 15,
    "id": "fc3b6e90",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.665153Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.665075Z",
+     "iopub.status.idle": "2026-07-02T23:32:07.667908Z",
+     "shell.execute_reply": "2026-07-02T23:32:07.667560Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1968,7 +2073,14 @@
    "cell_type": "code",
    "execution_count": 16,
    "id": "8d360bf8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:07.669063Z",
+     "iopub.status.busy": "2026-07-02T23:32:07.668989Z",
+     "iopub.status.idle": "2026-07-02T23:32:09.782645Z",
+     "shell.execute_reply": "2026-07-02T23:32:09.782076Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2104,7 +2216,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Preprocessing the fileset...\n",
+      "Preprocessing the fileset...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Fileset after preprocessing (excluding compressed_form string):\n"
      ]
     },
@@ -2353,7 +2471,14 @@
    "cell_type": "code",
    "execution_count": 17,
    "id": "2e8b6aa5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:09.784246Z",
+     "iopub.status.busy": "2026-07-02T23:32:09.784065Z",
+     "iopub.status.idle": "2026-07-02T23:32:10.556751Z",
+     "shell.execute_reply": "2026-07-02T23:32:10.556198Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2439,7 +2564,14 @@
    "cell_type": "code",
    "execution_count": 18,
    "id": "a60ff4e0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:10.558360Z",
+     "iopub.status.busy": "2026-07-02T23:32:10.558268Z",
+     "iopub.status.idle": "2026-07-02T23:32:12.047819Z",
+     "shell.execute_reply": "2026-07-02T23:32:12.047180Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2523,7 +2655,14 @@
    "cell_type": "code",
    "execution_count": 19,
    "id": "c54655a5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:12.049879Z",
+     "iopub.status.busy": "2026-07-02T23:32:12.049784Z",
+     "iopub.status.idle": "2026-07-02T23:32:13.451399Z",
+     "shell.execute_reply": "2026-07-02T23:32:13.450909Z"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -2599,19 +2738,44 @@
    "cell_type": "code",
    "execution_count": 20,
    "id": "39a43fa8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:13.453038Z",
+     "iopub.status.busy": "2026-07-02T23:32:13.452910Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.747719Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.747218Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/nmangane/scikit-hep-dev-4/coffea/src/coffea/nanoevents/schemas/nanoaod.py:264: RuntimeWarning: Missing cross-reference index for LowPtElectron_electronIdx => Electron\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for LowPtElectron_electronIdx => Electron\n",
       "  warnings.warn(\n",
-      "/Users/nmangane/scikit-hep-dev-4/coffea/src/coffea/nanoevents/schemas/nanoaod.py:264: RuntimeWarning: Missing cross-reference index for LowPtElectron_genPartIdx => GenPart\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for LowPtElectron_genPartIdx => GenPart\n",
       "  warnings.warn(\n",
-      "/Users/nmangane/scikit-hep-dev-4/coffea/src/coffea/nanoevents/schemas/nanoaod.py:264: RuntimeWarning: Missing cross-reference index for LowPtElectron_photonIdx => Photon\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for LowPtElectron_photonIdx => Photon\n",
       "  warnings.warn(\n",
-      "/Users/nmangane/scikit-hep-dev-4/coffea/src/coffea/nanoevents/schemas/nanoaod.py:264: RuntimeWarning: Missing cross-reference index for FatJet_genJetAK8Idx => GenJetAK8\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for FatJet_genJetAK8Idx => GenJetAK8\n",
+      "  warnings.warn(\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:336: RuntimeWarning: Branch Photon_mass already exists but its values will be replaced with 0.0\n",
+      "  warnings.warn(\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:336: RuntimeWarning: Branch Photon_charge already exists but its values will be replaced with 0.0\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for LowPtElectron_electronIdx => Electron\n",
+      "  warnings.warn(\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:297: RuntimeWarning: Missing cross-reference index for LowPtElectron_photonIdx => Photon\n",
+      "  warnings.warn(\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:336: RuntimeWarning: Branch Photon_mass already exists but its values will be replaced with 0.0\n",
+      "  warnings.warn(\n",
+      "/Users/nmangane/servicex_claude/coffea/src/coffea/nanoevents/schemas/nanoaod.py:336: RuntimeWarning: Branch Photon_charge already exists but its values will be replaced with 0.0\n",
       "  warnings.warn(\n"
      ]
     },
@@ -2711,7 +2875,14 @@
    "cell_type": "code",
    "execution_count": 21,
    "id": "e7919395",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.749318Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.749215Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.753528Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.753161Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2767,7 +2938,14 @@
    "cell_type": "code",
    "execution_count": 22,
    "id": "d860f60a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.754954Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.754878Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.758814Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.758442Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2812,7 +2990,14 @@
    "cell_type": "code",
    "execution_count": 23,
    "id": "01044461",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.760066Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.759987Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.763465Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.762990Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2848,7 +3033,14 @@
    "cell_type": "code",
    "execution_count": 24,
    "id": "ee931c3e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.764558Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.764499Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.767574Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.767030Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2913,7 +3105,14 @@
    "cell_type": "code",
    "execution_count": 25,
    "id": "bc8ca29a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.768739Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.768668Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.775571Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.775079Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3011,7 +3210,14 @@
    "cell_type": "code",
    "execution_count": 26,
    "id": "a6237760",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.776638Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.776576Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.782356Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.781926Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3069,7 +3275,14 @@
    "cell_type": "code",
    "execution_count": 27,
    "id": "60f065ea",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.783482Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.783408Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.786933Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.786436Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3131,7 +3344,14 @@
    "cell_type": "code",
    "execution_count": 28,
    "id": "f22002f4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.788092Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.788023Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.795655Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.795224Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3149,7 +3369,7 @@
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">DataGroupSpec</span><span style=\"font-weight: bold\">(</span>\n",
        "    <span style=\"color: #808000; text-decoration-color: #808000\">root</span>=<span style=\"font-weight: bold\">{</span>\n",
        "        <span style=\"color: #008000; text-decoration-color: #008000\">'higgs_m125'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">DatasetSpec</span><span style=\"font-weight: bold\">(</span>\n",
-       "            <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">InputFiles</span><span style=\"font-weight: bold\">(</span>\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">PreprocessedFiles</span><span style=\"font-weight: bold\">(</span>\n",
        "                <span style=\"color: #808000; text-decoration-color: #808000\">root</span>=<span style=\"font-weight: bold\">{</span>\n",
        "                    <span style=\"color: #008000; text-decoration-color: #008000\">'higgs_m125_part0.root'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">CoffeaROOTFileSpec</span><span style=\"font-weight: bold\">(</span>\n",
        "                        <span style=\"color: #808000; text-decoration-color: #808000\">object_path</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span>,\n",
@@ -3169,7 +3389,7 @@
        "            <span style=\"color: #808000; text-decoration-color: #808000\">did</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>\n",
        "        <span style=\"font-weight: bold\">)</span>,\n",
        "        <span style=\"color: #008000; text-decoration-color: #008000\">'higgs_m200'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">DatasetSpec</span><span style=\"font-weight: bold\">(</span>\n",
-       "            <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">InputFiles</span><span style=\"font-weight: bold\">(</span>\n",
+       "            <span style=\"color: #808000; text-decoration-color: #808000\">files</span>=<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">PreprocessedFiles</span><span style=\"font-weight: bold\">(</span>\n",
        "                <span style=\"color: #808000; text-decoration-color: #808000\">root</span>=<span style=\"font-weight: bold\">{</span>\n",
        "                    <span style=\"color: #008000; text-decoration-color: #008000\">'higgs_m200_part0.root'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">CoffeaROOTFileSpec</span><span style=\"font-weight: bold\">(</span>\n",
        "                        <span style=\"color: #808000; text-decoration-color: #808000\">object_path</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'Events'</span>,\n",
@@ -3196,7 +3416,7 @@
        "\u001b[1;35mDataGroupSpec\u001b[0m\u001b[1m(\u001b[0m\n",
        "    \u001b[33mroot\u001b[0m=\u001b[1m{\u001b[0m\n",
        "        \u001b[32m'higgs_m125'\u001b[0m: \u001b[1;35mDatasetSpec\u001b[0m\u001b[1m(\u001b[0m\n",
-       "            \u001b[33mfiles\u001b[0m=\u001b[1;35mInputFiles\u001b[0m\u001b[1m(\u001b[0m\n",
+       "            \u001b[33mfiles\u001b[0m=\u001b[1;35mPreprocessedFiles\u001b[0m\u001b[1m(\u001b[0m\n",
        "                \u001b[33mroot\u001b[0m=\u001b[1m{\u001b[0m\n",
        "                    \u001b[32m'higgs_m125_part0.root'\u001b[0m: \u001b[1;35mCoffeaROOTFileSpec\u001b[0m\u001b[1m(\u001b[0m\n",
        "                        \u001b[33mobject_path\u001b[0m=\u001b[32m'Events'\u001b[0m,\n",
@@ -3216,7 +3436,7 @@
        "            \u001b[33mdid\u001b[0m=\u001b[3;35mNone\u001b[0m\n",
        "        \u001b[1m)\u001b[0m,\n",
        "        \u001b[32m'higgs_m200'\u001b[0m: \u001b[1;35mDatasetSpec\u001b[0m\u001b[1m(\u001b[0m\n",
-       "            \u001b[33mfiles\u001b[0m=\u001b[1;35mInputFiles\u001b[0m\u001b[1m(\u001b[0m\n",
+       "            \u001b[33mfiles\u001b[0m=\u001b[1;35mPreprocessedFiles\u001b[0m\u001b[1m(\u001b[0m\n",
        "                \u001b[33mroot\u001b[0m=\u001b[1m{\u001b[0m\n",
        "                    \u001b[32m'higgs_m200_part0.root'\u001b[0m: \u001b[1;35mCoffeaROOTFileSpec\u001b[0m\u001b[1m(\u001b[0m\n",
        "                        \u001b[33mobject_path\u001b[0m=\u001b[32m'Events'\u001b[0m,\n",
@@ -3309,7 +3529,14 @@
    "cell_type": "code",
    "execution_count": 29,
    "id": "b5c82c85",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.796764Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.796704Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.799170Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.798738Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -3373,7 +3600,14 @@
    "cell_type": "code",
    "execution_count": 30,
    "id": "f6f4842c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.800305Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.800246Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.827349Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.826827Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -4354,7 +4588,14 @@
    "cell_type": "code",
    "execution_count": 31,
    "id": "aeb145d5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-02T23:32:21.828792Z",
+     "iopub.status.busy": "2026-07-02T23:32:21.828705Z",
+     "iopub.status.idle": "2026-07-02T23:32:21.834941Z",
+     "shell.execute_reply": "2026-07-02T23:32:21.834371Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -4506,7 +4747,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.0"
+   "version": "3.13.14"
   }
  },
  "nbformat": 4,

--- a/binder/processing.ipynb
+++ b/binder/processing.ipynb
@@ -1563,7 +1563,9 @@
    "metadata": {},
    "source": [
     "### Preprocessing\n",
-    "There are dataset discovery tools inside of coffea to help construct such datasets. Those will not be demonstrated here. For now, we'll take the above `initial_fileset` and preprocess it."
+    "There are dataset discovery tools inside of coffea to help construct such datasets. Those will not be demonstrated here. For now, we'll take the above `initial_fileset` and preprocess it.\n",
+    "\n",
+    "> **New:** `preprocess` accepts a `backend=` argument — `\"dask\"` (default), or the dask-free `\"iterative\"` / `\"futures\"` backends — and handles Parquet and RNTuple inputs (auto-detected, or via the `preprocess_parquet` / `preprocess_rntuple` helpers). See the [filespec notebook](filespec.ipynb) for a focused walkthrough."
    ]
   },
   {

--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -1,4 +1,11 @@
 from coffea.dataset_tools.apply_processor import apply_to_dataset, apply_to_fileset
+from coffea.dataset_tools.backends import (
+    DaskBackend,
+    FuturesBackend,
+    IterativeBackend,
+    PreprocessBackend,
+    PreprocessJob,
+)
 from coffea.dataset_tools.filespec import (
     CoffeaParquetFileSpec,
     CoffeaParquetFileSpecOptional,
@@ -60,4 +67,9 @@ __all__ = [
     "DatasetSpec",
     "DataGroupSpec",
     "ModelFactory",
+    "PreprocessBackend",
+    "PreprocessJob",
+    "DaskBackend",
+    "FuturesBackend",
+    "IterativeBackend",
 ]

--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -26,6 +26,7 @@ from coffea.dataset_tools.preprocess import (
     preprocess,
     preprocess_legacy,
     preprocess_parquet,
+    preprocess_rntuple,
     preprocess_root,
 )
 from coffea.dataset_tools.splitting import hash_fileset, split_fileset
@@ -34,6 +35,7 @@ __all__ = [
     "preprocess",
     "preprocess_legacy",
     "preprocess_parquet",
+    "preprocess_rntuple",
     "preprocess_root",
     "split_fileset",
     "hash_fileset",

--- a/src/coffea/dataset_tools/__init__.py
+++ b/src/coffea/dataset_tools/__init__.py
@@ -1,11 +1,4 @@
 from coffea.dataset_tools.apply_processor import apply_to_dataset, apply_to_fileset
-from coffea.dataset_tools.backends import (
-    DaskBackend,
-    FuturesBackend,
-    IterativeBackend,
-    PreprocessBackend,
-    PreprocessJob,
-)
 from coffea.dataset_tools.filespec import (
     CoffeaParquetFileSpec,
     CoffeaParquetFileSpecOptional,
@@ -35,6 +28,13 @@ from coffea.dataset_tools.preprocess import (
     preprocess_parquet,
     preprocess_rntuple,
     preprocess_root,
+)
+from coffea.dataset_tools.preprocess_backends import (
+    DaskBackend,
+    FuturesBackend,
+    IterativeBackend,
+    PreprocessBackend,
+    PreprocessJob,
 )
 from coffea.dataset_tools.splitting import hash_fileset, split_fileset
 

--- a/src/coffea/dataset_tools/backends.py
+++ b/src/coffea/dataset_tools/backends.py
@@ -15,11 +15,10 @@ behind a small backend interface so the same worker can run on:
   is IO-bound) with an opt-in process pool (mirrors ``FuturesExecutor``).
 
 The iterative and futures backends do not build a dask *task graph* for orchestration, and they
-are dask-free for parquet input and for TTree ROOT input (TTree form extraction uses uproot's own
-non-dask form builder, byte-identical to the ``uproot.dask`` form). The one remaining dask
-dependency is **RNTuple form extraction** (``save_form=True``): it still goes through
-``uproot.dask``, so a fully dask-free run of an RNTuple dataset currently also requires
-``save_form=False``. Making RNTuple form extraction dask-free is a possible follow-up.
+are dask-free for parquet input and for ROOT input of either flavor. ROOT form extraction
+(``save_form=True``) uses uproot's own non-dask form builder for both TTree and RNTuple, producing
+a form byte-identical to the ``uproot.dask`` form; it only falls back to ``uproot.dask`` (and thus
+dask) if that internal uproot helper is unavailable on an unexpected uproot version.
 
 The interface intentionally echoes the ``coffea.compute`` refactor (PR #1470): a ``Backend``
 turns a "computable" into a future-like ``Task`` whose ``result()`` blocks. Here the computable
@@ -402,8 +401,7 @@ def print_dask_backend_fallback_hint() -> None:
     coffea_console.print(
         "[bold red]The dask preprocessing backend is unavailable because dask / dask-awkward "
         "could not be imported.[/bold red]\n"
-        "Preprocessing can run without dask for parquet and TTree ROOT input: pass "
+        "Preprocessing can run without dask for parquet and ROOT input: pass "
         "[bold]backend='iterative'[/bold] (single process) or [bold]backend='futures'[/bold] "
-        "(thread pool) to preprocess() and the format-specific preprocess_* functions. "
-        "(RNTuple form extraction with save_form=True still needs dask.)"
+        "(thread pool) to preprocess() and the format-specific preprocess_* functions."
     )

--- a/src/coffea/dataset_tools/backends.py
+++ b/src/coffea/dataset_tools/backends.py
@@ -1,0 +1,409 @@
+"""Switchable execution backends for pydantic preprocessing.
+
+Preprocessing a :class:`~coffea.dataset_tools.filespec.DataGroupSpec` is, per dataset, an
+ordered map-reduce: a worker (``get_steps`` / ``get_parquet_form_uuid_steps``) is mapped over
+batches of normalized file records and the resulting awkward arrays are concatenated. This
+module factors that map-reduce out from :func:`coffea.dataset_tools.preprocess._preprocess_pydantic`
+behind a small backend interface so the same worker can run on:
+
+- :class:`DaskBackend` -- the historical path (``dask_awkward.map_partitions`` + an
+  ``AwkwardTreeReductionLayer`` + ``dask.compute``). This backend builds and executes a dask
+  task graph to orchestrate the map-reduce.
+- :class:`IterativeBackend` -- immediate (synchronous, single process) execution, mirroring
+  coffea's ``IterativeExecutor``.
+- :class:`FuturesBackend` -- a :mod:`concurrent.futures` pool, threads by default (preprocessing
+  is IO-bound) with an opt-in process pool (mirrors ``FuturesExecutor``).
+
+The iterative and futures backends do not build a dask *task graph* for orchestration, and they
+are dask-free for parquet input and for TTree ROOT input (TTree form extraction uses uproot's own
+non-dask form builder, byte-identical to the ``uproot.dask`` form). The one remaining dask
+dependency is **RNTuple form extraction** (``save_form=True``): it still goes through
+``uproot.dask``, so a fully dask-free run of an RNTuple dataset currently also requires
+``save_form=False``. Making RNTuple form extraction dask-free is a possible follow-up.
+
+The interface intentionally echoes the ``coffea.compute`` refactor (PR #1470): a ``Backend``
+turns a "computable" into a future-like ``Task`` whose ``result()`` blocks. Here the computable
+is a mapping ``{dataset_name: PreprocessJob}`` and the result is ``{dataset_name: awkward.Array}``.
+When ``coffea.compute`` lands, these backends should adapt to its ``RunningBackend``/``Task``
+protocols with little change.
+
+**Ordering is load-bearing.** Downstream post-processing zips the concatenated result against the
+original per-file order, so the reduction here is an *ordered* concatenation -- deliberately not
+the order-agnostic ``accumulate``/merging used by the event-processing executors.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Callable, Iterable, Mapping
+from concurrent.futures import Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import wait as futures_wait
+from dataclasses import dataclass
+from functools import partial
+from typing import Protocol, runtime_checkable
+
+import awkward
+
+from coffea.util import _import_dask, _import_dask_awkward, coffea_console
+
+__all__ = [
+    "PreprocessJob",
+    "PreprocessTask",
+    "PreprocessBackend",
+    "IterativeBackend",
+    "FuturesBackend",
+    "DaskBackend",
+    "ordered_concat",
+    "resolve_backend",
+]
+
+
+def ordered_concat(parts: Iterable[awkward.Array | None]) -> awkward.Array | None:
+    """Concatenate mapped outputs while preserving input order.
+
+    ``None`` parts are dropped. Returns ``None`` if nothing remains. This is the reduction step
+    for preprocessing and, unlike the order-agnostic accumulation used for processor outputs,
+    must preserve order because the caller re-zips the result against the original file order.
+    """
+    parts = [part for part in parts if part is not None]
+    if len(parts) == 0:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return awkward.concatenate(parts, axis=0)
+
+
+def _iter_batches(array: awkward.Array, files_per_batch: int):
+    """Yield contiguous slices of ``array`` of at most ``files_per_batch`` rows, in order.
+
+    An empty array yields itself once so the worker still produces a correctly-typed empty
+    result (matching the single-partition dask behaviour).
+    """
+    n = len(array)
+    if n == 0:
+        yield array
+        return
+    step = max(1, files_per_batch)
+    for start in range(0, n, step):
+        yield array[start : start + step]
+
+
+@dataclass
+class PreprocessJob:
+    """One dataset's preprocessing work: map ``map_fn`` over batches of ``array`` and concat.
+
+    Parameters
+    ----------
+        array : awkward.Array
+            Normalized file records (fields ``file``, ``object_path``, ``steps``,
+            ``num_entries``, ``uuid``) for a single dataset.
+        map_fn : Callable[[awkward.Array], awkward.Array]
+            The per-batch worker, e.g. ``functools.partial(get_steps, **options)``. Must be a
+            top-level (picklable) callable so it can run under a process pool.
+        files_per_batch : int, default 1
+            Number of files handled per unit of work. Larger values mean fewer, heavier tasks.
+    """
+
+    array: awkward.Array
+    map_fn: Callable[[awkward.Array], awkward.Array]
+    files_per_batch: int = 1
+
+
+@runtime_checkable
+class PreprocessTask(Protocol):
+    """Future-like handle to a submitted preprocessing computable (mirrors ``compute.Task``)."""
+
+    def result(self) -> dict[str, awkward.Array]:
+        """Block until done and return ``{dataset_name: concatenated awkward.Array}``."""
+
+    def wait(self) -> None:
+        """Block until the computation has finished, without returning the result."""
+
+
+class PreprocessBackend(ABC):
+    """Base class for preprocessing execution backends (mirrors ``compute.RunningBackend``)."""
+
+    @abstractmethod
+    def submit(self, jobs: Mapping[str, PreprocessJob]) -> PreprocessTask:
+        """Start executing ``jobs`` and return a non-blocking :class:`PreprocessTask`."""
+
+    def compute(self, jobs: Mapping[str, PreprocessJob]) -> dict[str, awkward.Array]:
+        """Convenience blocking call: ``submit(jobs).result()``."""
+        return self.submit(jobs).result()
+
+
+@dataclass
+class _CompletedTask:
+    """A :class:`PreprocessTask` whose work is already done (used by the iterative backend)."""
+
+    _results: dict[str, awkward.Array]
+
+    def result(self) -> dict[str, awkward.Array]:
+        return self._results
+
+    def wait(self) -> None:
+        return None
+
+
+@dataclass
+class IterativeBackend(PreprocessBackend):
+    """Execute preprocessing immediately -- synchronously, in the current thread.
+
+    Named to mirror coffea's ``IterativeExecutor``; the execution is "immediate" in that each
+    batch is mapped and reduced inline with no deferral or task graph. No dask required.
+    """
+
+    def submit(self, jobs: Mapping[str, PreprocessJob]) -> PreprocessTask:
+        results: dict[str, awkward.Array] = {}
+        for name, job in jobs.items():
+            parts = [
+                job.map_fn(batch)
+                for batch in _iter_batches(job.array, job.files_per_batch)
+            ]
+            results[name] = ordered_concat(parts)
+        return _CompletedTask(results)
+
+
+class _FuturesTask:
+    """A :class:`PreprocessTask` backed by :mod:`concurrent.futures` futures.
+
+    Futures are kept grouped and ordered per dataset so results reassemble in the original file
+    order regardless of completion order. A pool created by the backend is shut down once the
+    result has been gathered; an externally-supplied pool is left open.
+    """
+
+    def __init__(
+        self,
+        name_to_futures: dict[str, list[Future]],
+        pool: Executor,
+        owns_pool: bool,
+    ):
+        self._name_to_futures = name_to_futures
+        self._pool = pool
+        self._owns_pool = owns_pool
+
+    def _all_futures(self) -> list[Future]:
+        return [fut for futs in self._name_to_futures.values() for fut in futs]
+
+    def wait(self) -> None:
+        futures_wait(self._all_futures())
+
+    def result(self) -> dict[str, awkward.Array]:
+        try:
+            results: dict[str, awkward.Array] = {}
+            for name, futs in self._name_to_futures.items():
+                # .result() re-raises worker exceptions here; ordering follows submission
+                parts = [fut.result() for fut in futs]
+                results[name] = ordered_concat(parts)
+            return results
+        finally:
+            if self._owns_pool:
+                self._pool.shutdown()
+
+    def __del__(self):
+        # Safety net: an owned pool is normally shut down in result(); if the caller only
+        # wait()s or drops the task without calling result(), avoid leaking the pool.
+        # Executor.shutdown is idempotent, so a double call after result() is harmless.
+        if getattr(self, "_owns_pool", False):
+            self._pool.shutdown(wait=False)
+
+
+@dataclass
+class FuturesBackend(PreprocessBackend):
+    """Execute preprocessing over a :mod:`concurrent.futures` pool. No dask required.
+
+    Batches from every dataset are submitted to a single shared pool for good cross-dataset
+    load balancing, then reassembled per dataset in order.
+
+    Parameters
+    ----------
+        workers : int, default 1
+            Number of workers when this backend creates the pool.
+        use_processes : bool, default False
+            Create a :class:`~concurrent.futures.ProcessPoolExecutor` instead of the default
+            :class:`~concurrent.futures.ThreadPoolExecutor`. Threads are preferred because
+            preprocessing is IO-bound (opening files / reading metadata) and avoids pickling
+            the awkward arrays; use processes when form extraction is CPU-heavy.
+        pool : concurrent.futures.Executor or Callable, optional
+            An existing executor instance to reuse (left open by this backend), or a callable
+            (e.g. an ``Executor`` subclass) invoked as ``pool(max_workers=workers)``. Overrides
+            ``use_processes`` when given.
+    """
+
+    workers: int = 1
+    use_processes: bool = False
+    pool: Executor | Callable[..., Executor] | None = None
+
+    def _make_pool(self) -> tuple[Executor, bool]:
+        if isinstance(self.pool, Executor):
+            return self.pool, False
+        if self.pool is not None:
+            return self.pool(max_workers=self.workers), True
+        if self.use_processes:
+            return ProcessPoolExecutor(max_workers=self.workers), True
+        return ThreadPoolExecutor(max_workers=self.workers), True
+
+    def submit(self, jobs: Mapping[str, PreprocessJob]) -> PreprocessTask:
+        pool, owns_pool = self._make_pool()
+        try:
+            name_to_futures: dict[str, list[Future]] = {}
+            for name, job in jobs.items():
+                name_to_futures[name] = [
+                    pool.submit(job.map_fn, batch)
+                    for batch in _iter_batches(job.array, job.files_per_batch)
+                ]
+        except BaseException:
+            if owns_pool:
+                pool.shutdown()
+            raise
+        return _FuturesTask(name_to_futures, pool, owns_pool)
+
+
+class _DaskTask:
+    """A :class:`PreprocessTask` wrapping unmaterialized dask-awkward collections."""
+
+    def __init__(self, collections: dict, scheduler):
+        self._collections = collections
+        self._scheduler = scheduler
+        self._computed: dict[str, awkward.Array] | None = None
+
+    def wait(self) -> None:
+        self.result()
+
+    def result(self) -> dict[str, awkward.Array]:
+        if self._computed is None:
+            dask = _import_dask()
+            (self._computed,) = dask.compute(
+                self._collections, scheduler=self._scheduler
+            )
+        return self._computed
+
+
+@dataclass
+class DaskBackend(PreprocessBackend):
+    """Execute preprocessing as a dask-awkward task graph (the historical behaviour).
+
+    Per dataset this builds ``from_awkward`` -> ``map_partitions`` -> ``AwkwardTreeReductionLayer``
+    and lets a single ``dask.compute`` materialize all datasets together.
+
+    Parameters
+    ----------
+        scheduler : None or Callable or str, default None
+            Passed through to ``dask.compute``.
+        split_every : int, default 8
+            Fan-in of the tree reduction that concatenates per-batch results.
+    """
+
+    scheduler: None | Callable | str = None
+    split_every: int = 8
+
+    def _build_collection(self, name: str, job: PreprocessJob, dask, dask_awkward):
+        ak_norm_files = job.array
+        # guard files_per_batch<1 so the dask backend matches the iterative/futures batching
+        # (which clamp via max(1, files_per_batch)) instead of dividing by zero
+        files_per_batch = max(1, job.files_per_batch)
+        dak_norm_files = dask_awkward.from_awkward(
+            ak_norm_files, math.ceil(len(ak_norm_files) / files_per_batch)
+        )
+
+        concat_fn = partial(awkward.concatenate, axis=0)
+        split_every = self.split_every
+
+        files_trl_label = f"preprocess-{name}"
+        files_trl_token = dask.base.tokenize(dak_norm_files, concat_fn, split_every)
+        files_trl_name = f"{files_trl_label}-{files_trl_token}"
+        files_trl_tree_node_name = f"{files_trl_label}-tree-node-{files_trl_token}"
+
+        files_part = dask_awkward.map_partitions(
+            job.map_fn,
+            dak_norm_files,
+            meta=dask_awkward.lib.core.empty_typetracer(),
+        )
+
+        files_trl = dask_awkward.layers.layers.AwkwardTreeReductionLayer(
+            name=files_trl_name,
+            name_input=files_part.name,
+            npartitions_input=files_part.npartitions,
+            concat_func=concat_fn,
+            tree_node_func=lambda x: x,
+            finalize_func=lambda x: x,
+            split_every=split_every,
+            tree_node_name=files_trl_tree_node_name,
+        )
+
+        files_graph = dask.highlevelgraph.HighLevelGraph.from_collections(
+            files_trl_name, files_trl, dependencies=[files_part]
+        )
+
+        return dask_awkward.lib.core.new_array_object(
+            files_graph,
+            files_trl_name,
+            meta=dask_awkward.lib.core.empty_typetracer(),
+            npartitions=len(files_trl.output_partitions),
+        )
+
+    def submit(self, jobs: Mapping[str, PreprocessJob]) -> PreprocessTask:
+        dask = _import_dask()
+        dask_awkward = _import_dask_awkward()
+        collections = {
+            name: self._build_collection(name, job, dask, dask_awkward)
+            for name, job in jobs.items()
+        }
+        return _DaskTask(collections, self.scheduler)
+
+
+def resolve_backend(
+    backend: str | PreprocessBackend | None,
+    scheduler: None | Callable | str = None,
+) -> PreprocessBackend:
+    """Turn a ``backend`` selector into a :class:`PreprocessBackend` instance.
+
+    ``backend`` may be an existing :class:`PreprocessBackend` (returned as-is), or one of the
+    strings ``"dask"`` (default), ``"iterative"``, or ``"futures"``. ``scheduler`` is forwarded
+    to a default-constructed :class:`DaskBackend`; if it is set while a non-dask backend is
+    selected, a warning is issued because it has no effect there.
+    """
+    if isinstance(backend, PreprocessBackend):
+        # A pre-built instance is used as-is; we cannot inject `scheduler` into it (even a
+        # DaskBackend instance keeps its own scheduler), so warn rather than silently drop it.
+        if scheduler is not None:
+            warnings.warn(
+                "The 'scheduler' argument is ignored when a PreprocessBackend instance is "
+                "passed; set it on the instance, e.g. DaskBackend(scheduler=...).",
+                stacklevel=2,
+            )
+        return backend
+
+    if backend is None or backend == "dask":
+        return DaskBackend(scheduler=scheduler)
+
+    if scheduler is not None:
+        warnings.warn(
+            "The 'scheduler' argument only affects the dask backend and is ignored here.",
+            stacklevel=2,
+        )
+    if backend == "iterative":
+        return IterativeBackend()
+    if backend == "futures":
+        return FuturesBackend()
+    raise ValueError(
+        f"Unknown preprocessing backend {backend!r}; expected 'dask', 'iterative', "
+        "'futures', or a PreprocessBackend instance."
+    )
+
+
+def print_dask_backend_fallback_hint() -> None:
+    """Print (via ``coffea_console``) a hint that dask-free backends exist.
+
+    Called when the default dask backend fails because dask / dask-awkward are not importable.
+    """
+    coffea_console.print(
+        "[bold red]The dask preprocessing backend is unavailable because dask / dask-awkward "
+        "could not be imported.[/bold red]\n"
+        "Preprocessing can run without dask for parquet and TTree ROOT input: pass "
+        "[bold]backend='iterative'[/bold] (single process) or [bold]backend='futures'[/bold] "
+        "(thread pool) to preprocess() and the format-specific preprocess_* functions. "
+        "(RNTuple form extraction with save_form=True still needs dask.)"
+    )

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -30,6 +30,108 @@ from coffea.util import (
 )
 
 
+def _even_steps(num_entries: int, target_step_size: int) -> numpy.ndarray:
+    """Split ``num_entries`` into as-even-as-possible ``[start, stop]`` steps of ~target size."""
+    n_steps_target = max(round(num_entries / target_step_size), 1)
+    actual_step_size = math.ceil(num_entries / n_steps_target)
+    return numpy.array(
+        [
+            [i * actual_step_size, min((i + 1) * actual_step_size, num_entries)]
+            for i in range(n_steps_target)
+        ],
+        dtype="int64",
+    )
+
+
+def _aligned_steps(
+    boundaries,
+    target_step_size: int,
+    step_size_safety_factor: float,
+    file_label: str,
+    mode_label: str,
+) -> numpy.ndarray:
+    """Build ``[start, stop]`` steps that snap to natural boundaries (TTree clusters, RNTuple
+    cluster summaries, or parquet row groups).
+
+    ``boundaries`` is the increasing sequence of absolute entry offsets at which a step is
+    allowed to end, with the final element equal to ``num_entries``. Steps accumulate
+    boundaries until at least ``target_step_size`` entries are covered. ``mode_label`` is the
+    name of the user-facing option (``align_clusters`` or ``use_row_groups``) used in the
+    over-size warning.
+    """
+    out = [0]
+    for c in boundaries:
+        if c >= out[-1] + target_step_size:
+            out.append(c)
+    if boundaries[-1] != out[-1]:
+        out.append(boundaries[-1])
+    out = numpy.array(out, dtype="int64")
+    out = numpy.stack((out[:-1], out[1:]), axis=1)
+
+    step_mask = out[:, 1] - out[:, 0] > (1 + step_size_safety_factor) * target_step_size
+    if numpy.any(step_mask):
+        warnings.warn(
+            f"In file {file_label}, steps: {out[step_mask]} with {mode_label}=True are "
+            f"{step_size_safety_factor*100:.0f}% larger than target "
+            f"step size: {target_step_size}!"
+        )
+    return out
+
+
+def _rntuple_cluster_boundaries(rntuple, num_entries: int) -> list[int]:
+    """Absolute entry offsets at RNTuple cluster boundaries, terminating at ``num_entries``."""
+    boundaries = [cluster.num_first_entry for cluster in rntuple.cluster_summaries]
+    boundaries.append(num_entries)
+    return boundaries
+
+
+def _union_form_jsonstr(forms: list) -> str | None:
+    """Compute the union form (as a JSON string) over a list of awkward forms.
+
+    The input list is consumed. Returns None if the list is empty. Mirrors the merging of
+    flat-tuple-like schemas used when building a dataset's union form across files.
+    """
+    union_array = None
+    while len(forms):
+        new_array = awkward.Array(forms.pop().length_zero_array())
+        if union_array is None:
+            union_array = new_array
+        else:
+            union_array = awkward.to_packed(
+                awkward.merge_union_of_records(
+                    awkward.concatenate([union_array, new_array]), axis=0
+                )
+            )
+            union_array.layout.parameters.update(new_array.layout.parameters)
+    if union_array is None:
+        return None
+
+    union_form = union_array.layout.form
+    for icontent, content in enumerate(union_form.contents):
+        if isinstance(content, awkward.forms.IndexedOptionForm):
+            if (
+                not isinstance(content.content, awkward.forms.NumpyForm)
+                or content.content.primitive != "bool"
+            ):
+                raise ValueError(
+                    "IndexedOptionArrays can only contain NumpyArrays of "
+                    "bools in mergers of flat-tuple-like schemas!"
+                )
+            parameters = (
+                content.content.parameters.copy()
+                if content.content.parameters is not None
+                else {}
+            )
+            # re-create IndexOptionForm with parameters of lower level array
+            union_form.contents[icontent] = awkward.forms.IndexedOptionForm(
+                content.index,
+                content.content,
+                parameters=parameters,
+                form_key=content.form_key,
+            )
+    return union_form.to_json()
+
+
 def get_steps(
     normed_files: awkward.Array | dask_awkward.Array,
     step_size: int | None = None,
@@ -41,6 +143,7 @@ def get_steps(
     step_size_safety_factor: float = 0.5,
     uproot_options: dict = {},
     legacy_form_key: bool = True,
+    require_rntuple: bool = False,
 ) -> awkward.Array | dask_awkward.Array:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
@@ -69,6 +172,9 @@ def get_steps(
         legacy_form_key : bool, default True
             Use "form" for the compressed form key in the output for backwards compatibility.
             Set to False to use "compressed_form" instead.
+        require_rntuple : bool, default False
+            If True, require every object to be an RNTuple and raise a ValueError otherwise.
+            If False, TTree and RNTuple objects are auto-detected and handled transparently.
 
     Returns
     -------
@@ -91,21 +197,42 @@ def get_steps(
             else:
                 raise e
 
+        is_rntuple = isinstance(tree, uproot.behaviors.RNTuple.HasFields)
+        if require_rntuple and not is_rntuple:
+            raise ValueError(
+                f"require_rntuple=True but {arg.object_path!r} in {arg.file!r} is a "
+                f"{type(tree).__name__}, not an RNTuple."
+            )
+
         num_entries = tree.num_entries
 
         form_json = None
         form_hash = None
         if save_form:
-            form_str = uproot.dask(
-                tree,
-                ak_add_doc={"__doc__": "title", "typename": "typename"},
-                filter_name=no_filter,
-                filter_typename=no_filter,
-                filter_branch=partial(_is_interpretable, emit_warning=False),
-            ).layout.form.to_json()
+            if is_rntuple:
+                # uproot.dask cannot build a form from an already-opened RNTuple object, so
+                # the file/object spec must be passed (it does not re-read event data here).
+                form_dask = uproot.dask(
+                    {arg.file: arg.object_path},
+                    open_files=False,
+                    full_paths=True,
+                    ak_add_doc={"__doc__": "title", "typename": "typename"},
+                    filter_name=no_filter,
+                    filter_typename=no_filter,
+                    filter_branch=partial(_is_interpretable, emit_warning=False),
+                )
+            else:
+                form_dask = uproot.dask(
+                    tree,
+                    ak_add_doc={"__doc__": "title", "typename": "typename"},
+                    filter_name=no_filter,
+                    filter_typename=no_filter,
+                    filter_branch=partial(_is_interpretable, emit_warning=False),
+                )
+            form_str = form_dask.layout.form.to_json()
             # the function cache needs to be popped if present to prevent memory growth
             dask = _import_dask()
-            if hasattr(dask.base, "function_cache"):
+            if getattr(dask.base, "function_cache", None):
                 dask.base.function_cache.popitem()
 
             form_hash = hashlib.md5(form_str.encode("utf-8")).hexdigest()
@@ -134,40 +261,19 @@ def get_steps(
 
         if out_uuid != file_uuid or recalculate_steps:
             if align_clusters:
-                clusters = tree.common_entry_offsets()
-                out = [0]
-                for c in clusters:
-                    if c >= out[-1] + target_step_size:
-                        out.append(c)
-                if clusters[-1] != out[-1]:
-                    out.append(clusters[-1])
-                out = numpy.array(out, dtype="int64")
-                out = numpy.stack((out[:-1], out[1:]), axis=1)
-
-                step_mask = (
-                    out[:, 1] - out[:, 0]
-                    > (1 + step_size_safety_factor) * target_step_size
+                if is_rntuple:
+                    boundaries = _rntuple_cluster_boundaries(tree, num_entries)
+                else:
+                    boundaries = tree.common_entry_offsets()
+                out = _aligned_steps(
+                    boundaries,
+                    target_step_size,
+                    step_size_safety_factor,
+                    arg.file,
+                    "align_clusters",
                 )
-                if numpy.any(step_mask):
-                    warnings.warn(
-                        f"In file {arg.file}, steps: {out[step_mask]} with align_clusters=True are "
-                        f"{step_size_safety_factor*100:.0f}% larger than target "
-                        f"step size: {target_step_size}!"
-                    )
-
             else:
-                n_steps_target = max(round(num_entries / target_step_size), 1)
-                actual_step_size = math.ceil(num_entries / n_steps_target)
-                out = numpy.array(
-                    [
-                        [
-                            i * actual_step_size,
-                            min((i + 1) * actual_step_size, num_entries),
-                        ]
-                        for i in range(n_steps_target)
-                    ],
-                    dtype="int64",
-                )
+                out = _even_steps(num_entries, target_step_size)
 
             out_uuid = file_uuid
             out_steps = out.tolist()
@@ -413,7 +519,7 @@ def preprocess_legacy(
         ):
             # skip trivially filled or empty files
             form = awkward.forms.from_json(decompress_form(formstr))
-            if num_entries >= 0 and set(form.fields) != _trivial_file_fields:
+            if set(form.fields) != _trivial_file_fields:
                 dataset_forms.append(form)
             else:
                 warnings.warn(
@@ -425,46 +531,7 @@ def preprocess_legacy(
                     ", by default, removes empty files each dataset in a fileset."
                 )
 
-        union_array = None
-        union_form_jsonstr = None
-        while len(dataset_forms):
-            new_array = awkward.Array(dataset_forms.pop().length_zero_array())
-            if union_array is None:
-                union_array = new_array
-            else:
-                union_array = awkward.to_packed(
-                    awkward.merge_union_of_records(
-                        awkward.concatenate([union_array, new_array]), axis=0
-                    )
-                )
-                union_array.layout.parameters.update(new_array.layout.parameters)
-        if union_array is not None:
-            union_form = union_array.layout.form
-
-            for icontent, content in enumerate(union_form.contents):
-                if isinstance(content, awkward.forms.IndexedOptionForm):
-                    if (
-                        not isinstance(content.content, awkward.forms.NumpyForm)
-                        or content.content.primitive != "bool"
-                    ):
-                        raise ValueError(
-                            "IndexedOptionArrays can only contain NumpyArrays of "
-                            "bools in mergers of flat-tuple-like schemas!"
-                        )
-                    parameters = (
-                        content.content.parameters.copy()
-                        if content.content.parameters is not None
-                        else {}
-                    )
-                    # re-create IndexOptionForm with parameters of lower level array
-                    union_form.contents[icontent] = awkward.forms.IndexedOptionForm(
-                        content.index,
-                        content.content,
-                        parameters=parameters,
-                        form_key=content.form_key,
-                    )
-
-            union_form_jsonstr = union_form.to_json()
+        union_form_jsonstr = _union_form_jsonstr(dataset_forms)
 
         files_available = {
             item["file"]: {
@@ -567,7 +634,7 @@ def get_parquet_form_uuid_steps(
         file_exceptions : Exception | Warning | tuple[Exception | Warning], default (OSError,)
             What exceptions to catch when skipping bad files.
         save_form : bool, default False
-            Extract the form of the parquet file so we can skip opening files later.
+            Extract the form from the parquet metadata so we can skip opening files later.
         step_size_safety_factor : float, default 0.5
             When using use_row_groups, if a resulting step is larger than step_size by this factor
             warn the user that the resulting steps may be highly irregular.
@@ -596,8 +663,11 @@ def get_parquet_form_uuid_steps(
         form_json = None
         form_hash = None
         if save_form:
+            # parquet metadata already carries the form; reading it builds no dask graph,
+            # so (unlike the TTree/RNTuple path) there is no function cache to pop here.
             form = the_file["form"]
             form_str = form.to_json()
+
             form_hash = hashlib.md5(form_str.encode("utf-8")).hexdigest()
             form_json = compress_form(form_str)
 
@@ -624,41 +694,17 @@ def get_parquet_form_uuid_steps(
 
         if out_uuid != file_uuid or recalculate_steps:
             if use_row_groups:
-                row_group_entries = the_file["col_counts"]
-                out = [0]
-                this_offset = 0
-                for c in row_group_entries:
-                    this_offset += c
-                    if this_offset >= out[-1] + target_step_size:
-                        out.append(this_offset)
-                if this_offset != out[-1]:
-                    out.append(this_offset)
-                out = numpy.array(out, dtype="int64")
-                out = numpy.stack((out[:-1], out[1:]), axis=1)
-
-                step_mask = (
-                    out[:, 1] - out[:, 0]
-                    > (1 + step_size_safety_factor) * target_step_size
+                # cumulative row counts give the absolute offset at each row-group boundary
+                boundaries = numpy.cumsum(the_file["col_counts"]).tolist()
+                out = _aligned_steps(
+                    boundaries,
+                    target_step_size,
+                    step_size_safety_factor,
+                    arg.file,
+                    "use_row_groups",
                 )
-                if numpy.any(step_mask):
-                    warnings.warn(
-                        f"In file {arg.file}, steps: {out[step_mask]} with use_row_groups=True are "
-                        f"{step_size_safety_factor*100:.0f}% larger than target "
-                        f"step size: {target_step_size}!"
-                    )
             else:
-                n_steps_target = max(round(num_entries / target_step_size), 1)
-                actual_step_size = math.ceil(num_entries / n_steps_target)
-                out = numpy.array(
-                    [
-                        [
-                            i * actual_step_size,
-                            min((i + 1) * actual_step_size, num_entries),
-                        ]
-                        for i in range(n_steps_target)
-                    ],
-                    dtype="int64",
-                )
+                out = _even_steps(num_entries, target_step_size)
 
             out_uuid = file_uuid
             out_steps = out.tolist()
@@ -722,6 +768,9 @@ def preprocess_root(
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
 
+    Both TTree and RNTuple objects are auto-detected and handled; use :func:`preprocess_rntuple`
+    if you want to require that every object is an RNTuple.
+
     Parameters
     ----------
         datagroupspec : DataGroupSpec
@@ -773,6 +822,85 @@ def preprocess_root(
         filetype_options=uproot_options,
         step_size_safety_factor=step_size_safety_factor,
         allow_empty_datasets=allow_empty_datasets,
+    )
+
+
+def preprocess_rntuple(
+    datagroupspec: DataGroupSpec,
+    step_size: None | int = None,
+    align_clusters: bool = False,
+    recalculate_steps: bool = False,
+    files_per_batch: int = 1,
+    skip_bad_files: bool = False,
+    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
+    save_form: bool = True,
+    scheduler: None | Callable | str = None,
+    uproot_options: dict = {},
+    step_size_safety_factor: float = 0.5,
+    allow_empty_datasets: bool = False,
+) -> tuple[DataGroupSpec, DataGroupSpec]:
+    """
+    Preprocess datasets of ROOT files containing RNTuples, determining the steps for each file.
+
+    This is the RNTuple-specific counterpart to :func:`preprocess_root` (which is implicitly
+    TTree-oriented) and :func:`preprocess_parquet`. It requires every object to be an RNTuple
+    and raises a ValueError if a TTree is encountered, making it useful to assert the intended
+    file type. ``preprocess`` and ``preprocess_root`` already auto-detect and handle RNTuples
+    transparently, so this function is primarily for RNTuple-only workflows that want the
+    stricter contract.
+
+    Parameters
+    ----------
+        datagroupspec : DataGroupSpec
+            The set of datasets whose files will be preprocessed.
+        step_size : int or None, default None
+            If specified, the size of the steps to make when analyzing the input files.
+        align_clusters : bool, default False
+            Round to the RNTuple cluster boundaries when chunks are specified. Reduces data
+            transfer in analysis.
+        recalculate_steps : bool, default False
+            If steps are present in the input normed files, force the recalculation of those steps,
+            instead of only recalculating the steps if the uuid has changed.
+        files_per_batch : int, default 1
+            The number of files to preprocess in a single batch.
+            Large values will result in fewer dask tasks but each task will have to do more work.
+        skip_bad_files : bool, default False
+            Instead of failing, catch exceptions specified by file_exceptions and return null data.
+        file_exceptions : Exception or Warning or tuple[Exception or Warning], default (OSError,)
+            What exceptions to catch when skipping bad files.
+        save_form : bool, default True
+            Extract the form of the RNTuple from each file in each dataset, creating the union of the forms over the dataset.
+        scheduler : None or Callable or str, default None
+            Specifies the scheduler that dask should use to execute the preprocessing task graph.
+        uproot_options : dict, default {}
+            Options to pass to get_steps for opening files with uproot.
+        step_size_safety_factor : float, default 0.5
+            When using align_clusters, if a resulting step is larger than step_size by this factor
+            warn the user that the resulting steps may be highly irregular.
+        allow_empty_datasets : bool, default False
+            When a dataset query comes back completely empty, this is normally considered a processing error.
+            Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+    Returns
+    -------
+        out_available : DataGroupSpec
+            The subset of files in each dataset that were successfully preprocessed, organized by dataset.
+        out_updated : DataGroupSpec
+            The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
+    """
+    return _preprocess_pydantic(
+        datagroupspec=datagroupspec,
+        step_size=step_size,
+        use_alignment_boundaries=align_clusters,
+        recalculate_steps=recalculate_steps,
+        files_per_batch=files_per_batch,
+        skip_bad_files=skip_bad_files,
+        file_exceptions=file_exceptions,
+        save_form=save_form,
+        scheduler=scheduler,
+        filetype_options=uproot_options,
+        step_size_safety_factor=step_size_safety_factor,
+        allow_empty_datasets=allow_empty_datasets,
+        require_rntuple=True,
     )
 
 
@@ -856,6 +984,7 @@ def _preprocess_pydantic(
     filetype_options: dict = {},
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
+    require_rntuple: bool = False,
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Internal function to preprocess either ROOT or parquet DatasetSpecs in a DataGroupSpec.
@@ -909,6 +1038,8 @@ def _preprocess_pydantic(
         raise ValueError(
             f"_preprocess_pydantic expects a DataGroupSpec, got {type(datagroupspec)}"
         )
+    if len(datagroupspec) == 0:
+        return DataGroupSpec({}), DataGroupSpec({})
 
     dask = _import_dask()
     dask_awkward = _import_dask_awkward()
@@ -956,6 +1087,7 @@ def _preprocess_pydantic(
                 step_size_safety_factor=step_size_safety_factor,
                 legacy_form_key=False,  # in the pydantic preprocess function, the output form key is always "compressed_form", "form" is a method to extract the uncompressed form
                 uproot_options=filetype_options,
+                require_rntuple=require_rntuple,
                 meta=dask_awkward.lib.core.empty_typetracer(),
             )
         elif info.format == "parquet":
@@ -1037,7 +1169,7 @@ def _preprocess_pydantic(
         ):
             # skip trivially filled or empty files
             form = awkward.forms.from_json(decompress_form(formstr))
-            if num_entries >= 0 and set(form.fields) != _trivial_file_fields:
+            if set(form.fields) != _trivial_file_fields:
                 dataset_forms.append(form)
             else:
                 warnings.warn(
@@ -1049,46 +1181,7 @@ def _preprocess_pydantic(
                     ", by default, removes empty files each dataset in a fileset."
                 )
 
-        union_array = None
-        union_form_jsonstr = None
-        while len(dataset_forms):
-            new_array = awkward.Array(dataset_forms.pop().length_zero_array())
-            if union_array is None:
-                union_array = new_array
-            else:
-                union_array = awkward.to_packed(
-                    awkward.merge_union_of_records(
-                        awkward.concatenate([union_array, new_array]), axis=0
-                    )
-                )
-                union_array.layout.parameters.update(new_array.layout.parameters)
-        if union_array is not None:
-            union_form = union_array.layout.form
-
-            for icontent, content in enumerate(union_form.contents):
-                if isinstance(content, awkward.forms.IndexedOptionForm):
-                    if (
-                        not isinstance(content.content, awkward.forms.NumpyForm)
-                        or content.content.primitive != "bool"
-                    ):
-                        raise ValueError(
-                            "IndexedOptionArrays can only contain NumpyArrays of "
-                            "bools in mergers of flat-tuple-like schemas!"
-                        )
-                    parameters = (
-                        content.content.parameters.copy()
-                        if content.content.parameters is not None
-                        else {}
-                    )
-                    # re-create IndexOptionForm with parameters of lower level array
-                    union_form.contents[icontent] = awkward.forms.IndexedOptionForm(
-                        content.index,
-                        content.content,
-                        parameters=parameters,
-                        form_key=content.form_key,
-                    )
-
-            union_form_jsonstr = union_form.to_json()
+        union_form_jsonstr = _union_form_jsonstr(dataset_forms)
 
         files_available = {
             item["file"]: {

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -16,6 +16,22 @@ import numpy
 import uproot
 from uproot._util import no_filter
 
+try:
+    # Private uproot helper that builds a TTree's awkward form without dask. It is exactly what
+    # uproot.dask() uses internally, so the result is byte-identical to
+    # uproot.dask(tree).layout.form (verified in the test suite). Guarded so a uproot release
+    # that moves or renames it degrades gracefully to the dask-based path below.
+    from uproot._dask import _get_ttree_form as _uproot_get_ttree_form
+except Exception:  # pragma: no cover - depends on uproot internals
+    _uproot_get_ttree_form = None
+
+from coffea.dataset_tools.backends import (
+    DaskBackend,
+    PreprocessBackend,
+    PreprocessJob,
+    print_dask_backend_fallback_hint,
+    resolve_backend,
+)
 from coffea.dataset_tools.filespec import (
     DataGroupSpec,
     DatasetSpec,
@@ -132,6 +148,63 @@ def _union_form_jsonstr(forms: list) -> str | None:
     return union_form.to_json()
 
 
+_FORM_AK_ADD_DOC = {"__doc__": "title", "typename": "typename"}
+
+
+def _ttree_form_json(tree) -> str:
+    """Build a TTree's awkward form JSON without importing dask.
+
+    Reuses uproot's own form builder (``uproot._dask._get_ttree_form``), so the output is
+    byte-identical to ``uproot.dask(tree).layout.form.to_json()``. This is what lets the
+    ``iterative``/``futures`` backends extract TTree forms in a dask-free environment.
+    """
+    common_keys = tree.keys(
+        recursive=True,
+        filter_name=no_filter,
+        filter_typename=no_filter,
+        filter_branch=partial(_is_interpretable, emit_warning=False),
+        ignore_duplicates=True,
+    )
+    base_form = _uproot_get_ttree_form(awkward, tree, common_keys, _FORM_AK_ADD_DOC)
+    return base_form.to_json()
+
+
+def _dask_form_json(uproot_target, is_rntuple: bool) -> str:
+    """Build a form JSON via ``uproot.dask`` (requires dask).
+
+    Used for RNTuples -- whose form the dask path derives with transforms (dropping
+    ``_collection*`` subfields, nulling form keys, applying ``ak_add_doc``) that are not cheaply
+    reproducible without dask -- and as a fallback for TTrees when the private uproot form
+    builder is unavailable. ``uproot_target`` is an already-open TTree object, or a
+    ``{file: object_path}`` mapping (required for RNTuples, which cannot build a form from an
+    already-open object).
+    """
+    if is_rntuple:
+        form_dask = uproot.dask(
+            uproot_target,
+            open_files=False,
+            full_paths=True,
+            ak_add_doc=_FORM_AK_ADD_DOC,
+            filter_name=no_filter,
+            filter_typename=no_filter,
+            filter_branch=partial(_is_interpretable, emit_warning=False),
+        )
+    else:
+        form_dask = uproot.dask(
+            uproot_target,
+            ak_add_doc=_FORM_AK_ADD_DOC,
+            filter_name=no_filter,
+            filter_typename=no_filter,
+            filter_branch=partial(_is_interpretable, emit_warning=False),
+        )
+    form_str = form_dask.layout.form.to_json()
+    # the function cache needs to be popped if present to prevent memory growth
+    dask = _import_dask()
+    if getattr(dask.base, "function_cache", None):
+        dask.base.function_cache.popitem()
+    return form_str
+
+
 def get_steps(
     normed_files: awkward.Array | dask_awkward.Array,
     step_size: int | None = None,
@@ -209,31 +282,15 @@ def get_steps(
         form_json = None
         form_hash = None
         if save_form:
-            if is_rntuple:
-                # uproot.dask cannot build a form from an already-opened RNTuple object, so
-                # the file/object spec must be passed (it does not re-read event data here).
-                form_dask = uproot.dask(
-                    {arg.file: arg.object_path},
-                    open_files=False,
-                    full_paths=True,
-                    ak_add_doc={"__doc__": "title", "typename": "typename"},
-                    filter_name=no_filter,
-                    filter_typename=no_filter,
-                    filter_branch=partial(_is_interpretable, emit_warning=False),
-                )
+            if not is_rntuple and _uproot_get_ttree_form is not None:
+                # dask-free TTree form extraction; byte-identical to the uproot.dask form
+                form_str = _ttree_form_json(tree)
+            elif is_rntuple:
+                # RNTuple form extraction still goes through uproot.dask (requires dask)
+                form_str = _dask_form_json({arg.file: arg.object_path}, is_rntuple=True)
             else:
-                form_dask = uproot.dask(
-                    tree,
-                    ak_add_doc={"__doc__": "title", "typename": "typename"},
-                    filter_name=no_filter,
-                    filter_typename=no_filter,
-                    filter_branch=partial(_is_interpretable, emit_warning=False),
-                )
-            form_str = form_dask.layout.form.to_json()
-            # the function cache needs to be popped if present to prevent memory growth
-            dask = _import_dask()
-            if getattr(dask.base, "function_cache", None):
-                dask.base.function_cache.popitem()
+                # uproot without the private form builder: fall back to the dask-based path
+                form_str = _dask_form_json(tree, is_rntuple=False)
 
             form_hash = hashlib.md5(form_str.encode("utf-8")).hexdigest()
             form_json = compress_form(form_str)
@@ -675,6 +732,22 @@ def get_parquet_form_uuid_steps(
 
         file_uuid = the_file.get("uuid", None)
 
+        # Mirror the ROOT get_steps num_entries==0 guard: a 0-row file would otherwise reach
+        # _even_steps(0, 0) (division by zero) or _aligned_steps on empty row-group boundaries.
+        if num_entries == 0:
+            array.append(
+                {
+                    "file": arg.file,
+                    "object_path": arg.object_path,
+                    "steps": [[0, 0]],
+                    "num_entries": num_entries,
+                    "uuid": file_uuid,
+                    "compressed_form": form_json,
+                    "form_hash_md5": form_hash,
+                }
+            )
+            continue
+
         out_uuid = arg.uuid
         out_steps = arg.steps
 
@@ -764,6 +837,7 @@ def preprocess_root(
     uproot_options: dict = {},
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
+    backend: str | PreprocessBackend = "dask",
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
@@ -802,6 +876,10 @@ def preprocess_root(
         allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+        backend : str or PreprocessBackend, default "dask"
+            Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
+            synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
+            PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
     Returns
     -------
         out_available : DataGroupSpec
@@ -822,6 +900,7 @@ def preprocess_root(
         filetype_options=uproot_options,
         step_size_safety_factor=step_size_safety_factor,
         allow_empty_datasets=allow_empty_datasets,
+        backend=backend,
     )
 
 
@@ -838,6 +917,7 @@ def preprocess_rntuple(
     uproot_options: dict = {},
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
+    backend: str | PreprocessBackend = "dask",
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Preprocess datasets of ROOT files containing RNTuples, determining the steps for each file.
@@ -880,6 +960,10 @@ def preprocess_rntuple(
         allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+        backend : str or PreprocessBackend, default "dask"
+            Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
+            synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
+            PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
     Returns
     -------
         out_available : DataGroupSpec
@@ -901,6 +985,7 @@ def preprocess_rntuple(
         step_size_safety_factor=step_size_safety_factor,
         allow_empty_datasets=allow_empty_datasets,
         require_rntuple=True,
+        backend=backend,
     )
 
 
@@ -917,6 +1002,7 @@ def preprocess_parquet(
     parquet_options: dict = {},
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
+    backend: str | PreprocessBackend = "dask",
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Given a list of normalized files, determine the form, steps, and add the metadata for each file according to the supplied processing options.
@@ -948,6 +1034,10 @@ def preprocess_parquet(
         allow_empty_datasets : bool, default False
             When a dataset query comes back completely empty, this is normally considered a processing error.
             Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
+        backend : str or PreprocessBackend, default "dask"
+            Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
+            synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
+            PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
     Returns
     -------
         out_available : DataGroupSpec
@@ -968,6 +1058,7 @@ def preprocess_parquet(
         filetype_options=parquet_options,
         step_size_safety_factor=step_size_safety_factor,
         allow_empty_datasets=allow_empty_datasets,
+        backend=backend,
     )
 
 
@@ -985,6 +1076,7 @@ def _preprocess_pydantic(
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
     require_rntuple: bool = False,
+    backend: str | PreprocessBackend = "dask",
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Internal function to preprocess either ROOT or parquet DatasetSpecs in a DataGroupSpec.
@@ -1019,6 +1111,11 @@ def _preprocess_pydantic(
             Warn if aligned steps exceed target by this factor.
         allow_empty_datasets : bool, default False
             If True, warn instead of raising when a dataset has no accessible files.
+        backend : str or PreprocessBackend, default "dask"
+            Execution backend for the per-dataset map-reduce. One of "dask" (default),
+            "iterative" (immediate, synchronous, dask-free), "futures" (a dask-free
+            concurrent.futures thread pool), or a PreprocessBackend instance for full control.
+            ``scheduler`` only affects the dask backend.
 
     Returns
     -------
@@ -1041,14 +1138,14 @@ def _preprocess_pydantic(
     if len(datagroupspec) == 0:
         return DataGroupSpec({}), DataGroupSpec({})
 
-    dask = _import_dask()
-    dask_awkward = _import_dask_awkward()
-
     out_updated = datagroupspec.model_dump()
     out_available = datagroupspec.model_dump()
 
+    # Build one map-reduce job per dataset. The map worker (get_steps /
+    # get_parquet_form_uuid_steps) and the concatenating reduce are backend-agnostic; only the
+    # execution strategy (dask graph vs. futures vs. synchronous) is selected via `backend`.
     all_ak_norm_files = {}
-    files_to_preprocess = {}
+    jobs = {}
     for name, info in datagroupspec.items():
         norm_files = _normalize_pydantic_file_info(info)
         fields = ["file", "object_path", "steps", "num_entries", "uuid"]
@@ -1058,26 +1155,9 @@ def _preprocess_pydantic(
         )
         all_ak_norm_files[name] = ak_norm_files
 
-        dak_norm_files = dask_awkward.from_awkward(
-            ak_norm_files, math.ceil(len(ak_norm_files) / files_per_batch)
-        )
-
-        concat_fn = partial(
-            awkward.concatenate,
-            axis=0,
-        )
-
-        split_every = 8
-
-        files_trl_label = f"preprocess-{name}"
-        files_trl_token = dask.base.tokenize(dak_norm_files, concat_fn, split_every)
-        files_trl_name = f"{files_trl_label}-{files_trl_token}"
-        files_trl_tree_node_name = f"{files_trl_label}-tree-node-{files_trl_token}"
-
         if info.format == "root":
-            files_part = dask_awkward.map_partitions(
+            map_fn = partial(
                 get_steps,
-                dak_norm_files,
                 step_size=step_size,
                 align_clusters=use_alignment_boundaries,
                 recalculate_steps=recalculate_steps,
@@ -1088,12 +1168,10 @@ def _preprocess_pydantic(
                 legacy_form_key=False,  # in the pydantic preprocess function, the output form key is always "compressed_form", "form" is a method to extract the uncompressed form
                 uproot_options=filetype_options,
                 require_rntuple=require_rntuple,
-                meta=dask_awkward.lib.core.empty_typetracer(),
             )
         elif info.format == "parquet":
-            files_part = dask_awkward.map_partitions(
+            map_fn = partial(
                 get_parquet_form_uuid_steps,
-                dak_norm_files,
                 step_size=step_size,
                 use_row_groups=use_alignment_boundaries,
                 recalculate_steps=recalculate_steps,
@@ -1102,36 +1180,28 @@ def _preprocess_pydantic(
                 save_form=save_form,
                 step_size_safety_factor=step_size_safety_factor,
                 parquet_options=filetype_options,
-                meta=dask_awkward.lib.core.empty_typetracer(),
             )
         else:
             raise ValueError(
                 f"Dataset {name} has unsupported format {info.format}, supported formats are 'root' and 'parquet'."
             )
 
-        files_trl = dask_awkward.layers.layers.AwkwardTreeReductionLayer(
-            name=files_trl_name,
-            name_input=files_part.name,
-            npartitions_input=files_part.npartitions,
-            concat_func=concat_fn,
-            tree_node_func=lambda x: x,
-            finalize_func=lambda x: x,
-            split_every=split_every,
-            tree_node_name=files_trl_tree_node_name,
+        jobs[name] = PreprocessJob(
+            array=ak_norm_files, map_fn=map_fn, files_per_batch=files_per_batch
         )
 
-        files_graph = dask.highlevelgraph.HighLevelGraph.from_collections(
-            files_trl_name, files_trl, dependencies=[files_part]
-        )
-
-        files_to_preprocess[name] = dask_awkward.lib.core.new_array_object(
-            files_graph,
-            files_trl_name,
-            meta=dask_awkward.lib.core.empty_typetracer(),
-            npartitions=len(files_trl.output_partitions),
-        )
-
-    (all_processed_files,) = dask.compute(files_to_preprocess, scheduler=scheduler)
+    backend_obj = resolve_backend(backend, scheduler)
+    # Only submit() imports dask (for the dask backend); a ModuleNotFoundError here means the
+    # dask stack itself is missing, so we can point the user at the dask-free backends. Worker
+    # ImportErrors (e.g. a missing codec) surface later in result() and must NOT trigger the
+    # dask hint, so result() is called outside this guard.
+    try:
+        preprocess_task = backend_obj.submit(jobs)
+    except ModuleNotFoundError:
+        if isinstance(backend_obj, DaskBackend):
+            print_dask_backend_fallback_hint()
+        raise
+    all_processed_files = preprocess_task.result()
 
     for name, processed_files in all_processed_files.items():
 
@@ -1254,6 +1324,7 @@ def preprocess(
     preprocess_legacy_root: bool = False,
     use_row_groups: bool = False,
     parquet_options: dict = {},
+    backend: str | PreprocessBackend = "dask",
 ) -> tuple[DataGroupSpec, DataGroupSpec] | tuple[dict, dict]:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
@@ -1301,6 +1372,11 @@ def preprocess(
             Calculate steps according to the row_groups in the parquet files (only applies to DataGroupSpec datasets with parquet files).
         parquet_options : dict, default {}
             Options to pass to get_parquet_form_uuid_steps for opening parquet files (only applies to DataGroupSpec datasets with parquet files).
+        backend : str or PreprocessBackend, default "dask"
+            Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
+            synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
+            PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
+            Ignored when ``preprocess_legacy_root=True`` (the legacy path is always dask-based).
     Returns
     -------
         out_available : DataGroupSpec | dict
@@ -1384,6 +1460,7 @@ def preprocess(
             uproot_options=uproot_options,
             step_size_safety_factor=step_size_safety_factor,
             allow_empty_datasets=allow_empty_datasets,
+            backend=backend,
         )
         out_available_parquet, out_updated_parquet = preprocess_parquet(
             datasetspecs.filter_datasets(
@@ -1400,6 +1477,7 @@ def preprocess(
             parquet_options=parquet_options,
             step_size_safety_factor=step_size_safety_factor,
             allow_empty_datasets=allow_empty_datasets,
+            backend=backend,
         )
         # recombine outputs in original order, skipping datasets removed due to allow_empty_datasets.
         # The sub-results are already-validated DatasetSpec instances, so use model_construct to

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -46,6 +46,19 @@ from coffea.util import (
 )
 
 
+def _validate_step_size(step_size: int | None) -> None:
+    """Reject a non-positive ``step_size`` at the public entrypoints.
+
+    ``step_size`` is the number of entries per step; ``None`` means "one step per file". A value
+    < 1 is meaningless and would otherwise surface as a bare ``ZeroDivisionError`` from
+    ``_even_steps`` deep inside a worker (or dask graph).
+    """
+    if step_size is not None and step_size < 1:
+        raise ValueError(
+            f"step_size must be a positive integer (>= 1) or None, got {step_size!r}."
+        )
+
+
 def _even_steps(num_entries: int, target_step_size: int) -> numpy.ndarray:
     """Split ``num_entries`` into as-even-as-possible ``[start, stop]`` steps of ~target size."""
     n_steps_target = max(round(num_entries / target_step_size), 1)
@@ -468,6 +481,7 @@ def preprocess_legacy(
         out_updated : dict
             The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
     """
+    _validate_step_size(step_size)
     dask = _import_dask()
     dask_awkward = _import_dask_awkward()
 
@@ -1135,6 +1149,7 @@ def _preprocess_pydantic(
         raise ValueError(
             f"_preprocess_pydantic expects a DataGroupSpec, got {type(datagroupspec)}"
         )
+    _validate_step_size(step_size)
     if len(datagroupspec) == 0:
         return DataGroupSpec({}), DataGroupSpec({})
 

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -164,33 +164,63 @@ def _union_form_jsonstr(forms: list) -> str | None:
 _FORM_AK_ADD_DOC = {"__doc__": "title", "typename": "typename"}
 
 
-def _ttree_form_json(tree) -> str:
-    """Build a TTree's awkward form JSON without importing dask.
+def _null_form_keys(form):
+    """Return a copy of ``form`` with every ``form_key`` set to ``None``.
 
-    Reuses uproot's own form builder (``uproot._dask._get_ttree_form``), so the output is
-    byte-identical to ``uproot.dask(tree).layout.form.to_json()``. This is what lets the
-    ``iterative``/``futures`` backends extract TTree forms in a dask-free environment.
+    ``uproot.dask`` exposes its *meta* (typetracer) form, whose form keys are null, whereas
+    ``_get_ttree_form`` carries RNTuple column keys (``"column-N"``). Nulling the keys makes the
+    extracted form byte-identical to ``uproot.dask(...).layout.form`` and is a no-op for TTree
+    forms (already keyless). Implemented via the stable ``to_dict``/``from_dict`` round-trip.
     """
+    form_dict = form.to_dict()
+
+    def _strip(node):
+        if isinstance(node, dict):
+            if "form_key" in node:
+                node["form_key"] = None
+            for value in node.values():
+                _strip(value)
+        elif isinstance(node, list):
+            for value in node:
+                _strip(value)
+
+    _strip(form_dict)
+    return awkward.forms.from_dict(form_dict)
+
+
+def _awkward_form_json(tree, is_rntuple: bool) -> str:
+    """Build a TTree or RNTuple awkward form JSON without importing dask.
+
+    Reuses uproot's own form builder (``uproot._dask._get_ttree_form``, which handles both TTree
+    branches and RNTuple fields) and nulls the resulting form keys, producing output
+    byte-identical to ``uproot.dask(...).layout.form.to_json()``. This is what lets the
+    ``iterative``/``futures`` backends extract forms in a dask-free environment for both formats.
+
+    See the ``uproot-awkward-form-accessor`` dev note (a follow-up to expose a public uproot form
+    accessor) for how this should eventually collapse to a single public uproot call.
+    """
+    # RNTuples filter on fields and use full field paths; TTrees filter on branches.
+    filter_kwarg = "filter_field" if is_rntuple else "filter_branch"
     common_keys = tree.keys(
         recursive=True,
         filter_name=no_filter,
         filter_typename=no_filter,
-        filter_branch=partial(_is_interpretable, emit_warning=False),
+        full_paths=is_rntuple,
         ignore_duplicates=True,
+        **{filter_kwarg: partial(_is_interpretable, emit_warning=False)},
     )
     base_form = _uproot_get_ttree_form(awkward, tree, common_keys, _FORM_AK_ADD_DOC)
-    return base_form.to_json()
+    return _null_form_keys(base_form).to_json()
 
 
 def _dask_form_json(uproot_target, is_rntuple: bool) -> str:
     """Build a form JSON via ``uproot.dask`` (requires dask).
 
-    Used for RNTuples -- whose form the dask path derives with transforms (dropping
-    ``_collection*`` subfields, nulling form keys, applying ``ak_add_doc``) that are not cheaply
-    reproducible without dask -- and as a fallback for TTrees when the private uproot form
-    builder is unavailable. ``uproot_target`` is an already-open TTree object, or a
+    Fallback used only when uproot's internal form builder (``_get_ttree_form``) is unavailable
+    (an unexpected uproot version); the dask-free :func:`_awkward_form_json` is preferred for both
+    TTree and RNTuple. ``uproot_target`` is an already-open TTree object, or a
     ``{file: object_path}`` mapping (required for RNTuples, which cannot build a form from an
-    already-open object).
+    already-open object via ``uproot.dask``).
     """
     if is_rntuple:
         form_dask = uproot.dask(
@@ -295,14 +325,13 @@ def get_steps(
         form_json = None
         form_hash = None
         if save_form:
-            if not is_rntuple and _uproot_get_ttree_form is not None:
-                # dask-free TTree form extraction; byte-identical to the uproot.dask form
-                form_str = _ttree_form_json(tree)
+            if _uproot_get_ttree_form is not None:
+                # dask-free form extraction (TTree and RNTuple); byte-identical to uproot.dask
+                form_str = _awkward_form_json(tree, is_rntuple)
             elif is_rntuple:
-                # RNTuple form extraction still goes through uproot.dask (requires dask)
+                # uproot without the private form builder: fall back to the dask-based path
                 form_str = _dask_form_json({arg.file: arg.object_path}, is_rntuple=True)
             else:
-                # uproot without the private form builder: fall back to the dask-based path
                 form_str = _dask_form_json(tree, is_rntuple=False)
 
             form_hash = hashlib.md5(form_str.encode("utf-8")).hexdigest()

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import hashlib
+import json
 import math
 import warnings
 from collections.abc import Callable
@@ -19,8 +20,8 @@ from uproot._util import no_filter
 try:
     # Private uproot helper that builds a TTree's awkward form without dask. It is exactly what
     # uproot.dask() uses internally, so the result is byte-identical to
-    # uproot.dask(tree).layout.form (verified in the test suite). Guarded so a uproot release
-    # that moves or renames it degrades gracefully to the dask-based path below.
+    # uproot.dask(tree).layout.form. Guarded so a uproot release that moves or renames it
+    # degrades gracefully to the dask-based path below.
     from uproot._dask import _get_ttree_form as _uproot_get_ttree_form
 except Exception:  # pragma: no cover - depends on uproot internals
     _uproot_get_ttree_form = None
@@ -164,15 +165,17 @@ def _union_form_jsonstr(forms: list) -> str | None:
 _FORM_AK_ADD_DOC = {"__doc__": "title", "typename": "typename"}
 
 
-def _null_form_keys(form):
-    """Return a copy of ``form`` with every ``form_key`` set to ``None``.
+def _form_json_with_null_keys(form) -> str:
+    """Serialize ``form`` to JSON with every ``form_key`` set to ``None``.
 
     ``uproot.dask`` exposes its *meta* (typetracer) form, whose form keys are null, whereas
     ``_get_ttree_form`` carries RNTuple column keys (``"column-N"``). Nulling the keys makes the
-    extracted form byte-identical to ``uproot.dask(...).layout.form`` and is a no-op for TTree
-    forms (already keyless). Implemented via the stable ``to_dict``/``from_dict`` round-trip.
+    serialized form byte-identical to ``uproot.dask(...).layout.form.to_json()`` and is a no-op
+    for TTree forms (already keyless). The keys are stripped on the ``to_dict`` representation
+    and serialized directly, matching ``Form.to_json`` (``json.dumps`` of the verbose dict)
+    without rebuilding a ``Form`` tree in between.
     """
-    form_dict = form.to_dict()
+    form_dict = form.to_dict(verbose=True)
 
     def _strip(node):
         if isinstance(node, dict):
@@ -185,7 +188,7 @@ def _null_form_keys(form):
                 _strip(value)
 
     _strip(form_dict)
-    return awkward.forms.from_dict(form_dict)
+    return json.dumps(form_dict)
 
 
 def _awkward_form_json(tree, is_rntuple: bool) -> str:
@@ -195,9 +198,6 @@ def _awkward_form_json(tree, is_rntuple: bool) -> str:
     branches and RNTuple fields) and nulls the resulting form keys, producing output
     byte-identical to ``uproot.dask(...).layout.form.to_json()``. This is what lets the
     ``iterative``/``futures`` backends extract forms in a dask-free environment for both formats.
-
-    See the ``uproot-awkward-form-accessor`` dev note (a follow-up to expose a public uproot form
-    accessor) for how this should eventually collapse to a single public uproot call.
     """
     # RNTuples filter on fields and use full field paths; TTrees filter on branches.
     filter_kwarg = "filter_field" if is_rntuple else "filter_branch"
@@ -210,17 +210,18 @@ def _awkward_form_json(tree, is_rntuple: bool) -> str:
         **{filter_kwarg: partial(_is_interpretable, emit_warning=False)},
     )
     base_form = _uproot_get_ttree_form(awkward, tree, common_keys, _FORM_AK_ADD_DOC)
-    return _null_form_keys(base_form).to_json()
+    return _form_json_with_null_keys(base_form)
 
 
-def _dask_form_json(uproot_target, is_rntuple: bool) -> str:
+def _dask_form_json(uproot_target, is_rntuple: bool, uproot_options: dict = {}) -> str:
     """Build a form JSON via ``uproot.dask`` (requires dask).
 
     Fallback used only when uproot's internal form builder (``_get_ttree_form``) is unavailable
     (an unexpected uproot version); the dask-free :func:`_awkward_form_json` is preferred for both
     TTree and RNTuple. ``uproot_target`` is an already-open TTree object, or a
     ``{file: object_path}`` mapping (required for RNTuples, which cannot build a form from an
-    already-open object via ``uproot.dask``).
+    already-open object via ``uproot.dask``). ``uproot_options`` is forwarded to the file open
+    when ``uproot_target`` is a mapping.
     """
     if is_rntuple:
         form_dask = uproot.dask(
@@ -231,6 +232,7 @@ def _dask_form_json(uproot_target, is_rntuple: bool) -> str:
             filter_name=no_filter,
             filter_typename=no_filter,
             filter_branch=partial(_is_interpretable, emit_warning=False),
+            **uproot_options,
         )
     else:
         form_dask = uproot.dask(
@@ -297,6 +299,7 @@ def get_steps(
         array : awkward.Array or dask_awkward.Array
             The normalized file descriptions, appended with the calculated steps for those files.
     """
+    _validate_step_size(step_size)
     nf_backend = awkward.backend(normed_files)
     lz_or_nf = awkward.typetracer.length_zero_if_typetracer(normed_files)
     output_form_key = "form" if legacy_form_key else "compressed_form"
@@ -306,19 +309,19 @@ def get_steps(
         try:
             the_file = uproot.open({arg.file: None}, **uproot_options)
             tree = the_file[arg.object_path]
+            is_rntuple = isinstance(tree, uproot.behaviors.RNTuple.HasFields)
+            if require_rntuple and not is_rntuple:
+                # raised inside this block so skip_bad_files/file_exceptions can skip the file
+                raise ValueError(
+                    f"require_rntuple=True but {arg.object_path!r} in {arg.file!r} is a "
+                    f"{type(tree).__name__}, not an RNTuple."
+                )
         except file_exceptions as e:
             if skip_bad_files:
                 array.append(None)
                 continue
             else:
                 raise e
-
-        is_rntuple = isinstance(tree, uproot.behaviors.RNTuple.HasFields)
-        if require_rntuple and not is_rntuple:
-            raise ValueError(
-                f"require_rntuple=True but {arg.object_path!r} in {arg.file!r} is a "
-                f"{type(tree).__name__}, not an RNTuple."
-            )
 
         num_entries = tree.num_entries
 
@@ -330,7 +333,11 @@ def get_steps(
                 form_str = _awkward_form_json(tree, is_rntuple)
             elif is_rntuple:
                 # uproot without the private form builder: fall back to the dask-based path
-                form_str = _dask_form_json({arg.file: arg.object_path}, is_rntuple=True)
+                form_str = _dask_form_json(
+                    {arg.file: arg.object_path},
+                    is_rntuple=True,
+                    uproot_options=uproot_options,
+                )
             else:
                 form_str = _dask_form_json(tree, is_rntuple=False)
 
@@ -744,6 +751,7 @@ def get_parquet_form_uuid_steps(
         array : awkward.Array | dask_awkward.Array
             The normalized file descriptions, appended with the calculated steps for those files.
     """
+    _validate_step_size(step_size)
     nf_backend = awkward.backend(normed_files)
     lz_or_nf = awkward.typetracer.length_zero_if_typetracer(normed_files)
 
@@ -775,8 +783,8 @@ def get_parquet_form_uuid_steps(
 
         file_uuid = the_file.get("uuid", None)
 
-        # Mirror the ROOT get_steps num_entries==0 guard: a 0-row file would otherwise reach
-        # _even_steps(0, 0) (division by zero) or _aligned_steps on empty row-group boundaries.
+        # A 0-row file gets a single trivial step: it has no row groups to align to and no
+        # entries to split into steps.
         if num_entries == 0:
             array.append(
                 {
@@ -793,20 +801,6 @@ def get_parquet_form_uuid_steps(
 
         out_uuid = arg.uuid
         out_steps = arg.steps
-
-        if num_entries == 0:
-            array.append(
-                {
-                    "file": arg.file,
-                    "object_path": arg.object_path,
-                    "steps": [[0, 0]],
-                    "num_entries": num_entries,
-                    "uuid": file_uuid,
-                    "compressed_form": form_json,
-                    "form_hash_md5": form_hash,
-                }
-            )
-            continue
 
         if out_uuid != file_uuid or recalculate_steps:
             if use_row_groups:
@@ -881,12 +875,13 @@ def preprocess_root(
     step_size_safety_factor: float = 0.5,
     allow_empty_datasets: bool = False,
     backend: str | PreprocessBackend = "dask",
+    require_rntuple: bool = False,
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Given a list of normalized file and object paths (defined in uproot), determine the steps for each file according to the supplied processing options.
 
-    Both TTree and RNTuple objects are auto-detected and handled; use :func:`preprocess_rntuple`
-    if you want to require that every object is an RNTuple.
+    Both TTree and RNTuple objects are auto-detected and handled; pass ``require_rntuple=True``
+    (or use the :func:`preprocess_rntuple` alias) to require that every object is an RNTuple.
 
     Parameters
     ----------
@@ -923,6 +918,11 @@ def preprocess_root(
             Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
             synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
             PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
+        require_rntuple : bool, default False
+            If True, require every dataset to be ROOT-format and every object to be an RNTuple.
+            A parquet dataset raises a ValueError; a TTree object raises a ValueError inside the
+            worker, subject to ``skip_bad_files``/``file_exceptions`` like any other per-file
+            error.
     Returns
     -------
         out_available : DataGroupSpec
@@ -944,92 +944,26 @@ def preprocess_root(
         step_size_safety_factor=step_size_safety_factor,
         allow_empty_datasets=allow_empty_datasets,
         backend=backend,
+        require_rntuple=require_rntuple,
     )
 
 
 def preprocess_rntuple(
     datagroupspec: DataGroupSpec,
-    step_size: None | int = None,
-    align_clusters: bool = False,
-    recalculate_steps: bool = False,
-    files_per_batch: int = 1,
-    skip_bad_files: bool = False,
-    file_exceptions: Exception | Warning | tuple[Exception | Warning] = (OSError,),
-    save_form: bool = True,
-    scheduler: None | Callable | str = None,
-    uproot_options: dict = {},
-    step_size_safety_factor: float = 0.5,
-    allow_empty_datasets: bool = False,
-    backend: str | PreprocessBackend = "dask",
+    **kwargs,
 ) -> tuple[DataGroupSpec, DataGroupSpec]:
     """
     Preprocess datasets of ROOT files containing RNTuples, determining the steps for each file.
 
-    This is the RNTuple-specific counterpart to :func:`preprocess_root` (which is implicitly
-    TTree-oriented) and :func:`preprocess_parquet`. It requires every object to be an RNTuple
-    and raises a ValueError if a TTree is encountered, making it useful to assert the intended
-    file type. ``preprocess`` and ``preprocess_root`` already auto-detect and handle RNTuples
-    transparently, so this function is primarily for RNTuple-only workflows that want the
-    stricter contract.
-
-    Parameters
-    ----------
-        datagroupspec : DataGroupSpec
-            The set of datasets whose files will be preprocessed.
-        step_size : int or None, default None
-            If specified, the size of the steps to make when analyzing the input files.
-        align_clusters : bool, default False
-            Round to the RNTuple cluster boundaries when chunks are specified. Reduces data
-            transfer in analysis.
-        recalculate_steps : bool, default False
-            If steps are present in the input normed files, force the recalculation of those steps,
-            instead of only recalculating the steps if the uuid has changed.
-        files_per_batch : int, default 1
-            The number of files to preprocess in a single batch.
-            Large values will result in fewer dask tasks but each task will have to do more work.
-        skip_bad_files : bool, default False
-            Instead of failing, catch exceptions specified by file_exceptions and return null data.
-        file_exceptions : Exception or Warning or tuple[Exception or Warning], default (OSError,)
-            What exceptions to catch when skipping bad files.
-        save_form : bool, default True
-            Extract the form of the RNTuple from each file in each dataset, creating the union of the forms over the dataset.
-        scheduler : None or Callable or str, default None
-            Specifies the scheduler that dask should use to execute the preprocessing task graph.
-        uproot_options : dict, default {}
-            Options to pass to get_steps for opening files with uproot.
-        step_size_safety_factor : float, default 0.5
-            When using align_clusters, if a resulting step is larger than step_size by this factor
-            warn the user that the resulting steps may be highly irregular.
-        allow_empty_datasets : bool, default False
-            When a dataset query comes back completely empty, this is normally considered a processing error.
-            Toggle this argument to True to change this to warnings and allow incomplete returned filesets.
-        backend : str or PreprocessBackend, default "dask"
-            Execution backend for preprocessing: "dask" (default), "iterative" (immediate,
-            synchronous, dask-free), "futures" (dask-free concurrent.futures thread pool), or a
-            PreprocessBackend instance. The ``scheduler`` argument only affects the dask backend.
-    Returns
-    -------
-        out_available : DataGroupSpec
-            The subset of files in each dataset that were successfully preprocessed, organized by dataset.
-        out_updated : DataGroupSpec
-            The original set of datasets including files that were not accessible, updated to include the result of preprocessing where available.
+    Alias for :func:`preprocess_root` with ``require_rntuple=True``: every dataset must be
+    ROOT-format (parquet datasets raise a ValueError) and every object must be an RNTuple
+    (a TTree raises a ValueError inside the worker, subject to ``skip_bad_files``/
+    ``file_exceptions``). ``preprocess`` and ``preprocess_root`` already auto-detect and handle
+    RNTuples transparently, so this function is for RNTuple-only workflows that want the
+    stricter contract. All other arguments are forwarded to :func:`preprocess_root`.
     """
-    return _preprocess_pydantic(
-        datagroupspec=datagroupspec,
-        step_size=step_size,
-        use_alignment_boundaries=align_clusters,
-        recalculate_steps=recalculate_steps,
-        files_per_batch=files_per_batch,
-        skip_bad_files=skip_bad_files,
-        file_exceptions=file_exceptions,
-        save_form=save_form,
-        scheduler=scheduler,
-        filetype_options=uproot_options,
-        step_size_safety_factor=step_size_safety_factor,
-        allow_empty_datasets=allow_empty_datasets,
-        require_rntuple=True,
-        backend=backend,
-    )
+    kwargs["require_rntuple"] = True
+    return preprocess_root(datagroupspec, **kwargs)
 
 
 def preprocess_parquet(
@@ -1214,6 +1148,11 @@ def _preprocess_pydantic(
                 require_rntuple=require_rntuple,
             )
         elif info.format == "parquet":
+            if require_rntuple:
+                raise ValueError(
+                    f"require_rntuple=True but dataset {name!r} is parquet-format; "
+                    "only ROOT files can contain RNTuples."
+                )
             map_fn = partial(
                 get_parquet_form_uuid_steps,
                 step_size=step_size,
@@ -1309,21 +1248,19 @@ def _preprocess_pydantic(
             for item in awkward.drop_none(processed_files_without_forms).to_list()
         }
 
-        # Assemble both outputs by filename in the original input order, rather than zipping the
-        # processed results positionally against the input. Matching by key means correctness no
-        # longer depends on the order in which the backend reduced/concatenated the per-file
-        # results -- only that each processed record carries its filename. This is what lets the
-        # reduce be order-agnostic (relevant for meshing with the coffea.compute refactor).
-        original_files = [item["file"] for item in all_ak_norm_files[name].to_list()]
+        # Assemble both outputs by filename in the original input order. Matching by key keeps
+        # correctness independent of the order in which the backend reduced/concatenated the
+        # per-file results -- each processed record carries its filename.
+        orig_items = all_ak_norm_files[name].to_list()
 
         files_available = {
-            filename: available_by_file[filename]
-            for filename in original_files
-            if filename in available_by_file
+            item["file"]: available_by_file[item["file"]]
+            for item in orig_items
+            if item["file"] in available_by_file
         }
 
         files_out = {}
-        for orig_item in all_ak_norm_files[name].to_list():
+        for orig_item in orig_items:
             filename = orig_item["file"]
             # processed info when available, else fall back to the original input info
             files_out[filename] = available_by_file.get(
@@ -1499,6 +1436,10 @@ def preprocess(
                     "Entries assigned via item assignment are not validated; rebuild or re-validate the "
                     "DataGroupSpec (e.g. DataGroupSpec.model_validate(...)) so every entry is a DatasetSpec."
                 )
+        # Resolve the backend once so warnings (e.g. an ignored scheduler) are emitted a single
+        # time even for mixed root+parquet filesets, which dispatch to two sub-calls below.
+        backend = resolve_backend(backend, scheduler)
+        scheduler = None
         # split datasetspecs into uproot and parquet files, keeping track of original order
         original_order = list(datasetspecs.keys())
         formats = [dss.format for dss in datasetspecs.values()]

--- a/src/coffea/dataset_tools/preprocess.py
+++ b/src/coffea/dataset_tools/preprocess.py
@@ -25,17 +25,17 @@ try:
 except Exception:  # pragma: no cover - depends on uproot internals
     _uproot_get_ttree_form = None
 
-from coffea.dataset_tools.backends import (
+from coffea.dataset_tools.filespec import (
+    DataGroupSpec,
+    DatasetSpec,
+    ModelFactory,
+)
+from coffea.dataset_tools.preprocess_backends import (
     DaskBackend,
     PreprocessBackend,
     PreprocessJob,
     print_dask_backend_fallback_hint,
     resolve_backend,
-)
-from coffea.dataset_tools.filespec import (
-    DataGroupSpec,
-    DatasetSpec,
-    ModelFactory,
 )
 from coffea.util import (
     _import_dask,
@@ -1297,7 +1297,9 @@ def _preprocess_pydantic(
 
         union_form_jsonstr = _union_form_jsonstr(dataset_forms)
 
-        files_available = {
+        # Index successfully-processed files by filename. Skipped/bad files were dropped as
+        # None by the worker and are simply absent here.
+        available_by_file = {
             item["file"]: {
                 "object_path": item["object_path"],
                 "steps": item["steps"],
@@ -1307,17 +1309,32 @@ def _preprocess_pydantic(
             for item in awkward.drop_none(processed_files_without_forms).to_list()
         }
 
+        # Assemble both outputs by filename in the original input order, rather than zipping the
+        # processed results positionally against the input. Matching by key means correctness no
+        # longer depends on the order in which the backend reduced/concatenated the per-file
+        # results -- only that each processed record carries its filename. This is what lets the
+        # reduce be order-agnostic (relevant for meshing with the coffea.compute refactor).
+        original_files = [item["file"] for item in all_ak_norm_files[name].to_list()]
+
+        files_available = {
+            filename: available_by_file[filename]
+            for filename in original_files
+            if filename in available_by_file
+        }
+
         files_out = {}
-        for proc_item, orig_item in zip(
-            processed_files_without_forms.to_list(), all_ak_norm_files[name].to_list()
-        ):
-            item = orig_item if proc_item is None else proc_item
-            files_out[item["file"]] = {
-                "object_path": item["object_path"],
-                "steps": item["steps"],
-                "num_entries": item["num_entries"],
-                "uuid": item["uuid"],
-            }
+        for orig_item in all_ak_norm_files[name].to_list():
+            filename = orig_item["file"]
+            # processed info when available, else fall back to the original input info
+            files_out[filename] = available_by_file.get(
+                filename,
+                {
+                    "object_path": orig_item["object_path"],
+                    "steps": orig_item["steps"],
+                    "num_entries": orig_item["num_entries"],
+                    "uuid": orig_item["uuid"],
+                },
+            )
 
         out_updated[name]["files"] = files_out
         out_available[name]["files"] = files_available

--- a/src/coffea/dataset_tools/preprocess_backends.py
+++ b/src/coffea/dataset_tools/preprocess_backends.py
@@ -21,14 +21,15 @@ a form byte-identical to the ``uproot.dask`` form; it only falls back to ``uproo
 dask) if that internal uproot helper is unavailable on an unexpected uproot version.
 
 The interface intentionally echoes the ``coffea.compute`` refactor (PR #1470): a ``Backend``
-turns a "computable" into a future-like ``Task`` whose ``result()`` blocks. Here the computable
-is a mapping ``{dataset_name: PreprocessJob}`` and the result is ``{dataset_name: awkward.Array}``.
-When ``coffea.compute`` lands, these backends should adapt to its ``RunningBackend``/``Task``
-protocols with little change.
+turns a "computable" into a future-like ``Task`` (``result`` / ``partial_result`` / ``wait``)
+whose ``result()`` blocks. Here the computable is a mapping ``{dataset_name: PreprocessJob}`` and
+the result is ``{dataset_name: awkward.Array}``. When ``coffea.compute`` lands, these backends
+should adapt to its ``RunningBackend``/``Task`` protocols with little change.
 
-**Ordering is load-bearing.** Downstream post-processing zips the concatenated result against the
-original per-file order, so the reduction here is an *ordered* concatenation -- deliberately not
-the order-agnostic ``accumulate``/merging used by the event-processing executors.
+**Ordering is not load-bearing for correctness.** The reduction concatenates per-batch results,
+and the concrete backends happen to preserve submission order, but the downstream post-processing
+assembles its outputs *by filename* (see ``_preprocess_pydantic``), so a backend is free to reduce
+in any order -- which is what allows meshing with an order-agnostic ``compute`` reduce.
 """
 
 from __future__ import annotations
@@ -60,11 +61,12 @@ __all__ = [
 
 
 def ordered_concat(parts: Iterable[awkward.Array | None]) -> awkward.Array | None:
-    """Concatenate mapped outputs while preserving input order.
+    """Concatenate mapped outputs, preserving input order.
 
     ``None`` parts are dropped. Returns ``None`` if nothing remains. This is the reduction step
-    for preprocessing and, unlike the order-agnostic accumulation used for processor outputs,
-    must preserve order because the caller re-zips the result against the original file order.
+    for preprocessing. Order is preserved for tidiness/determinism, but is not required for
+    correctness: the downstream consumer assembles its outputs by filename, so the reduce may run
+    in any order.
     """
     parts = [part for part in parts if part is not None]
     if len(parts) == 0:
@@ -117,6 +119,15 @@ class PreprocessTask(Protocol):
     def result(self) -> dict[str, awkward.Array]:
         """Block until done and return ``{dataset_name: concatenated awkward.Array}``."""
 
+    def partial_result(self) -> dict[str, awkward.Array]:
+        """Return results for the work finished so far, without blocking on the rest.
+
+        Datasets/batches still running are omitted; a dataset appears only once at least one of
+        its batches has completed. Mirrors ``compute.Task.partial_result`` (intended for
+        resumable/progress use). Backends that cannot produce a cheap partial (e.g. a fused dask
+        graph) may return the full :meth:`result`.
+        """
+
     def wait(self) -> None:
         """Block until the computation has finished, without returning the result."""
 
@@ -140,6 +151,10 @@ class _CompletedTask:
     _results: dict[str, awkward.Array]
 
     def result(self) -> dict[str, awkward.Array]:
+        return self._results
+
+    def partial_result(self) -> dict[str, awkward.Array]:
+        # work already finished in submit(), so the partial result is the full result
         return self._results
 
     def wait(self) -> None:
@@ -200,6 +215,21 @@ class _FuturesTask:
         finally:
             if self._owns_pool:
                 self._pool.shutdown()
+
+    def partial_result(self) -> dict[str, awkward.Array]:
+        # Gather only the batches that have completed successfully, per dataset, without blocking.
+        # The owned pool is deliberately NOT shut down (unfinished work may still be running).
+        results: dict[str, awkward.Array] = {}
+        for name, futs in self._name_to_futures.items():
+            done_parts = [
+                fut.result()
+                for fut in futs
+                if fut.done() and not fut.cancelled() and fut.exception() is None
+            ]
+            merged = ordered_concat(done_parts)
+            if merged is not None:
+                results[name] = merged
+        return results
 
     def __del__(self):
         # Safety net: an owned pool is normally shut down in result(); if the caller only
@@ -278,6 +308,10 @@ class _DaskTask:
                 self._collections, scheduler=self._scheduler
             )
         return self._computed
+
+    def partial_result(self) -> dict[str, awkward.Array]:
+        # A fused dask graph has no cheap partial: fall back to the full (blocking) result.
+        return self.result()
 
 
 @dataclass

--- a/src/coffea/dataset_tools/preprocess_backends.py
+++ b/src/coffea/dataset_tools/preprocess_backends.py
@@ -6,8 +6,8 @@ batches of normalized file records and the resulting awkward arrays are concaten
 module factors that map-reduce out from :func:`coffea.dataset_tools.preprocess._preprocess_pydantic`
 behind a small backend interface so the same worker can run on:
 
-- :class:`DaskBackend` -- the historical path (``dask_awkward.map_partitions`` + an
-  ``AwkwardTreeReductionLayer`` + ``dask.compute``). This backend builds and executes a dask
+- :class:`DaskBackend` -- the default: ``dask_awkward.map_partitions`` + an
+  ``AwkwardTreeReductionLayer`` + ``dask.compute``. This backend builds and executes a dask
   task graph to orchestrate the map-reduce.
 - :class:`IterativeBackend` -- immediate (synchronous, single process) execution, mirroring
   coffea's ``IterativeExecutor``.
@@ -20,16 +20,14 @@ are dask-free for parquet input and for ROOT input of either flavor. ROOT form e
 a form byte-identical to the ``uproot.dask`` form; it only falls back to ``uproot.dask`` (and thus
 dask) if that internal uproot helper is unavailable on an unexpected uproot version.
 
-The interface intentionally echoes the ``coffea.compute`` refactor (PR #1470): a ``Backend``
-turns a "computable" into a future-like ``Task`` (``result`` / ``partial_result`` / ``wait``)
-whose ``result()`` blocks. Here the computable is a mapping ``{dataset_name: PreprocessJob}`` and
-the result is ``{dataset_name: awkward.Array}``. When ``coffea.compute`` lands, these backends
-should adapt to its ``RunningBackend``/``Task`` protocols with little change.
+A ``Backend`` turns a "computable" into a future-like ``Task`` (``result`` / ``partial_result``
+/ ``wait``) whose ``result()`` blocks. Here the computable is a mapping
+``{dataset_name: PreprocessJob}`` and the result is ``{dataset_name: awkward.Array}``.
 
-**Ordering is not load-bearing for correctness.** The reduction concatenates per-batch results,
-and the concrete backends happen to preserve submission order, but the downstream post-processing
-assembles its outputs *by filename* (see ``_preprocess_pydantic``), so a backend is free to reduce
-in any order -- which is what allows meshing with an order-agnostic ``compute`` reduce.
+Ordering is not load-bearing for correctness: the reduction concatenates per-batch results, and
+the concrete backends happen to preserve submission order, but the downstream post-processing
+assembles its outputs *by filename* (see ``_preprocess_pydantic``), so a backend is free to
+reduce in any order.
 """
 
 from __future__ import annotations
@@ -40,7 +38,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Mapping
 from concurrent.futures import Executor, Future, ProcessPoolExecutor, ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import partial
 from typing import Protocol, runtime_checkable
 
@@ -114,7 +112,7 @@ class PreprocessJob:
 
 @runtime_checkable
 class PreprocessTask(Protocol):
-    """Future-like handle to a submitted preprocessing computable (mirrors ``compute.Task``)."""
+    """Future-like handle to a submitted preprocessing computable."""
 
     def result(self) -> dict[str, awkward.Array]:
         """Block until done and return ``{dataset_name: concatenated awkward.Array}``."""
@@ -123,9 +121,8 @@ class PreprocessTask(Protocol):
         """Return results for the work finished so far, without blocking on the rest.
 
         Datasets/batches still running are omitted; a dataset appears only once at least one of
-        its batches has completed. Mirrors ``compute.Task.partial_result`` (intended for
-        resumable/progress use). Backends that cannot produce a cheap partial (e.g. a fused dask
-        graph) may return the full :meth:`result`.
+        its batches has completed. Intended for resumable/progress use. Backends that cannot
+        produce a cheap partial (e.g. a fused dask graph) may return the full :meth:`result`.
         """
 
     def wait(self) -> None:
@@ -133,7 +130,7 @@ class PreprocessTask(Protocol):
 
 
 class PreprocessBackend(ABC):
-    """Base class for preprocessing execution backends (mirrors ``compute.RunningBackend``)."""
+    """Base class for preprocessing execution backends."""
 
     @abstractmethod
     def submit(self, jobs: Mapping[str, PreprocessJob]) -> PreprocessTask:
@@ -211,14 +208,21 @@ class _FuturesTask:
                 # .result() re-raises worker exceptions here; ordering follows submission
                 parts = [fut.result() for fut in futs]
                 results[name] = ordered_concat(parts)
-            return results
-        finally:
+        except BaseException:
+            # fail fast: cancel batches that have not started so a fatal error does not wait
+            # for the rest of the fileset to be processed
+            for fut in self._all_futures():
+                fut.cancel()
             if self._owns_pool:
-                self._pool.shutdown()
+                self._pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        if self._owns_pool:
+            self._pool.shutdown()
+        return results
 
     def partial_result(self) -> dict[str, awkward.Array]:
         # Gather only the batches that have completed successfully, per dataset, without blocking.
-        # The owned pool is deliberately NOT shut down (unfinished work may still be running).
+        # The owned pool is not shut down here; unfinished work may still be running.
         results: dict[str, awkward.Array] = {}
         for name, futs in self._name_to_futures.items():
             done_parts = [
@@ -248,8 +252,11 @@ class FuturesBackend(PreprocessBackend):
 
     Parameters
     ----------
-        workers : int, default 1
-            Number of workers when this backend creates the pool.
+        workers : int or None, default None
+            Number of workers when this backend creates the pool. ``None`` uses the executor's
+            default sizing (for :class:`~concurrent.futures.ThreadPoolExecutor`,
+            ``min(32, os.cpu_count() + 4)``; for
+            :class:`~concurrent.futures.ProcessPoolExecutor`, ``os.cpu_count()``).
         use_processes : bool, default False
             Create a :class:`~concurrent.futures.ProcessPoolExecutor` instead of the default
             :class:`~concurrent.futures.ThreadPoolExecutor`. Threads are preferred because
@@ -261,7 +268,7 @@ class FuturesBackend(PreprocessBackend):
             ``use_processes`` when given.
     """
 
-    workers: int = 1
+    workers: int | None = None
     use_processes: bool = False
     pool: Executor | Callable[..., Executor] | None = None
 
@@ -316,7 +323,7 @@ class _DaskTask:
 
 @dataclass
 class DaskBackend(PreprocessBackend):
-    """Execute preprocessing as a dask-awkward task graph (the historical behaviour).
+    """Execute preprocessing as a dask-awkward task graph (the default).
 
     Per dataset this builds ``from_awkward`` -> ``map_partitions`` -> ``AwkwardTreeReductionLayer``
     and lets a single ``dask.compute`` materialize all datasets together.
@@ -393,18 +400,22 @@ def resolve_backend(
 ) -> PreprocessBackend:
     """Turn a ``backend`` selector into a :class:`PreprocessBackend` instance.
 
-    ``backend`` may be an existing :class:`PreprocessBackend` (returned as-is), or one of the
-    strings ``"dask"`` (default), ``"iterative"``, or ``"futures"``. ``scheduler`` is forwarded
-    to a default-constructed :class:`DaskBackend`; if it is set while a non-dask backend is
-    selected, a warning is issued because it has no effect there.
+    ``backend`` may be an existing :class:`PreprocessBackend`, or one of the strings ``"dask"``
+    (default), ``"iterative"``, or ``"futures"``. ``scheduler`` is forwarded to a
+    default-constructed :class:`DaskBackend`, and is injected into a passed :class:`DaskBackend`
+    instance whose own ``scheduler`` is unset (a copy is returned; the instance is not mutated).
+    If ``scheduler`` is set while a non-dask backend is selected, or the :class:`DaskBackend`
+    instance already carries its own scheduler, a warning is issued because the argument has no
+    effect there.
     """
     if isinstance(backend, PreprocessBackend):
-        # A pre-built instance is used as-is; we cannot inject `scheduler` into it (even a
-        # DaskBackend instance keeps its own scheduler), so warn rather than silently drop it.
         if scheduler is not None:
+            if isinstance(backend, DaskBackend) and backend.scheduler is None:
+                return replace(backend, scheduler=scheduler)
             warnings.warn(
-                "The 'scheduler' argument is ignored when a PreprocessBackend instance is "
-                "passed; set it on the instance, e.g. DaskBackend(scheduler=...).",
+                "The 'scheduler' argument is ignored when a PreprocessBackend instance "
+                "carries its own execution configuration; set it on the instance, e.g. "
+                "DaskBackend(scheduler=...).",
                 stacklevel=2,
             )
         return backend

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -1,11 +1,13 @@
 import contextlib
 import copy
 import json
+from functools import partial
 from pathlib import Path
 
 import awkward
 import pytest
 import uproot
+from uproot._util import no_filter
 from uproot.exceptions import KeyInFileError
 
 from coffea.dataset_tools import (
@@ -17,16 +19,19 @@ from coffea.dataset_tools import (
     max_chunks_per_file,
     max_files,
     preprocess,
+    preprocess_rntuple,
+    preprocess_root,
     slice_chunks,
     slice_files,
     split_fileset,
 )
 from coffea.dataset_tools.filespec import (
     DataGroupSpec,
+    PreprocessedFiles,
 )
 from coffea.nanoevents import BaseSchema, NanoAODSchema
 from coffea.processor.test_items import NanoEventsProcessor, NanoTestProcessor
-from coffea.util import decompress_form
+from coffea.util import _is_interpretable, decompress_form
 
 dask_awkward = pytest.importorskip("dask_awkward")
 
@@ -749,6 +754,58 @@ def test_preprocess_calculate_form(dask_client, preprocess_legacy_root):
             )
 
 
+def test_preprocess_rntuple():
+    """RNTuple .root files are preprocessed via preprocess_rntuple, auto-detected by
+    preprocess_root, and preprocess_rntuple rejects TTree files.
+
+    Uses the synchronous scheduler (RNTuple preprocessing does not require a distributed
+    client and this keeps the test fast and deterministic).
+    """
+    rntuple_file = "tests/samples/nano_dy_rntuple.root"
+    rntuple_fileset = DataGroupSpec({"ZJets": {"files": {rntuple_file: "Events"}}})
+
+    available, _updated = preprocess_rntuple(
+        rntuple_fileset, step_size=15, save_form=True, scheduler="synchronous"
+    )
+
+    dataset = available["ZJets"]
+    assert isinstance(dataset.files, PreprocessedFiles)
+    spec = dataset.files[rntuple_file]
+    assert spec.num_entries == 40
+    assert spec.steps == [[0, 14], [14, 28], [28, 40]]
+
+    # the stored union form matches the form uproot produces under the same interpretable-branch
+    # filter that preprocessing applies (which, for RNTuples, drops _collection* subfields)
+    raw_form = uproot.dask(
+        {rntuple_file: "Events"},
+        open_files=False,
+        ak_add_doc={"__doc__": "title", "typename": "typename"},
+        filter_name=no_filter,
+        filter_typename=no_filter,
+        filter_branch=partial(_is_interpretable, emit_warning=False),
+    ).layout.form.to_json()
+    assert decompress_form(dataset.compressed_form) == raw_form
+
+    # preprocess_root auto-detects the RNTuple and yields the same steps
+    available_auto, _ = preprocess_root(
+        DataGroupSpec({"ZJets": {"files": {rntuple_file: "Events"}}}),
+        step_size=15,
+        save_form=False,
+        scheduler="synchronous",
+    )
+    auto_spec = available_auto["ZJets"].files[rntuple_file]
+    assert auto_spec.steps == [[0, 14], [14, 28], [28, 40]]
+
+    # preprocess_rntuple must reject a TTree file
+    ttree_fileset = DataGroupSpec(
+        {"ZJets": {"files": {"tests/samples/nano_dy.root": "Events"}}}
+    )
+    with pytest.raises(ValueError, match="require_rntuple"):
+        preprocess_rntuple(
+            ttree_fileset, step_size=15, save_form=False, scheduler="synchronous"
+        )
+
+
 @pytest.mark.dask_client
 def test_preprocess_failed_file(dask_client):
     with dask_client.as_current() as _, pytest.raises(FileNotFoundError):
@@ -948,6 +1005,22 @@ def test_filter_files(the_fileset):
         assert filtered_files == DataGroupSpec(target)
     else:
         assert filtered_files == target
+
+
+def test_filter_files_returns_preprocessed_files():
+    """Regression (B1/T3): filtering a preprocessed DataGroupSpec keeps each dataset's
+    files as a PreprocessedFiles (all surviving files are concrete), and empty files are
+    removed."""
+    filtered = filter_files(DataGroupSpec(_updated_result))
+    assert isinstance(filtered, DataGroupSpec)
+    for name, dataset in filtered.items():
+        assert isinstance(
+            dataset.files, PreprocessedFiles
+        ), f"{name} files should be PreprocessedFiles, got {type(dataset.files).__name__}"
+        # the empty file present in _updated_result must have been filtered out
+        assert all(
+            spec.num_entries and spec.num_entries > 0 for spec in dataset.files.values()
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -1008,9 +1008,9 @@ def test_filter_files(the_fileset):
 
 
 def test_filter_files_returns_preprocessed_files():
-    """Regression (B1/T3): filtering a preprocessed DataGroupSpec keeps each dataset's
-    files as a PreprocessedFiles (all surviving files are concrete), and empty files are
-    removed."""
+    """Filtering a preprocessed DataGroupSpec keeps each dataset's files as a
+    PreprocessedFiles (all surviving files are concrete), and empty files are removed.
+    """
     filtered = filter_files(DataGroupSpec(_updated_result))
     assert isinstance(filtered, DataGroupSpec)
     for name, dataset in filtered.items():

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -245,27 +245,47 @@ def test_fallback_hint_mentions_backends(capsys):
     assert "futures" in out
 
 
-def test_ttree_form_json_matches_uproot_dask():
-    """The dask-free TTree form builder must stay byte-identical to uproot.dask's form,
-    otherwise the iterative/futures backends would store forms incompatible with the dask
-    read path used at analysis time."""
+@pytest.mark.parametrize(
+    "sample, is_rntuple",
+    [
+        ("tests/samples/nano_dy.root", False),
+        ("tests/samples/nano_dy_rntuple.root", True),
+    ],
+)
+def test_awkward_form_json_matches_uproot_dask(sample, is_rntuple):
+    """The dask-free form builder must stay byte-identical to uproot.dask's form for both TTree
+    and RNTuple, otherwise the iterative/futures backends would store forms incompatible with the
+    dask read path used at analysis time."""
     from functools import partial
 
     import uproot
     from uproot._util import no_filter
 
-    from coffea.dataset_tools.preprocess import _FORM_AK_ADD_DOC, _ttree_form_json
+    from coffea.dataset_tools.preprocess import _FORM_AK_ADD_DOC, _awkward_form_json
     from coffea.util import _is_interpretable
 
-    tree = uproot.open({"tests/samples/nano_dy.root": None})["Events"]
-    dask_form = uproot.dask(
-        tree,
-        ak_add_doc=_FORM_AK_ADD_DOC,
-        filter_name=no_filter,
-        filter_typename=no_filter,
-        filter_branch=partial(_is_interpretable, emit_warning=False),
-    ).layout.form.to_json()
-    assert _ttree_form_json(tree) == dask_form
+    tree = uproot.open({sample: None})["Events"]
+    filt = partial(_is_interpretable, emit_warning=False)
+    if is_rntuple:
+        # RNTuples cannot build a form from an already-open object via uproot.dask; pass the spec
+        dask_form = uproot.dask(
+            {sample: "Events"},
+            open_files=False,
+            full_paths=True,
+            ak_add_doc=_FORM_AK_ADD_DOC,
+            filter_name=no_filter,
+            filter_typename=no_filter,
+            filter_branch=filt,
+        ).layout.form.to_json()
+    else:
+        dask_form = uproot.dask(
+            tree,
+            ak_add_doc=_FORM_AK_ADD_DOC,
+            filter_name=no_filter,
+            filter_typename=no_filter,
+            filter_branch=filt,
+        ).layout.form.to_json()
+    assert _awkward_form_json(tree, is_rntuple) == dask_form
 
 
 def test_step_size_zero_or_negative_raises(tmp_path):

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -259,6 +259,8 @@ def test_awkward_form_json_matches_uproot_dask(sample, is_rntuple):
     """The dask-free form builder must stay byte-identical to uproot.dask's form for both TTree
     and RNTuple, otherwise the iterative/futures backends would store forms incompatible with the
     dask read path used at analysis time."""
+    pytest.importorskip("dask")
+    pytest.importorskip("dask_awkward")
     from functools import partial
 
     import uproot

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -1,4 +1,4 @@
-"""Tests for the switchable preprocessing backends in coffea.dataset_tools.backends."""
+"""Tests for the switchable preprocessing backends in coffea.dataset_tools.preprocess_backends."""
 
 import shutil
 
@@ -11,9 +11,10 @@ from coffea.dataset_tools import (
     FuturesBackend,
     IterativeBackend,
     PreprocessBackend,
+    PreprocessJob,
     preprocess,
 )
-from coffea.dataset_tools.backends import (
+from coffea.dataset_tools.preprocess_backends import (
     _iter_batches,
     ordered_concat,
     resolve_backend,
@@ -161,7 +162,7 @@ def test_dask_import_failure_prints_hint(tmp_path, monkeypatch):
     backends is emitted before the ModuleNotFoundError propagates."""
     import importlib
 
-    backends_mod = importlib.import_module("coffea.dataset_tools.backends")
+    backends_mod = importlib.import_module("coffea.dataset_tools.preprocess_backends")
     # the package re-exports the `preprocess` function, shadowing the submodule attribute,
     # so fetch the module object explicitly rather than via attribute access
     preprocess_mod = importlib.import_module("coffea.dataset_tools.preprocess")
@@ -237,7 +238,9 @@ def test_empty_parquet_file_does_not_crash(tmp_path):
 
 
 def test_fallback_hint_mentions_backends(capsys):
-    from coffea.dataset_tools.backends import print_dask_backend_fallback_hint
+    from coffea.dataset_tools.preprocess_backends import (
+        print_dask_backend_fallback_hint,
+    )
 
     print_dask_backend_fallback_hint()
     out = capsys.readouterr().out
@@ -313,3 +316,35 @@ def test_backends_are_preprocessbackend_instances():
     assert isinstance(DaskBackend(), PreprocessBackend)
     assert isinstance(IterativeBackend(), PreprocessBackend)
     assert isinstance(FuturesBackend(), PreprocessBackend)
+
+
+def test_skipped_bad_file_assembled_by_filename(tmp_path):
+    """A skipped bad file is absent from `available` but retained in `updated` with its original
+    input info, assembled by filename in the original input order (no positional zip).
+    """
+    good = "tests/samples/nano_dy.root"
+    bad = str(tmp_path / "does_not_exist.root")
+    dgs = DataGroupSpec({"ZJets": {"files": {bad: "Events", good: "Events"}}})
+    available, updated = preprocess(
+        dgs, step_size=20, save_form=True, skip_bad_files=True, backend="iterative"
+    )
+    # updated keeps both files, in the original input order; available drops the bad one
+    assert list(updated["ZJets"].files) == [bad, good]
+    assert bad not in available["ZJets"].files
+    assert good in available["ZJets"].files
+
+
+def test_partial_result_equals_result_when_complete():
+    """partial_result() must agree with result() once all work has finished, for the eager and
+    futures backends (mirrors coffea.compute Task.partial_result)."""
+    arr = awkward.Array([{"x": i} for i in range(4)])
+    jobs = {
+        "d": PreprocessJob(array=arr, map_fn=lambda batch: batch, files_per_batch=1)
+    }
+    for backend in (IterativeBackend(), FuturesBackend(workers=2)):
+        task = backend.submit(jobs)
+        task.wait()
+        partial = task.partial_result()
+        result = task.result()
+        assert result["d"].to_list() == arr.to_list()
+        assert partial["d"].to_list() == result["d"].to_list()

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -268,6 +268,27 @@ def test_ttree_form_json_matches_uproot_dask():
     assert _ttree_form_json(tree) == dask_form
 
 
+def test_step_size_zero_or_negative_raises(tmp_path):
+    """step_size < 1 is rejected with a clear ValueError at the entrypoint rather than a bare
+    ZeroDivisionError from deep inside a worker."""
+    dgs = _multi_file_fileset(tmp_path)
+    for bad in (0, -5):
+        with pytest.raises(ValueError, match="step_size must be a positive integer"):
+            preprocess(dgs, step_size=bad, save_form=False, backend="iterative")
+    # None and >= 1 are accepted (smoke: no raise)
+    preprocess(dgs, step_size=1, save_form=False, backend="iterative")
+
+
+def test_step_size_zero_raises_in_legacy_path():
+    """The legacy path validates step_size too, before importing dask or opening files."""
+    from coffea.dataset_tools import preprocess_legacy
+
+    with pytest.raises(ValueError, match="step_size must be a positive integer"):
+        preprocess_legacy(
+            {"ds": {"files": {"nonexistent.root": "Events"}}}, step_size=0
+        )
+
+
 def test_backends_are_preprocessbackend_instances():
     assert isinstance(DaskBackend(), PreprocessBackend)
     assert isinstance(IterativeBackend(), PreprocessBackend)

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -1,0 +1,274 @@
+"""Tests for the switchable preprocessing backends in coffea.dataset_tools.backends."""
+
+import shutil
+
+import awkward
+import pytest
+
+from coffea.dataset_tools import (
+    DaskBackend,
+    DataGroupSpec,
+    FuturesBackend,
+    IterativeBackend,
+    PreprocessBackend,
+    preprocess,
+)
+from coffea.dataset_tools.backends import (
+    _iter_batches,
+    ordered_concat,
+    resolve_backend,
+)
+
+
+def _multi_file_fileset(tmp_path):
+    """A single dataset with two identical-form ROOT files (so form union is trivial)."""
+    src = "tests/samples/nano_dy.root"
+    copy = tmp_path / "nano_dy_copy.root"
+    shutil.copy(src, copy)
+    return DataGroupSpec(
+        {
+            "ZJets": {"files": {src: "Events", str(copy): "Events"}},
+            "ZJets2": {"files": {src: "Events"}},
+        }
+    )
+
+
+# --------------------------------------------------------------------------------------
+# ordered_concat / _iter_batches unit tests
+# --------------------------------------------------------------------------------------
+
+
+def test_ordered_concat_preserves_order():
+    a = awkward.Array([1, 2])
+    b = awkward.Array([3, 4])
+    c = awkward.Array([5])
+    assert ordered_concat([a, b, c]).to_list() == [1, 2, 3, 4, 5]
+
+
+def test_ordered_concat_drops_none_and_handles_empty():
+    a = awkward.Array([1, 2])
+    assert ordered_concat([None, a, None]).to_list() == [1, 2]
+    # single element is returned as-is
+    assert ordered_concat([a]) is a
+    # nothing to concatenate
+    assert ordered_concat([]) is None
+    assert ordered_concat([None, None]) is None
+
+
+def test_iter_batches_slices_in_order():
+    arr = awkward.Array([{"x": i} for i in range(5)])
+    batches = list(_iter_batches(arr, files_per_batch=2))
+    assert [b.x.to_list() for b in batches] == [[0, 1], [2, 3], [4]]
+
+
+def test_iter_batches_empty_yields_once():
+    arr = awkward.Array([{"x": 1}])[0:0]
+    batches = list(_iter_batches(arr, files_per_batch=1))
+    assert len(batches) == 1
+    assert len(batches[0]) == 0
+
+
+# --------------------------------------------------------------------------------------
+# resolve_backend
+# --------------------------------------------------------------------------------------
+
+
+def test_resolve_backend_strings():
+    assert isinstance(resolve_backend("dask"), DaskBackend)
+    assert isinstance(resolve_backend(None), DaskBackend)
+    assert isinstance(resolve_backend("iterative"), IterativeBackend)
+    assert isinstance(resolve_backend("futures"), FuturesBackend)
+
+
+def test_resolve_backend_instance_passthrough():
+    inst = IterativeBackend()
+    assert resolve_backend(inst) is inst
+
+
+def test_resolve_backend_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown preprocessing backend"):
+        resolve_backend("nonsense")
+
+
+def test_resolve_backend_scheduler_warns_for_non_dask_string():
+    with pytest.warns(UserWarning, match="only affects the dask backend"):
+        resolve_backend("iterative", scheduler="synchronous")
+
+
+def test_resolve_backend_scheduler_warns_for_instance():
+    # A pre-built instance can't have `scheduler` injected, so it warns regardless of type.
+    with pytest.warns(UserWarning, match="ignored when a PreprocessBackend instance"):
+        resolve_backend(FuturesBackend(), scheduler="synchronous")
+    with pytest.warns(UserWarning, match="ignored when a PreprocessBackend instance"):
+        resolve_backend(DaskBackend(), scheduler="synchronous")
+
+
+def test_resolve_backend_scheduler_no_warn_for_dask_string(recwarn):
+    resolve_backend("dask", scheduler="synchronous")
+    assert not any("ignored" in str(w.message) for w in recwarn)
+
+
+# --------------------------------------------------------------------------------------
+# Backend equivalence (dask-free backends do not import dask)
+# --------------------------------------------------------------------------------------
+
+
+def test_iterative_and_threads_agree(tmp_path):
+    dgs = _multi_file_fileset(tmp_path)
+    a_iter, u_iter = preprocess(dgs, step_size=7, save_form=True, backend="iterative")
+    a_thr, u_thr = preprocess(
+        dgs, step_size=7, save_form=True, backend=FuturesBackend(workers=2)
+    )
+    # DatasetSpec.__eq__ compares decoded forms (ignoring non-deterministic compressed bytes)
+    assert a_iter == a_thr
+    assert u_iter == u_thr
+    # order of files within a dataset is preserved by the ordered reduce
+    src = "tests/samples/nano_dy.root"
+    assert list(a_iter["ZJets"].files)[0] == src
+
+
+def test_iterative_preserves_steps_and_form(tmp_path):
+    dgs = _multi_file_fileset(tmp_path)
+    available, _ = preprocess(dgs, step_size=7, save_form=True, backend="iterative")
+    ds = available["ZJets"]
+    assert len(ds.files) == 2
+    for fs in ds.files.values():
+        assert fs.num_entries == 40
+        assert fs.uuid is not None
+        assert fs.steps[0][0] == 0
+    assert ds.compressed_form is not None
+
+
+def test_dask_matches_dask_free(tmp_path):
+    pytest.importorskip("dask")
+    pytest.importorskip("dask_awkward")
+    dgs = _multi_file_fileset(tmp_path)
+    a_dask, u_dask = preprocess(
+        dgs, step_size=7, save_form=True, backend="dask", scheduler="synchronous"
+    )
+    a_iter, u_iter = preprocess(dgs, step_size=7, save_form=True, backend="iterative")
+    assert a_dask == a_iter
+    assert u_dask == u_iter
+
+
+# --------------------------------------------------------------------------------------
+# dask-unavailable fallback hint
+# --------------------------------------------------------------------------------------
+
+
+def test_dask_import_failure_prints_hint(tmp_path, monkeypatch):
+    """When the default dask backend can't import dask, a hint about the dask-free
+    backends is emitted before the ModuleNotFoundError propagates."""
+    import importlib
+
+    backends_mod = importlib.import_module("coffea.dataset_tools.backends")
+    # the package re-exports the `preprocess` function, shadowing the submodule attribute,
+    # so fetch the module object explicitly rather than via attribute access
+    preprocess_mod = importlib.import_module("coffea.dataset_tools.preprocess")
+
+    def _boom():
+        raise ModuleNotFoundError("no dask here")
+
+    monkeypatch.setattr(backends_mod, "_import_dask", _boom)
+
+    called = {"hint": False}
+    orig_hint = preprocess_mod.print_dask_backend_fallback_hint
+
+    def _hint():
+        called["hint"] = True
+        orig_hint()
+
+    monkeypatch.setattr(preprocess_mod, "print_dask_backend_fallback_hint", _hint)
+
+    dgs = _multi_file_fileset(tmp_path)
+    with pytest.raises(ModuleNotFoundError):
+        preprocess(dgs, step_size=7, save_form=True, backend="dask")
+    assert called["hint"] is True
+
+
+def test_worker_modulenotfound_does_not_trigger_dask_hint(tmp_path, monkeypatch):
+    """A ModuleNotFoundError raised by a worker during compute (surfaced in Task.result())
+    must NOT print the 'dask could not be imported' hint -- only a failure to import dask in
+    submit() should."""
+    import importlib
+
+    preprocess_mod = importlib.import_module("coffea.dataset_tools.preprocess")
+
+    class _RaisingTask:
+        def result(self):
+            raise ModuleNotFoundError("missing xrootd inside a worker")
+
+    class _FakeDaskBackend(DaskBackend):
+        def submit(self, jobs):  # submit succeeds; the error is deferred to result()
+            return _RaisingTask()
+
+    called = {"hint": False}
+    monkeypatch.setattr(
+        preprocess_mod,
+        "print_dask_backend_fallback_hint",
+        lambda: called.__setitem__("hint", True),
+    )
+    monkeypatch.setattr(
+        preprocess_mod, "resolve_backend", lambda b, s=None: _FakeDaskBackend()
+    )
+
+    dgs = _multi_file_fileset(tmp_path)
+    with pytest.raises(ModuleNotFoundError, match="missing xrootd"):
+        preprocess(dgs, step_size=7, save_form=True, backend="dask")
+    assert called["hint"] is False
+
+
+def test_empty_parquet_file_does_not_crash(tmp_path):
+    """A 0-row parquet file must yield steps=[[0, 0]] instead of a ZeroDivisionError,
+    mirroring the ROOT get_steps num_entries==0 guard."""
+    from coffea.dataset_tools import preprocess_parquet
+
+    path = tmp_path / "empty.parquet"
+    awkward.to_parquet(awkward.Array([{"x": 1.0, "y": 2}])[0:0], str(path))
+    dgs = DataGroupSpec({"E": {"files": {str(path): None}}})
+
+    # recalculate_steps=True forces the step-computation branch that used to divide by zero
+    _available, updated = preprocess_parquet(
+        dgs, recalculate_steps=True, save_form=True, backend="iterative"
+    )
+    fs = next(iter(updated["E"].files.values()))
+    assert fs.num_entries == 0
+    assert fs.steps == [[0, 0]]
+
+
+def test_fallback_hint_mentions_backends(capsys):
+    from coffea.dataset_tools.backends import print_dask_backend_fallback_hint
+
+    print_dask_backend_fallback_hint()
+    out = capsys.readouterr().out
+    assert "iterative" in out
+    assert "futures" in out
+
+
+def test_ttree_form_json_matches_uproot_dask():
+    """The dask-free TTree form builder must stay byte-identical to uproot.dask's form,
+    otherwise the iterative/futures backends would store forms incompatible with the dask
+    read path used at analysis time."""
+    from functools import partial
+
+    import uproot
+    from uproot._util import no_filter
+
+    from coffea.dataset_tools.preprocess import _FORM_AK_ADD_DOC, _ttree_form_json
+    from coffea.util import _is_interpretable
+
+    tree = uproot.open({"tests/samples/nano_dy.root": None})["Events"]
+    dask_form = uproot.dask(
+        tree,
+        ak_add_doc=_FORM_AK_ADD_DOC,
+        filter_name=no_filter,
+        filter_typename=no_filter,
+        filter_branch=partial(_is_interpretable, emit_warning=False),
+    ).layout.form.to_json()
+    assert _ttree_form_json(tree) == dask_form
+
+
+def test_backends_are_preprocessbackend_instances():
+    assert isinstance(DaskBackend(), PreprocessBackend)
+    assert isinstance(IterativeBackend(), PreprocessBackend)
+    assert isinstance(FuturesBackend(), PreprocessBackend)

--- a/tests/test_dataset_tools_backends.py
+++ b/tests/test_dataset_tools_backends.py
@@ -96,12 +96,25 @@ def test_resolve_backend_scheduler_warns_for_non_dask_string():
         resolve_backend("iterative", scheduler="synchronous")
 
 
+def test_resolve_backend_scheduler_injected_into_dask_instance(recwarn):
+    """A DaskBackend instance with no scheduler of its own receives the scheduler argument
+    (as a copy; the original instance is not mutated), without warning."""
+    inst = DaskBackend(split_every=4)
+    resolved = resolve_backend(inst, scheduler="synchronous")
+    assert resolved.scheduler == "synchronous"
+    assert resolved.split_every == 4
+    assert inst.scheduler is None
+    assert not any("ignored" in str(w.message) for w in recwarn)
+
+
 def test_resolve_backend_scheduler_warns_for_instance():
-    # A pre-built instance can't have `scheduler` injected, so it warns regardless of type.
+    # scheduler cannot be injected into a non-dask instance or a DaskBackend that already
+    # carries its own scheduler, so it warns instead of silently dropping the argument
     with pytest.warns(UserWarning, match="ignored when a PreprocessBackend instance"):
         resolve_backend(FuturesBackend(), scheduler="synchronous")
     with pytest.warns(UserWarning, match="ignored when a PreprocessBackend instance"):
-        resolve_backend(DaskBackend(), scheduler="synchronous")
+        inst = DaskBackend(scheduler="threads")
+        assert resolve_backend(inst, scheduler="synchronous") is inst
 
 
 def test_resolve_backend_scheduler_no_warn_for_dask_string(recwarn):
@@ -228,7 +241,7 @@ def test_empty_parquet_file_does_not_crash(tmp_path):
     awkward.to_parquet(awkward.Array([{"x": 1.0, "y": 2}])[0:0], str(path))
     dgs = DataGroupSpec({"E": {"files": {str(path): None}}})
 
-    # recalculate_steps=True forces the step-computation branch that used to divide by zero
+    # recalculate_steps=True forces the step-computation branch
     _available, updated = preprocess_parquet(
         dgs, recalculate_steps=True, save_form=True, backend="iterative"
     )
@@ -337,8 +350,8 @@ def test_skipped_bad_file_assembled_by_filename(tmp_path):
 
 
 def test_partial_result_equals_result_when_complete():
-    """partial_result() must agree with result() once all work has finished, for the eager and
-    futures backends (mirrors coffea.compute Task.partial_result)."""
+    """partial_result() agrees with result() once all work has finished, for the eager and
+    futures backends."""
     arr = awkward.Array([{"x": i} for i in range(4)])
     jobs = {
         "d": PreprocessJob(array=arr, map_fn=lambda batch: batch, files_per_batch=1)
@@ -350,3 +363,102 @@ def test_partial_result_equals_result_when_complete():
         result = task.result()
         assert result["d"].to_list() == arr.to_list()
         assert partial["d"].to_list() == result["d"].to_list()
+
+
+def test_futures_default_workers_uses_executor_default():
+    """FuturesBackend defaults workers to None, deferring pool sizing to the executor
+    (parallel by default), including via the string selector."""
+    assert FuturesBackend().workers is None
+    assert resolve_backend("futures").workers is None
+
+
+def test_futures_string_backend_matches_iterative(tmp_path):
+    dgs = _multi_file_fileset(tmp_path)
+    a_fut, u_fut = preprocess(dgs, step_size=7, save_form=True, backend="futures")
+    a_iter, u_iter = preprocess(dgs, step_size=7, save_form=True, backend="iterative")
+    assert a_fut == a_iter
+    assert u_fut == u_iter
+
+
+def test_futures_result_failure_cancels_pending():
+    """When a batch fails, result() re-raises after cancelling batches that have not started,
+    so a fatal error does not wait for the rest of the fileset to be processed."""
+    import threading
+    from concurrent.futures import Future, ThreadPoolExecutor
+
+    from coffea.dataset_tools.preprocess_backends import _FuturesTask
+
+    release = threading.Event()
+    ran = threading.Event()
+    pool = ThreadPoolExecutor(max_workers=1)
+    try:
+        pool.submit(release.wait)  # occupies the only worker
+        pending = pool.submit(ran.set)  # queued behind the blocker
+
+        failed = Future()
+        failed.set_exception(ValueError("boom"))
+
+        task = _FuturesTask({"d": [failed, pending]}, pool, owns_pool=True)
+        with pytest.raises(ValueError, match="boom"):
+            task.result()
+        assert pending.cancelled()
+        assert not ran.is_set()
+    finally:
+        release.set()
+
+
+def test_preprocess_rntuple_skips_ttree_file_when_requested():
+    """With require_rntuple, a TTree object raises a ValueError that participates in
+    skip_bad_files/file_exceptions like any other per-file error."""
+    from coffea.dataset_tools import preprocess_rntuple
+
+    rnt = "tests/samples/nano_dy_rntuple.root"
+    ttree = "tests/samples/nano_dy.root"
+    dgs = DataGroupSpec({"D": {"files": {rnt: "Events", ttree: "Events"}}})
+
+    with pytest.raises(ValueError, match="not an RNTuple"):
+        preprocess_rntuple(dgs, save_form=False, backend="iterative")
+
+    available, updated = preprocess_rntuple(
+        dgs,
+        save_form=False,
+        backend="iterative",
+        skip_bad_files=True,
+        file_exceptions=(OSError, ValueError),
+    )
+    assert list(available["D"].files) == [rnt]
+    assert list(updated["D"].files) == [rnt, ttree]
+
+
+def test_preprocess_rntuple_rejects_parquet(tmp_path):
+    """require_rntuple rejects parquet-format datasets with a clear error."""
+    from coffea.dataset_tools import preprocess_rntuple
+
+    path = tmp_path / "d.parquet"
+    awkward.to_parquet(awkward.Array([{"x": 1.0}]), str(path))
+    dgs = DataGroupSpec({"P": {"files": {str(path): None}}})
+    with pytest.raises(ValueError, match="parquet-format"):
+        preprocess_rntuple(dgs, save_form=False, backend="iterative")
+
+
+def test_workers_validate_step_size():
+    """get_steps and get_parquet_form_uuid_steps reject step_size < 1 directly, including
+    negative values (which would otherwise silently produce a single step per file)."""
+    from coffea.dataset_tools.preprocess import get_parquet_form_uuid_steps, get_steps
+
+    normed = awkward.Array(
+        [
+            {
+                "file": "tests/samples/nano_dy.root",
+                "object_path": "Events",
+                "steps": None,
+                "num_entries": None,
+                "uuid": None,
+            }
+        ]
+    )
+    for bad in (0, -5):
+        with pytest.raises(ValueError, match="step_size must be a positive integer"):
+            get_steps(normed, step_size=bad)
+        with pytest.raises(ValueError, match="step_size must be a positive integer"):
+            get_parquet_form_uuid_steps(normed, step_size=bad)


### PR DESCRIPTION
Adds RNTuple capability to preprocessing, plus alternative backends (besides dask) to permit different processing modes. The backend design is intended to potentially interface with the coffea.compute refactor in the future.

This has been largely implemented by Claude Fable 5 + Opus 4.8, with hands-on guidance from me

This PR is rebased to https://github.com/scikit-hep/coffea/pull/1528

Todos: 
- [ ] cleanup filespec.ipynb to better demonstrate the method-chaining for slicing etc
- [ ] decide on whether this backends approach makes sense right now
- [ ] full human review of code