### PR TITLE
feat: allow uv sync to work as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dask-worker-space/
 src/coffea/_version.py
 
 .DS_Store
+
+# Don't track lock files
+uv.lock

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -279,6 +279,9 @@ to make a new kernel available that uses this environment.
    pip install --editable .[dev,dask]
    ```
 
+   If you use [`uv`](https://docs.astral.sh/uv/) to manage your python environments, you can also simply run
+   `uv sync` to install the development dependencies.
+
 3. Develop a cool new feature or fix some bugs
 
 4. Lint source, run tests, and build documentation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,8 +124,8 @@ dev = [
   "sphinx-autobuild>=2024.10.03"
 ]
 
-#[project.entry-points."dask.sizeof"]
-#coffea = "coffea.sizeof:register"
+[dependency-groups]
+dev = ["coffea[dev]"]
 
 [tool.hatch]
 version.source = "vcs"


### PR DESCRIPTION
Creates a dev dependency group that references the existing dev extra. A long-term migration to dependency groups for development may be in order but for now this is simple and backwards-compatible.