### PR TITLE
fix(tests): clean up parsl DFK so the HTEX interchange does not leak

### DIFF
--- a/tests/test_parsl.py
+++ b/tests/test_parsl.py
@@ -76,26 +76,33 @@ def test_parsl_htex_executor(tmp_path):
     )
     parsl.load(parsl_config)
 
-    filelist = {
-        "ZJets": [osp.join(os.getcwd(), "tests/samples/nano_dy.root")],
-        "Data": [osp.join(os.getcwd(), "tests/samples/nano_dimuon.root")],
-    }
+    # the DFK must be cleaned up explicitly: parsl's atexit hook only warns, and
+    # the HTEX interchange is a detached subprocess that outlives the test session
+    # unless HighThroughputExecutor.shutdown() runs via dfk.cleanup()
+    try:
+        filelist = {
+            "ZJets": [osp.join(os.getcwd(), "tests/samples/nano_dy.root")],
+            "Data": [osp.join(os.getcwd(), "tests/samples/nano_dimuon.root")],
+        }
 
-    do_parsl_job(filelist)
-    do_parsl_job(filelist, compression=1)
+        do_parsl_job(filelist)
+        do_parsl_job(filelist, compression=1)
 
-    filelist = {
-        "ZJets": {
-            "treename": "Events",
-            "files": [osp.join(os.getcwd(), "tests/samples/nano_dy.root")],
-        },
-        "Data": {
-            "treename": "Events",
-            "files": [osp.join(os.getcwd(), "tests/samples/nano_dimuon.root")],
-        },
-    }
+        filelist = {
+            "ZJets": {
+                "treename": "Events",
+                "files": [osp.join(os.getcwd(), "tests/samples/nano_dy.root")],
+            },
+            "Data": {
+                "treename": "Events",
+                "files": [osp.join(os.getcwd(), "tests/samples/nano_dimuon.root")],
+            },
+        }
 
-    do_parsl_job(filelist)
+        do_parsl_job(filelist)
+    finally:
+        parsl.dfk().cleanup()
+        parsl.clear()
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

Running the test suite locally leaves orphaned processes behind — visible in `top`/`btop` as `parsl: HTEX interchange`, along with a `process_worker_pool.py`. They survive the pytest session and stay until killed by hand, holding their ZMQ ports (55000–56000 range) the whole time.

The cause is `tests/test_parsl.py::test_parsl_htex_executor`: it calls `parsl.load(parsl_config)` but never tears the DataFlowKernel down. Three things combine to make that leak:

1. In current parsl the interchange is not a `multiprocessing` child — it's `subprocess.Popen(["interchange.py"], ...)` (`parsl/executors/high_throughput/executor.py`), so Python's `multiprocessing` atexit reaper never sees it.
2. The only thing that terminates it is `HighThroughputExecutor.shutdown()`, reachable only from `DataFlowKernel.cleanup()`.
3. Parsl's own atexit hook, `DataFlowKernel.atexit_cleanup`, deliberately does not clean up — it just logs `"Python is exiting with a DFK still running. You should call parsl.dfk().cleanup() before exiting..."`.

So on pytest exit the interchange is orphaned and reparented to init/launchd.

`coffea.processor.ParslExecutor` is not at fault: it only sets `cleanup = True` when it created the DFK itself, so its `finally: parsl.dfk().cleanup()` correctly does not fire for a DFK the test owns. The test owns it and never releases it.

## Fix

Wrap the test body in `try/finally` and call `parsl.dfk().cleanup()` / `parsl.clear()`, matching what `test_parsl_start_stop` already does via `_parsl_stop()`.

## Verification

On master, `pytest tests/test_parsl.py::test_parsl_htex_executor` passes and leaves behind:

```
 9344     1 parsl: HTEX interchange
 9357  9356 .../process_worker_pool.py --max_workers_per_node=1 ...
```

(note PPID 1 on the interchange — orphaned).

With this change, `pytest tests/test_parsl.py` → `5 passed`, and the same `ps` check afterwards returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)