### PR TITLE
fix(nanoevents): Candidate + Candidate no longer silently drops charge

### DIFF
--- a/src/coffea/nanoevents/methods/candidate.py
+++ b/src/coffea/nanoevents/methods/candidate.py
@@ -12,8 +12,6 @@ from coffea.nanoevents.methods import vector
 
 behavior = dict(vector.behavior)
 
-behavior.update(awkward._util.copy_behaviors("LorentzVector", "Candidate", behavior))
-
 
 @awkward.mixin_class(behavior)
 class Candidate(vector.LorentzVector):
@@ -57,6 +55,19 @@ class Candidate(vector.LorentzVector):
         parent = super()
         if hasattr(parent, "__awkward_validation__"):
             parent.__awkward_validation__()
+
+
+# Copy the cross-class LorentzVector behaviors (e.g. Candidate + TwoVector) onto
+# Candidate, but only for keys the ``@mixin_class`` decorator has not already
+# registered. This MUST run after the decorator: ``copy_behaviors`` would
+# otherwise pre-register ``(add, Candidate, Candidate)`` -> LorentzVector.add via
+# the ``setdefault`` used by ``mixin_class``, shadowing Candidate's own
+# charge-propagating ``add`` (see scikit-hep/coffea#1578).
+for _key, _value in awkward._util.copy_behaviors(
+    "LorentzVector", "Candidate", behavior
+).items():
+    behavior.setdefault(_key, _value)
+del _key, _value
 
 
 @awkward.mixin_class(behavior)

--- a/src/coffea/nanoevents/methods/nanoaod.py
+++ b/src/coffea/nanoevents/methods/nanoaod.py
@@ -199,10 +199,6 @@ GenParticleRecord.ProjectionClass3D = vector.ThreeVectorRecord  # noqa: F821
 GenParticleRecord.ProjectionClass4D = GenParticleRecord  # noqa: F821
 GenParticleRecord.MomentumClass = vector.LorentzVectorRecord  # noqa: F821
 
-behavior.update(
-    awkward._util.copy_behaviors("PtEtaPhiMLorentzVector", "GenVisTau", behavior)
-)
-
 
 @awkward.mixin_class(behavior)
 class GenVisTau(candidate.PtEtaPhiMCandidate, base.NanoCollection):
@@ -219,6 +215,18 @@ class GenVisTau(candidate.PtEtaPhiMCandidate, base.NanoCollection):
         return dask_array._events().GenPart._apply_global_index(
             dask_array.genPartIdxMotherG
         )
+
+
+# Fill in cross-class LorentzVector behaviors for GenVisTau without overwriting
+# the charge-propagating Candidate.add the decorator just registered. Running
+# ``copy_behaviors`` before the decorator would pre-seed
+# ``(add, GenVisTau, GenVisTau)`` -> LorentzVector.add and silently drop charge
+# on ``GenVisTau + GenVisTau`` (see scikit-hep/coffea#1578).
+for _key, _value in awkward._util.copy_behaviors(
+    "PtEtaPhiMLorentzVector", "GenVisTau", behavior
+).items():
+    behavior.setdefault(_key, _value)
+del _key, _value
 
 
 _set_repr_name("GenVisTau")

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -1132,3 +1132,96 @@ def test_awkward_validation():
             with_name="SecondaryVertex",
             behavior=nanoaod.behavior,
         )
