### PR TITLE
fix(nanoevents): include !loadallowmissing branches in typetracer column reporting

### DIFF
--- a/src/coffea/nanoevents/trace.py
+++ b/src/coffea/nanoevents/trace.py
@@ -97,11 +97,16 @@ def _make_length_zero_one_tracer(
 def _form_keys_to_columns(touched: list) -> frozenset[str]:
     # translate the touched buffer keys to branch names
     keys = set()
-    # each buffer key encodes the necessary branches through a "!load" instruction in the coffea DSL
+    # each buffer key encodes the necessary branches through a "!load" instruction in the coffea DSL.
+    # Branches that may be missing in some files carry a "!loadallowmissing" token instead of a
+    # plain "!load" (generated in nanoevents/mapping/uproot.py), so match with startswith("!load")
+    # to stay consistent with nanoevents/mapping/base.py.
     for _buffer_key in touched:
         elements = unquote(_buffer_key.split("/")[-1]).split(",")
         keys |= {
-            elements[idx - 1] for idx, instr in enumerate(elements) if instr == "!load"
+            elements[idx - 1]
+            for idx, instr in enumerate(elements)
+            if instr.startswith("!load")
         }
     return frozenset(keys)
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -193,3 +193,28 @@ def test_tracing_nanoevents():
     _untypetracable_analysis(events)
     access_log = [x.branch for x in access_log]
     assert sorted(set(access_log)) == ["MET_sumEt"]
+
+
+def test_form_keys_to_columns_loadallowmissing():
+    # Regression test for scikit-hep/coffea#1578: branches that may be missing in
+    # some files carry the "!loadallowmissing" token (generated in
+    # nanoevents/mapping/uproot.py) instead of a plain "!load". The column-touch
+    # reporting must include these branches, matching the startswith("!load")
+    # convention used in nanoevents/mapping/base.py.
+    from coffea.nanoevents.trace import _form_keys_to_columns
+    from coffea.nanoevents.util import quote
+
+    prefix = "some-uuid/%2FEvents%3B1/0-40"
+    normal = prefix + "/data/" + quote("Muon_pt,!load,!content")
+    allowmissing_index = (
+        prefix + "/index/" + quote("Muon_missing,!loadallowmissing,!index")
+    )
+    allowmissing_content = (
+        prefix + "/data/" + quote("Muon_missing,!loadallowmissing,!content")
+    )
+
+    result = _form_keys_to_columns([normal, allowmissing_index, allowmissing_content])
+
+    # Muon_missing must not be silently dropped just because it may be absent in
+    # some files (would fail before the fix with the exact `== "!load"` match).
+    assert result == frozenset({"Muon_pt", "Muon_missing"})


### PR DESCRIPTION
**Part of #1578** — reporting-side companion to the `keys_for_buffer_keys` fix for *dask mode + saved union forms fabricates all-None columns*.

The typetracer-based necessary-columns reporting in `nanoevents/trace.py` (`_form_keys_to_columns`, used by all `trace_*` entry points) matched the coffea-DSL load token with an exact `== "!load"` comparison. Branches that may be absent in some files are lazified with the `!loadallowmissing` token (from `nanoevents/mapping/uproot.py`), so the exact match silently dropped them from the reported necessary columns.

This changes the comparison to `startswith("!load")`, consistent with how the token is consumed in `nanoevents/mapping/base.py` and with the `keys_for_buffer_keys` fix. A unit-level regression test constructing both a normal `!load` node and a `!loadallowmissing` node (using the real quoted-node buffer-key format, verified against a virtual-mode `data_touched` report) fails on the old code and passes on the new. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)