### PR TITLE
fix: pass strings instead of class objects to copy_behaviors()

### DIFF
--- a/src/coffea/nanoevents/methods/edm4hep.py
+++ b/src/coffea/nanoevents/methods/edm4hep.py
@@ -203,7 +203,7 @@ class edm4hep_nanocollection(base.NanoCollection):
 
 
 behavior.update(
-    awkward._util.copy_behaviors(base.NanoCollection, edm4hep_nanocollection, behavior)
+    awkward._util.copy_behaviors("NanoCollection", "edm4hep_nanocollection", behavior)
 )
 
 
@@ -257,7 +257,7 @@ class MomentumCandidate(vector.LorentzVector):
 
 
 behavior.update(
-    awkward._util.copy_behaviors(vector.LorentzVector, MomentumCandidate, behavior)
+    awkward._util.copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
 )
 MomentumCandidateArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MomentumCandidateArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -321,7 +321,7 @@ class MCParticle(MomentumCandidate, edm4hep_nanocollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(awkward._util.copy_behaviors(MomentumCandidate, MCParticle, behavior))
+behavior.update(awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior))
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass4D = MCParticleArray  # noqa: F821
@@ -435,7 +435,7 @@ class ReconstructedParticle(MomentumCandidate, edm4hep_nanocollection):
 
 _set_repr_name("ReconstructedParticle")
 behavior.update(
-    awkward._util.copy_behaviors(MomentumCandidate, ReconstructedParticle, behavior)
+    awkward._util.copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
 )
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821

--- a/src/coffea/nanoevents/methods/edm4hep.py
+++ b/src/coffea/nanoevents/methods/edm4hep.py
@@ -321,7 +321,9 @@ class MCParticle(MomentumCandidate, edm4hep_nanocollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior))
+behavior.update(
+    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
+)
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass4D = MCParticleArray  # noqa: F821

--- a/src/coffea/nanoevents/methods/edm4hep.py
+++ b/src/coffea/nanoevents/methods/edm4hep.py
@@ -9,6 +9,24 @@ behavior = {}
 behavior.update(base.behavior)
 
 
+def _copy_behaviors(from_name, to_name, behavior):
+    """Copy cross-class behaviors from ``from_name`` onto ``to_name`` in place.
+
+    Uses ``setdefault`` rather than ``dict.update``: these copies run *after* the
+    target class is defined, and ``awkward.mixin_class`` registers a class's own
+    record via plain assignment (overwrite). A blanket ``update`` would therefore
+    clobber the subclass's own record/array registration with the parent's,
+    silently downcasting e.g. an ``MCParticle`` to a ``MomentumCandidate`` (which
+    then lacks methods like ``get_daughters``). ``setdefault`` fills in only the
+    genuinely-new cross-class keys and leaves the subclass's own entries intact.
+    See scikit-hep/coffea#1594.
+    """
+    for key, value in awkward._util.copy_behaviors(
+        from_name, to_name, behavior
+    ).items():
+        behavior.setdefault(key, value)
+
+
 class _EDM4HEPEvents(behavior["NanoEvents"]):
     """EDM4HEP Events"""
 
@@ -202,9 +220,7 @@ class edm4hep_nanocollection(base.NanoCollection):
         )
 
 
-behavior.update(
-    awkward._util.copy_behaviors("NanoCollection", "edm4hep_nanocollection", behavior)
-)
+_copy_behaviors("NanoCollection", "edm4hep_nanocollection", behavior)
 
 
 @awkward.mixin_class(behavior)
@@ -256,9 +272,7 @@ class MomentumCandidate(vector.LorentzVector):
             parent.__awkward_validation__()
 
 
-behavior.update(
-    awkward._util.copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
-)
+_copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
 MomentumCandidateArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MomentumCandidateArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 MomentumCandidateArray.ProjectionClass4D = vector.LorentzVectorArray  # noqa: F821
