### PR TITLE
docs: draft docs for processor runner attributes

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+.jupyter_cache
+jupyter_execute

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,4 +9,7 @@ source/modules: source/api_reference.md
 clean:
 	rm -rf build source/modules source/api
 
+watch:
+	sphinx-autobuild source build
+
 .PHONY: clean

--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -20,6 +20,7 @@ imported explicitly.
 ```{eval-rst}
 .. autosummary::
     :toctree: modules
+    :caption: Available by Default
     :template: automodapi_templ.rst
 
     coffea.analysis_tools
@@ -50,6 +51,7 @@ must be explicitly imported.
 ```{eval-rst}
 .. autosummary::
     :toctree: modules
+    :caption: Need to Manually Import
     :template: automodapi_templ.rst
 
     coffea.dataset_tools.dataset_query

--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -48,9 +48,11 @@ package that are not included in the `coffea` namespace. That is, they
 must be explicitly imported.
 
 ```{eval-rst}
-.. automodule:: coffea.dataset_tools.dataset_query
-    :members:
+.. autosummary::
+    :toctree: modules
+    :template: automodapi_templ.rst
 
-.. automodule:: coffea.dataset_tools.rucio_utils
-    :members:
+    coffea.dataset_tools.dataset_query
+    coffea.dataset_tools.rucio_utils
+    coffea.processor.dask
 ```

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -69,6 +69,12 @@ ask for help.
 
 - Preview the generated HTML at `docs/build/html/index.html` before opening
   your pull request.
+- Parts of the documentation reference optional sub-components of coffea,
+  so you may want to install all of the optional components in order to
+  mimic the complete documentation site. `pip install -e .[dev,caches,dask,dask-awkward]`
+- Additionally, parts of the documentation use `graphviz` to construct
+  class inheritance trees. If you want to view those, install the `graphviz`
+  system package as well (e.g. `sudo apt install graphviz` on Debian variants).
 
 ## Release cadence
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -71,10 +71,12 @@ ask for help.
   your pull request.
 - Parts of the documentation reference optional sub-components of coffea,
   so you may want to install all of the optional components in order to
-  mimic the complete documentation site. `pip install -e .[dev,caches,dask,dask-awkward]`
+  mimic the complete documentation site. `pip install -e .[dev,caches,dask,dask-awkward,rucio]`
 - Additionally, parts of the documentation use `graphviz` to construct
   class inheritance trees. If you want to view those, install the `graphviz`
   system package as well (e.g. `sudo apt install graphviz` on Debian variants).
+- The `make watch` command uses `sphinx-autobuild` to re-build the pages as
+  you change the source files which can be helpful depending on your workflow.
 
 ## Release cadence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ dev = [
   "ipython",
   "myst-nb",
   "pydata-sphinx-theme",
+  "sphinx-autobuild>=2024.10.03"
 ]
 
 #[project.entry-points."dask.sizeof"]

--- a/src/coffea/processor/dask/__init__.py
+++ b/src/coffea/processor/dask/__init__.py
@@ -1,3 +1,5 @@
+"""helpers for tuning dask behavior for coffea"""
+
 import os
 from collections.abc import MutableMapping
 from threading import Lock
@@ -12,6 +14,8 @@ get_worker = _distributed.get_worker
 
 
 class ColumnCache(WorkerPlugin, MutableMapping):
