### PR TITLE
chore: bokeh 3.10 does not work anymore with the pinned dask/distributed that dask-awkward imposes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,10 @@ dask = [
   "bokeh!=3.0.*,>=2.4.2",
 ]
 dask-awkward = [
+  "coffea[dask]",
   "dask-awkward>=2025.9.0",
   "dask-histogram>=2025.2.0",
+  "bokeh<3.10",
 ]
 parsl = [
   "parsl>=2024.12.09"


### PR DESCRIPTION
Hit in the integration tests, when we install dask-awkward, get get an old version of dask/distributed. We should pin bokeh to < 3.10 in that case as well. Also the dask-awkward optional dependencies should be an extension of the dask dependencies. So start with coffea[dask] at the top.