### PR TITLE
feat: add overloads for some awkward reducers for coffea's vectors

### DIFF
--- a/src/coffea/nanoevents/methods/vector.py
+++ b/src/coffea/nanoevents/methods/vector.py
@@ -142,6 +142,16 @@ def _coordinate_validation(fields):
     )
 
 
+# awkward looks up reducer overloads by record name only, so the ones vector
+# registers for Momentum{2,3,4}D never reach our collections. Forward those that
+# don't rebuild a record. Sum has to go through our own, which keeps the charge
+# field and names the result after what it actually built.
+_count_reducer = vector.backends.awkward.behavior[awkward.count, "Momentum4D"]
+_count_nonzero_reducer = vector.backends.awkward.behavior[
+    awkward.count_nonzero, "Momentum4D"
+]
+
+
 @awkward.mixin_class(behavior)
 class TwoVector(MomentumAwkward2D):
     """A cartesian 2-dimensional vector
@@ -188,6 +198,18 @@ class TwoVector(MomentumAwkward2D):
             with_name="TwoVector",
             behavior=self.behavior,
         )
+
+    @awkward.mixin_class_method(awkward.sum)
+    def _reduce_sum(self, mask_identity):
+        return self.sum(axis=1)
+
+    @awkward.mixin_class_method(awkward.count)
+    def _reduce_count(self, mask_identity):
+        return _count_reducer(self, mask_identity)
+
+    @awkward.mixin_class_method(awkward.count_nonzero)
+    def _reduce_count_nonzero(self, mask_identity):
+        return _count_nonzero_reducer(self, mask_identity)
 
     @awkward.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):
@@ -303,6 +325,18 @@ class ThreeVector(MomentumAwkward3D):
             with_name="ThreeVector",
             behavior=self.behavior,
         )
+
+    @awkward.mixin_class_method(awkward.sum)
+    def _reduce_sum(self, mask_identity):
+        return self.sum(axis=1)
+
+    @awkward.mixin_class_method(awkward.count)
+    def _reduce_count(self, mask_identity):
+        return _count_reducer(self, mask_identity)
+
+    @awkward.mixin_class_method(awkward.count_nonzero)
+    def _reduce_count_nonzero(self, mask_identity):
+        return _count_nonzero_reducer(self, mask_identity)
 
     @awkward.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):
@@ -423,6 +457,18 @@ class LorentzVector(MomentumAwkward4D):
             with_name="LorentzVector",
             behavior=self.behavior,
         )
+
+    @awkward.mixin_class_method(awkward.sum)
+    def _reduce_sum(self, mask_identity):
+        return self.sum(axis=1)
+
+    @awkward.mixin_class_method(awkward.count)
+    def _reduce_count(self, mask_identity):
+        return _count_reducer(self, mask_identity)
+
+    @awkward.mixin_class_method(awkward.count_nonzero)
+    def _reduce_count_nonzero(self, mask_identity):
+        return _count_nonzero_reducer(self, mask_identity)
 
     @awkward.mixin_class_method(numpy.multiply, {numbers.Number})
     def multiply(self, other):

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -1225,3 +1225,27 @@ def test_genvistau_addition_propagates_charge():
     common = (ak.num(gvt) >= 1) & (ak.num(mu) >= 1)
     gm = gvt[common][:, 0] + mu[common][:, 0]
     assert "charge" in gm.fields
+
+
+@pytest.mark.parametrize(
+    "name,fields,behavior",
+    [
+        ("TwoVector", ["x", "y"], "vector"),
+        ("ThreeVector", ["x", "y", "z"], "vector"),
+        ("LorentzVector", ["x", "y", "z", "t"], "vector"),
+        ("Candidate", ["x", "y", "z", "t", "charge"], "candidate"),
+    ],
+)
+def test_ak_reducers(name, fields, behavior):
+    """Regression test for scikit-hep/coffea#1620"""
+    from coffea.nanoevents.methods import candidate
+
+    a = ak.zip(
+        {f: [[1.0, 0.0], [], [2.0]] for f in fields},
+        with_name=name,
+        behavior={"vector": vector, "candidate": candidate}[behavior].behavior,
+    )
+    assert_record_arrays_equal(ak.sum(a, axis=1), a.sum(axis=1))
+    assert ak.to_list(ak.sum(a, axis=1, mask_identity=True))[1] is None
+    assert ak.to_list(ak.count(a, axis=1)) == [2, 0, 1]
+    assert ak.to_list(ak.count_nonzero(a, axis=1)) == [1, 0, 1]

--- a/tests/test_nanoevents_vector.py
+++ b/tests/test_nanoevents_vector.py
@@ -1241,11 +1241,17 @@ def test_ak_reducers(name, fields, behavior):
     from coffea.nanoevents.methods import candidate
 
     a = ak.zip(
-        {f: [[1.0, 0.0], [], [2.0]] for f in fields},
+        {f: [[1.0, 0.0], [], [2.0], [1.0, 2.0]] for f in fields},
+        with_name=name,
+        behavior={"vector": vector, "candidate": candidate}[behavior].behavior,
+    )
+    expected_sum = ak.zip(
+        {f: [1.0, 0.0, 2.0, 3.0] for f in fields},
         with_name=name,
         behavior={"vector": vector, "candidate": candidate}[behavior].behavior,
     )
     assert_record_arrays_equal(ak.sum(a, axis=1), a.sum(axis=1))
+    assert_record_arrays_equal(ak.sum(a, axis=1), expected_sum)
     assert ak.to_list(ak.sum(a, axis=1, mask_identity=True))[1] is None
-    assert ak.to_list(ak.count(a, axis=1)) == [2, 0, 1]
-    assert ak.to_list(ak.count_nonzero(a, axis=1)) == [1, 0, 1]
+    assert ak.to_list(ak.count(a, axis=1)) == [2, 0, 1, 2]
+    assert ak.to_list(ak.count_nonzero(a, axis=1)) == [1, 0, 1, 2]


### PR DESCRIPTION
Closes https://github.com/scikit-hep/coffea/issues/1620

Adds overloads for `ak.sum`, `ak.count` and `ak.count_nonzero` on vectors coffea defines. The overloads for count and count nonzero are taken directly from scikit-hep/vector while for sum we use coffea's own `sum` method that its vectors define since we also need to deal with charge which scikit-hep/vector does not deal with.