@@ -321,9 +335,7 @@ class MCParticle(MomentumCandidate, edm4hep_nanocollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(
-    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
-)
+_copy_behaviors("MomentumCandidate", "MCParticle", behavior)
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass4D = MCParticleArray  # noqa: F821
@@ -436,9 +448,7 @@ class ReconstructedParticle(MomentumCandidate, edm4hep_nanocollection):
 
 
 _set_repr_name("ReconstructedParticle")
-behavior.update(
-    awkward._util.copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
-)
+_copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass4D = ReconstructedParticleArray  # noqa: F821

--- a/src/coffea/nanoevents/methods/fcc.py
+++ b/src/coffea/nanoevents/methods/fcc.py
@@ -2,6 +2,7 @@ import awkward
 import numpy
 
 from coffea.nanoevents.methods import base, edm4hep, vector
+from coffea.nanoevents.methods.edm4hep import _copy_behaviors
 from coffea.util import dask_property
 
 behavior = {}
@@ -73,9 +74,7 @@ class MomentumCandidate(vector.LorentzVector):
             parent.__awkward_validation__()
 
 
-behavior.update(
-    awkward._util.copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
-)
+_copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
 
 MomentumCandidateArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MomentumCandidateArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -179,9 +178,7 @@ class MCParticle(MomentumCandidate, base.NanoCollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(
-    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
-)
+_copy_behaviors("MomentumCandidate", "MCParticle", behavior)
 
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -251,9 +248,7 @@ class ReconstructedParticle(MomentumCandidate, base.NanoCollection):
 
 
 _set_repr_name("ReconstructedParticle")
-behavior.update(
-    awkward._util.copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
-)
+_copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
 
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -447,9 +442,11 @@ class MCParticle(edm4hep.MCParticle):  # noqa: F811
 
 
 _set_repr_name_edm4hep1("MCParticle")
-behavior_edm4hep1.update(
-    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
-)
+for _key, _value in awkward._util.copy_behaviors(
+    "MomentumCandidate", "MCParticle", behavior
+).items():
+    behavior_edm4hep1.setdefault(_key, _value)
+del _key, _value
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass4D = MCParticleArray  # noqa: F821
@@ -502,11 +499,7 @@ class ReconstructedParticle(edm4hep.ReconstructedParticle):  # noqa: F811
 
 
 _set_repr_name_edm4hep1("ReconstructedParticle")
-behavior_edm4hep1.update(
-    awkward._util.copy_behaviors(
-        "MomentumCandidate", "ReconstructedParticle", behavior_edm4hep1
-    )
-)
+_copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior_edm4hep1)
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
 ReconstructedParticleArray.ProjectionClass4D = ReconstructedParticleArray  # noqa: F821

--- a/src/coffea/nanoevents/methods/fcc.py
+++ b/src/coffea/nanoevents/methods/fcc.py
@@ -74,7 +74,7 @@ class MomentumCandidate(vector.LorentzVector):
 
 
 behavior.update(
-    awkward._util.copy_behaviors(vector.LorentzVector, MomentumCandidate, behavior)
+    awkward._util.copy_behaviors("LorentzVector", "MomentumCandidate", behavior)
 )
 
 MomentumCandidateArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
@@ -179,7 +179,7 @@ class MCParticle(MomentumCandidate, base.NanoCollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(awkward._util.copy_behaviors(MomentumCandidate, MCParticle, behavior))
+behavior.update(awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior))
 
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -250,7 +250,7 @@ class ReconstructedParticle(MomentumCandidate, base.NanoCollection):
 
 _set_repr_name("ReconstructedParticle")
 behavior.update(
-    awkward._util.copy_behaviors(MomentumCandidate, ReconstructedParticle, behavior)
+    awkward._util.copy_behaviors("MomentumCandidate", "ReconstructedParticle", behavior)
 )
 
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
@@ -446,7 +446,7 @@ class MCParticle(edm4hep.MCParticle):  # noqa: F811
 
 _set_repr_name_edm4hep1("MCParticle")
 behavior_edm4hep1.update(
-    awkward._util.copy_behaviors(MomentumCandidate, MCParticle, behavior)
+    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
 )
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821
@@ -502,7 +502,7 @@ class ReconstructedParticle(edm4hep.ReconstructedParticle):  # noqa: F811
 _set_repr_name_edm4hep1("ReconstructedParticle")
 behavior_edm4hep1.update(
     awkward._util.copy_behaviors(
-        MomentumCandidate, ReconstructedParticle, behavior_edm4hep1
+        "MomentumCandidate", "ReconstructedParticle", behavior_edm4hep1
     )
 )
 ReconstructedParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821

--- a/src/coffea/nanoevents/methods/fcc.py
+++ b/src/coffea/nanoevents/methods/fcc.py
@@ -179,7 +179,9 @@ class MCParticle(MomentumCandidate, base.NanoCollection):
 
 
 _set_repr_name("MCParticle")
-behavior.update(awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior))
+behavior.update(
+    awkward._util.copy_behaviors("MomentumCandidate", "MCParticle", behavior)
+)
 
 MCParticleArray.ProjectionClass2D = vector.TwoVectorArray  # noqa: F821
 MCParticleArray.ProjectionClass3D = vector.ThreeVectorArray  # noqa: F821


### PR DESCRIPTION
`copy_behaviors()` in awkward matches by string equality only. When you pass class objects (like `vector.LorentzVector` or `MomentumCandidate`), the internal lookup never matches them against the string keys or tuple elements in the behavior registry. The function returns `{}`, and `behavior.update({})` is a no-op.

All 9 `copy_behaviors()` calls in `edm4hep.py` and `fcc.py` were passing class objects, so none of them actually worked. Cross-class behavior propagation (LorentzVector methods onto MomentumCandidate, MCParticle inheriting from MomentumCandidate, the EDM4hep1 FCC copies) was silently broken. The issue has a standalone awkward-only reproducer showing `copy_behaviors(LorentzVector, MomentumCandidate, behavior)` returns `{}` while the string version does the right thing.

The fix converts every call site to pass string class names, matching the pattern already used in `candidate.py:15`. Same 9 call sites, same behavior dicts, just string arguments instead of class objects. No imports changed, no refactors.

Tests pass.

Closes #1594