### PR TITLE
fix(jetmet): JER down variation no longer corrupts mass_orig

### DIFF
--- a/src/coffea/jetmet_tools/CorrectedJetsFactory.py
+++ b/src/coffea/jetmet_tools/CorrectedJetsFactory.py
@@ -383,10 +383,12 @@ class CorrectedJetsFactory:
             down = awkward.flatten(jets)
             # always forward the original (likely corrected) pt/mass
             down = awkward.with_field(
-                up, down[self.name_map["JetPt"]], where=self.name_map["JetPt"] + "_orig"
+                down,
+                down[self.name_map["JetPt"]],
+                where=self.name_map["JetPt"] + "_orig",
             )
             down = awkward.with_field(
-                up,
+                down,
                 down[self.name_map["JetMass"]],
                 where=self.name_map["JetMass"] + "_orig",
             )

--- a/tests/test_jetmet_tools.py
+++ b/tests/test_jetmet_tools.py
@@ -915,6 +915,20 @@ def test_corrected_jets_factory():
     assert name_map["JetPt"] + "_orig" in corrected_jets.JES_AbsoluteStat.up.fields
     assert name_map["JetPt"] + "_orig" in corrected_jets.JER.up.fields
 
+    # Regression test for scikit-hep/coffea#1578: the JER "down" variation must
+    # forward the original (pre-smearing) pt/mass in pt_orig/mass_orig, not the
+    # up-smeared values. Compare against the untouched original arrays.
+    orig_pt = ak.flatten(corrected_jets.pt_orig)
+    orig_mass = ak.flatten(corrected_jets.mass_orig)
+    for var in ("up", "down"):
+        assert ak.all(ak.flatten(corrected_jets.JER[var].pt_orig) == orig_pt)
+        assert ak.all(ak.flatten(corrected_jets.JER[var].mass_orig) == orig_mass)
+    # The down variation's forwarded originals must differ from the up-smeared values.
+    assert ak.any(
+        ak.flatten(corrected_jets.JER.down.mass_orig)
+        != ak.flatten(corrected_jets.JER.up.mass)
+    )
+
     tic = time.time()
     met_factory = CorrectedMETFactory(name_map)
     toc = time.time()


### PR DESCRIPTION
**Part of #1578** — critical bug 1: *JER "down" variation corrupts `mass_orig`*.

In `CorrectedJetsFactory`, the JER "down" variation forwarded the original pre-smearing `pt_orig`/`mass_orig` by calling `awkward.with_field` with the already up-smeared `up` record as the base, rather than a fresh flatten of the original jets. Because the mass forward read its value from the previous (`up`-based) intermediate, `JER.down.mass_orig` silently held the **up-smeared mass** instead of the original mass; anyone reading `mass_orig` on the down variation got wrong values (MET propagation was unaffected). In practice `pt_orig` stayed correct only by ordering luck; both forwards are repaired to use the freshly flattened `down` record for robustness.

A regression test asserts that both `JER.up` and `JER.down` expose `pt_orig`/`mass_orig` equal to the untouched original arrays (and that the down originals differ from the up-smeared mass); it fails on `master` and passes with this fix. The full `tests/test_jetmet_tools.py` suite (17 tests, including the dask-awkward variants) passes, and `pre-commit run --all-files` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)