+    """dask worker plugin to cache columns of data"""
+
     name = "columncache"
 
     def __init__(self, maxmem=5e8, maxcompressed=2e9, maxdisk=1e10):

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1170,6 +1170,18 @@ class Runner:
             determine chunking.  Defaults to a in-memory LRU cache that holds 100k entries
             (about 1MB depending on the length of filenames, etc.)  If you edit an input file
             (please don't) during a session, the session can be restarted to clear the cache.
+        skipbadfiles : bool or tuple of exceptions
+            If True, skip files which throw an exception when opened.
+            If a tuple of exceptions, only skip files that throw those exceptions.
+            If False, 
+        xrootdtimeout : int, optional
+        align_clusters: bool, optional
+        savemetrics: bool, optional
+        schema: schemas.BaseSchema, optional
+        processor_compression: int, optional
+        format: str, optional
+            Defines input file format, must be either 'root' or 'parquet'
+        cachestrategy: "dask-worker" or callable of a mapping, optional
         checkpointer : CheckpointerABC, optional
             A CheckpointerABC instance to manage checkpointing of each chunk output
         use_result_type : bool, optional

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1145,7 +1145,8 @@ class ParquetFileContext:
 class Runner:
     """A convenience wrapper to submit jobs for a file set
 
-    A file set in this context is a dictionary of dataset: [file list] entries.
+    A file set in this context is a dictionary where the key is the name
+    of a dataset and the value is a list of files.
 
     Parameters
     ----------
@@ -1206,6 +1207,9 @@ class Runner:
         cachestrategy: "dask-worker" or callable returning a mapping, optional
             Define the cache used to hold columns of data in memory for re-processing.
             The default is ``None`` where no caching takes place.
+            If the literal "dask-worker", use the :py:class:`ColumnCache <coffea.processor.dask.ColumnCache>`
+            plugin added to the dask worker by name. *Warning* If the ColumnCache plugin is not
+            found by name, then it is silently ignored and no caching takes place.
             The cache constructed from this strategy is passed as ``buffer_cache``
             to :py:class:`NanoEventsFactory <coffea.nanoevents.NanoEventsFactory>`.
         checkpointer : CheckpointerABC, optional

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1176,8 +1176,7 @@ class Runner:
             Defaults to False.
         xrootdtimeout : int, optional
             Passed to `uproot.open <https://uproot.readthedocs.io/en/latest/uproot.reading.open.html>`_
-            as the ``timeout`` option where it is also undocumented, but I assume is the time in seconds
-            the function will wait before giving up on opening a file.
+            as the ``timeout`` option. The time in seconds we will wait before giving up on the file.
             Defaults to 60, ignored if ``format`` is not ``"root"``.
         align_clusters: bool, optional
             ROOT files write data from adjacent entries of TTree branches and RNTuple fields into clusters.

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1145,7 +1145,7 @@ class ParquetFileContext:
 class Runner:
     """A convenience wrapper to submit jobs for a file set
 
-    A file set in this context is a dictionary of dataset: [file list] entries. 
+    A file set in this context is a dictionary of dataset: [file list] entries.
 
     Parameters
     ----------

--- a/src/coffea/processor/executor.py
+++ b/src/coffea/processor/executor.py
@@ -1143,13 +1143,9 @@ class ParquetFileContext:
 
 @dataclass
 class Runner:
-    """A tool to run a processor using uproot for data delivery
+    """A convenience wrapper to submit jobs for a file set
 
-    A convenience wrapper to submit jobs for a file set, which is a
-    dictionary of dataset: [file list] entries.  Supports only uproot TTree
-    reading, via NanoEvents.  For more customized processing,
-    e.g. to read other objects from the files and pass them into data frames,
-    one can write a similar function in their user code.
+    A file set in this context is a dictionary of dataset: [file list] entries. 
 
     Parameters
     ----------
@@ -1170,18 +1166,48 @@ class Runner:
             determine chunking.  Defaults to a in-memory LRU cache that holds 100k entries
             (about 1MB depending on the length of filenames, etc.)  If you edit an input file
             (please don't) during a session, the session can be restarted to clear the cache.
-        skipbadfiles : bool or tuple of exceptions
-            If True, skip files which throw an exception when opened.
+        skipbadfiles : bool or tuple of Exception, optional
+            If True, skip files which throw an ``OSError`` exception when opened after reaching
+            the limit on retry attempts.
             If a tuple of exceptions, only skip files that throw those exceptions.
-            If False, 
+            If False, propagate the exception thrown by the file open upwards, probably causing
+            processing to cease.
+            Defaults to False.
         xrootdtimeout : int, optional
+            Passed to `uproot.open <https://uproot.readthedocs.io/en/latest/uproot.reading.open.html>`_
+            as the ``timeout`` option where it is also undocumented, but I assume is the time in seconds
+            the function will wait before giving up on opening a file.
+            Defaults to 60, ignored if ``format`` is not ``"root"``.
         align_clusters: bool, optional
+            ROOT files write data from adjacent entries of TTree branches and RNTuple fields into clusters.
+            If this option is True, we attempt to read those clusters in sequence together,
+            hopefully improving overall read performance.
+            Defaults to False, only usable when input ``format`` is ``"root"``.
         savemetrics: bool, optional
-        schema: schemas.BaseSchema, optional
+            If True, include timing, I/O, and memory usage metrics in the output result.
+            Defaults to False.
+        schema: BaseSchema instance, optional
+            The schema to use for opening the file and interpreting the data.
+            Defaults to the NanoAODSchema.
         processor_compression: int, optional
+            The compression level to use when compressing the processor instance before
+            sending it to the worker. A value of ``None`` will prevent any compression from
+            being done on the processor instance which can be helpful in the case where your
+            processor instance is failing to be handled by ``cloudpickle`` but can cause
+            performance bottlenecks if sending your processor instance to/from the workers
+            becomes the longest task.
+            The default value is ``1``.
+            This is passed as ``compression_level`` to
+            `lz4.frame.compress <https://python-lz4.readthedocs.io/en/stable/lz4.frame.html#lz4.frame.compress>`_
+            for those curious.
         format: str, optional
-            Defines input file format, must be either 'root' or 'parquet'
-        cachestrategy: "dask-worker" or callable of a mapping, optional
+            Defines input file format, must be either ``"root"`` or ``"parquet"``.
+            Defaults to ``"root"``.
+        cachestrategy: "dask-worker" or callable returning a mapping, optional
+            Define the cache used to hold columns of data in memory for re-processing.
+            The default is ``None`` where no caching takes place.
+            The cache constructed from this strategy is passed as ``buffer_cache``
+            to :py:class:`NanoEventsFactory <coffea.nanoevents.NanoEventsFactory>`.
         checkpointer : CheckpointerABC, optional
             A CheckpointerABC instance to manage checkpointing of each chunk output
         use_result_type : bool, optional


### PR DESCRIPTION
This resolves #1379 , starting small with an less-distributed update to get used to the developing flow before I start on larger rewrites/refactors of the documentation pages.

While I was adding in cross-links I slightly updated how the non-namespace modules are documented. Instead of just dumping them at the bottom of the API Reference page, I have them constructed into their own toctree which a spearate caption.

<img width="396" height="695" alt="image" src="https://github.com/user-attachments/assets/1311908c-7a61-4510-8474-8c8acfbfac06" />

Other QoL updates:
- a few more comments about how to get started contributing to the documentation, mainly mentioning that optional dependencies should be included in developer environment
- include `sphinx-autobuild` so the pages are automatically rebuilt when source files change (its not very fast, but it avoids having to manually re-run `make` every time.)