+
+
+def test_candidate_addition_propagates_charge():
+    """Regression test for scikit-hep/coffea#1578.
+
+    ``Candidate + Candidate`` (and any same-class candidate sum) must keep the
+    ``charge`` field and sum charges. Before the fix, a module-level
+    ``copy_behaviors`` call pre-registered LorentzVector's charge-less ``add``
+    for ``(Candidate, Candidate)`` (via ``setdefault`` in ``mixin_class``),
+    silently dropping charge.
+    """
+    from coffea.nanoevents.methods import candidate
+
+    # ---- Candidate + Candidate ----
+    c1 = ak.zip(
+        {"x": [1.0], "y": [0.0], "z": [0.0], "t": [10.0], "charge": [1]},
+        with_name="Candidate",
+        behavior=candidate.behavior,
+    )
+    c2 = ak.zip(
+        {"x": [0.0], "y": [1.0], "z": [0.0], "t": [20.0], "charge": [-1]},
+        with_name="Candidate",
+        behavior=candidate.behavior,
+    )
+    csum = c1 + c2
+    assert "charge" in csum.fields
+    assert ak.to_list(csum.charge) == [0]
+    assert ak.to_list(csum.x) == [1.0]
+    assert ak.to_list(csum.t) == [30.0]
+
+    same_sign = c1 + c1
+    assert ak.to_list(same_sign.charge) == [2]
+
+    # ---- PtEtaPhiMCandidate + PtEtaPhiMCandidate ----
+    m1 = ak.zip(
+        {"pt": [10.0], "eta": [0.5], "phi": [0.1], "mass": [0.105], "charge": [1]},
+        with_name="PtEtaPhiMCandidate",
+        behavior=candidate.behavior,
+    )
+    m2 = ak.zip(
+        {"pt": [20.0], "eta": [-0.5], "phi": [0.2], "mass": [0.105], "charge": [-1]},
+        with_name="PtEtaPhiMCandidate",
+        behavior=candidate.behavior,
+    )
+    msum = m1 + m2
+    assert "charge" in msum.fields
+    assert ak.to_list(msum.charge) == [0]
+
+    # ---- PtEtaPhiECandidate + PtEtaPhiECandidate ----
+    e1 = ak.zip(
+        {"pt": [10.0], "eta": [0.5], "phi": [0.1], "energy": [10.6], "charge": [1]},
+        with_name="PtEtaPhiECandidate",
+        behavior=candidate.behavior,
+    )
+    e2 = ak.zip(
+        {"pt": [20.0], "eta": [-0.5], "phi": [0.2], "energy": [20.6], "charge": [-1]},
+        with_name="PtEtaPhiECandidate",
+        behavior=candidate.behavior,
+    )
+    esum = e1 + e2
+    assert "charge" in esum.fields
+    assert ak.to_list(esum.charge) == [0]
+
+
+def test_genvistau_addition_propagates_charge():
+    """Regression test for scikit-hep/coffea#1578 (GenVisTau asymmetry).
+
+    ``GenVisTau + GenVisTau`` dropped charge while ``GenVisTau + Muon`` kept it,
+    because GenVisTau's module-level ``copy_behaviors`` (from
+    PtEtaPhiMLorentzVector) ran before its ``@mixin_class`` decorator and
+    shadowed the inherited charge-propagating ``Candidate.add``.
+    """
+    from coffea.nanoevents import NanoAODSchema, NanoEventsFactory
+
+    NanoAODSchema.warn_missing_crossrefs = False
+    events = NanoEventsFactory.from_root(
+        {"tests/samples/nano_dy.root": "Events"},
+        schemaclass=NanoAODSchema,
+        mode="eager",
+    ).events()
+
+    gvt = events.GenVisTau
+    pairs = gvt[ak.num(gvt) >= 2]
+    assert len(pairs) > 0, "sample must contain events with >=2 GenVisTau"
+    gg = pairs[:, 0] + pairs[:, 1]
+    assert "charge" in gg.fields
+    assert ak.all(gg.charge == (pairs[:, 0].charge + pairs[:, 1].charge))
+
+    # Cross-class sum must still keep charge (never regressed).
+    mu = events.Muon
+    common = (ak.num(gvt) >= 1) & (ak.num(mu) >= 1)
+    gm = gvt[common][:, 0] + mu[common][:, 0]
+    assert "charge" in gm.fields


### PR DESCRIPTION
**Part of #1578** — critical bug 6: *Candidate + Candidate silently drops charge*.

Candidate-derived four-vector addition was silently dropping the `charge` field for same-class sums. The cause was ordering: a module-level `awkward._util.copy_behaviors` call ran **before** the `@awkward.mixin_class` decorator, and because `mixin_class` registers ufunc behaviors with `setdefault`, the copied charge-less `LorentzVector.add` pre-empted `Candidate`'s own charge-propagating `add` for the `(add, Candidate, Candidate)` key. The same anti-pattern in `nanoaod.py` made `GenVisTau + GenVisTau` drop charge even though `GenVisTau + Muon` kept it. (Classes copying from `PtEtaPhiMCandidate` — Muon, Tau, etc. — were unaffected because that source `add` already propagates charge.)

This PR moves the `copy_behaviors` merges to run after each class is defined and merges them with `setdefault` semantics, so cross-class behaviors are still copied while the charge-aware `add` wins for same-class sums. Regression tests cover `Candidate`, `PtEtaPhiMCandidate`, `PtEtaPhiECandidate`, and `GenVisTau` (from a NanoAOD sample), verified to fail before the fix and pass after (35/35 in `tests/test_nanoevents_vector.py`, 19/19 in `tests/test_nanoevents.py`). Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)