### PR TITLE
fix(nanoevents): TreeMaker schema no longer truncates subbranch field names

### DIFF
--- a/src/coffea/nanoevents/schemas/treemaker.py
+++ b/src/coffea/nanoevents/schemas/treemaker.py
@@ -139,7 +139,7 @@ class TreeMakerSchema(BaseSchema):
 
             if cname not in branch_forms:
                 collection = zip_forms(
-                    {k[len(cname) + 1]: branch_forms.pop(k) for k in items}, cname
+                    {k[len(cname) + 1 :]: branch_forms.pop(k) for k in items}, cname
                 )
                 branch_forms[cname] = collection
             else:

--- a/tests/test_nanoevents_treemaker.py
+++ b/tests/test_nanoevents_treemaker.py
@@ -84,6 +84,26 @@ def test_nested_collection(collection, subcollection, arr_type, element, events)
         )
 
 
+@pytest.mark.parametrize(
+    "collection",
+    ["JetsJECup", "JetsJECdown"],
+)
+def test_subbranch_field_names_not_truncated(events, collection):
+    # Regression test for scikit-hep/coffea#1578: the schema previously used
+    # ``k[len(cname) + 1]`` (single index) instead of a slice, truncating
+    # subbranch field names to a single character. That silently collapsed
+    # distinct subbranches sharing a first letter (e.g. "jerFactor" and
+    # "origIndex" -> "j" and "o"), dropping one of them.
+    fields = events[collection].fields
+    assert "jerFactor" in fields
+    assert "origIndex" in fields
+    assert "j" not in fields
+    assert "o" not in fields
+    # Values must remain readable through the full field names.
+    assert ak.all(ak.num(events[collection].jerFactor.compute(), axis=1) >= 0)
+    assert ak.all(ak.num(events[collection].origIndex.compute(), axis=1) >= 0)
+
+
 def test_uproot_write(tmp_path):
     path = os.path.abspath("tests/samples/treemaker.root")
     orig_events = NanoEventsFactory.from_root(


### PR DESCRIPTION
**Part of #1578** — critical bug 3: *TreeMaker schema truncates field names (missing slice colon)*.

The TreeMaker schema's single-collection branch used `k[len(cname) + 1]` (a single-character index) rather than a slice, truncating each subbranch field name to one character. When two subbranches of a collection share a first letter — e.g. `jerFactor` and `origIndex` under `JetsJECup` — both collapse to the same one-character key and one is silently dropped, producing wrong-but-not-erroring data.

This changes the index to the slice `k[len(cname) + 1:]`, matching the already-correct nested-collection code path a few lines below. On the shipped `tests/samples/treemaker.root`, `events.JetsJECup.fields` goes from `['j', 'o']` to the correct `['jerFactor', 'origIndex']`. A parametrized regression test asserts the full field names are present, the truncated names are absent, and the values remain readable; it fails on the old code and passes with the fix (17/17 in `tests/test_nanoevents_treemaker.py`). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)