### PR TITLE
fix: forward decompression and interpretation executor in eager and virtual mode

### DIFF
--- a/src/coffea/nanoevents/factory.py
+++ b/src/coffea/nanoevents/factory.py
@@ -459,6 +459,8 @@ class NanoEventsFactory:
             file_handle=file_handle,
             use_ak_forth=use_ak_forth,
             virtual=mode == "virtual",
+            decompression_executor=decompression_executor,
+            interpretation_executor=interpretation_executor,
             preloaded_arrays=preloaded_arrays,
             buffer_cache=buffer_cache,
         )


### PR DESCRIPTION
`NanoEventsFactory.from_root` only forwarded `decompression_executor` and `interpretation_executor` in `dask` mode or with `preload` used, but not in `eager` / `virtual` mode so far (which always fell back to `TrivialExecutor`). This is fixed now.